### PR TITLE
RSA key: ignore and warn about empty passphrase for NSS keys

### DIFF
--- a/lib/libswan/secrets.c
+++ b/lib/libswan/secrets.c
@@ -700,6 +700,7 @@ static err_t lsw_process_rsa_keycert(struct RSA_private_key *rsak)
 {
 	char friendly_name[PATH_MAX]; /* XXX: is there an NSS limit < PATH_MAX ? */
 	err_t ugh = NULL;
+	bool unexpected;
 
 	zero(&friendly_name);
 
@@ -710,7 +711,15 @@ static err_t lsw_process_rsa_keycert(struct RSA_private_key *rsak)
 	else
 		memcpy(friendly_name, flp->tok, flp->cur - flp->tok);
 
-	if (shift()) {
+	unexpected = shift();
+	/* we used to recommend people to provide an empty passphrase for NSS keys */
+	if (unexpected && (strcmp(flp->tok, "\"\"") == 0 || strcmp(flp->tok, "''") == 0)) {
+		libreswan_log("RSA private key file "
+				"-- ignoring empty token after friendly_name "
+				"-- this will be an error in a future release");
+		unexpected = shift();
+	}
+	if (unexpected) {
 		ugh = "RSA private key file -- unexpected token after friendly_name";
 	} else {
 		ugh = extract_and_add_secret_from_nss_cert_file(rsak, friendly_name);


### PR DESCRIPTION
README.nss used to recommend adding an empty passphrase for NSS keys in
ipsec.secrets but commit 96d89e16 made any extra tokens errors which breaks
old ipsec.secrets files when used with new libreswan versions.

Ignore an empty passphrase token for now and log a warning about it saying
it'll be an error in a future release.

https://bugzilla.redhat.com/show_bug.cgi?id=1144941
