### PR TITLE
libipsecconf: Avoid bad seek

### DIFF
--- a/lib/libipsecconf/parser.l
+++ b/lib/libipsecconf/parser.l
@@ -314,14 +314,9 @@ int parser_y_eof(void)
 	printf("stacktop->filename = %s\n",
 		stacktop->filename != NULL ? stacktop->filename : "NULL");
 #endif
-	if (stacktop->file){
-	    char ch;
-	    fseek(stacktop->file,-1L,SEEK_END);
-	    ch = (char)fgetc(stacktop->file);
-	    if (ch != '\n' && stacktop->once){
-		stacktop->once = 0;
-		return EOL;
-	    }
+	if (stacktop->once) {
+	    stacktop->once = 0;
+	    return EOL;
 	}
 	if(parser_y_eof()) {
 	   yyterminate();

--- a/lib/libipsecconf/parser.y
+++ b/lib/libipsecconf/parser.y
@@ -79,8 +79,8 @@ static struct starter_comments_list *_parser_comments;
  */
 
 config_file:
-        blanklines versionstmt blanklines sections
-        | blanklines sections
+        blanklines versionstmt blanklines sections blanklines
+        | blanklines sections blanklines
         ;
 
 /* check out the version number - this is optional (and we're phasing out its use) */


### PR DESCRIPTION
fseek(-1L, SEEK_END) causes lseek(0, SEEK_CUR) on ordinary files, causing a
seek to the beginning and duplicate file parse. On pipes, it does not work
at all, causing the EOL to be inserted even when it was there:

can not load config '-': -:21: syntax error, unexpected EOL, expecting $end []

Too bad NetworkManager feeds the connection configuration into a pipe.

Let's just add the trailing line break unconditionally and allow the trailing
blank lines in grammar.