### PR TITLE
Fix dkms source name when working from git repo

### DIFF
--- a/debian/libreswan-modules-dkms.postinst
+++ b/debian/libreswan-modules-dkms.postinst
@@ -2,7 +2,7 @@
 set -e
 test $DEBIAN_SCRIPT_DEBUG && set -v -x
 
-VERSION=$(dpkg-query -W -f='${Version}' libreswan-modules-dkms | sed -e 's/.*:\(.*\)/\1/' -e 's/\(.*\)-.*/\1/')
+VERSION=$(dpkg-query -W -f='${Version}' libreswan-modules-dkms | sed -e 's/.*:\(.*\)/\1/' -e 's/-.*//')
 ARCH=`dpkg --print-architecture`
 
 . /usr/share/debconf/confmodule

--- a/debian/libreswan-modules-dkms.prerm
+++ b/debian/libreswan-modules-dkms.prerm
@@ -4,7 +4,7 @@ test $DEBIAN_SCRIPT_DEBUG && set -v -x
 
 #DEBHELPER#
 
-VERSION=$(dpkg-query -W -f='${Version}' libreswan-modules-dkms | sed -e 's/.*:\(.*\)/\1/' -e 's/\(.*\)-.*/\1/')
+VERSION=$(dpkg-query -W -f='${Version}' libreswan-modules-dkms | sed -e 's/.*:\(.*\)/\1/' -e 's/-.*//')
 
 case "$1" in
     remove|upgrade)


### PR DESCRIPTION
Installing the dkms package built from a git checkout fails because it doesn't use the correct module name, for example 3.9~583. Output of the dpkg-query command is for example `1:3.9~dirty-69fbb754b836710a86e83c1a9a064e54dde4c711`, the source package installs `/usr/src/libreswan-3.9~dirty` so it just needs to strip to the first hyphen.

The previous failling error message was "This package appears to be a binaries-only package" (sorry, don't more scrollback
