### PR TITLE
makrelease: Use git describe to look up the version

### DIFF
--- a/packaging/utils/makerelease
+++ b/packaging/utils/makerelease
@@ -8,7 +8,7 @@ then
 fi
 if [ -z "$VERSION" ]
 then
-	VERSION=`git tag | tail -1| sed -e "s/v//"`
+	VERSION=`git describe --tags --dirty | tail -1| sed -e "s/v//"`
 fi
 
 if [ -z "$FORCE" ]


### PR DESCRIPTION
Git tag's sorting (either lexicographic or numeric) are of no use.
