### PR TITLE
Simplify Upstart job, use exec in script section so PID is tracked correctly

### DIFF
--- a/initsystems/upstart/ipsec.conf.in
+++ b/initsystems/upstart/ipsec.conf.in
@@ -11,16 +11,12 @@ stop on runlevel [!2345]
 
 respawn
 
-pre-start script
-    cd /
-    . /etc/default/pluto
-    @FINALSBINDIR@/ipsec addconn --config @FINALCONFFILE@ --checkconfig
-end script
+pre-start exec @FINALSBINDIR@/ipsec addconn --config @FINALCONFFILE@ --checkconfig
 
 script
     . /etc/default/pluto
     @FINALSBINDIR@/ipsec _stackmanager start
-    @FINALLIBEXECDIR@/pluto --config @FINALCONFFILE@ --nofork $PLUTO_OPTIONS
+    exec @FINALLIBEXECDIR@/pluto --config @FINALCONFFILE@ --nofork $PLUTO_OPTIONS
 end script
 
 pre-stop script


### PR DESCRIPTION
The sections are always in root, no need to cd to root. $PLUTO_OPTIONS are not used in the pre-start command so there is no need to source the default file there. The script section should use exec so that the correct PID is tracked (this is not too much of an issue, since the PID tracked formerly was the shell, which exits when the real daemon does).