### PR TITLE
Build fixes

### DIFF
--- a/programs/pluto/ikev2_parent.c
+++ b/programs/pluto/ikev2_parent.c
@@ -78,6 +78,7 @@
 			send_v2_notification_from_md(md, t, NULL); \
 	}
 
+#ifdef XAUTH_HAVE_PAM
 struct ikev2_pam_helper {
 	struct pam_thread_arg pam;	/* writable inside thread */
 	bool pam_status;		/* set inside the thread */
@@ -91,9 +92,10 @@ struct ikev2_pam_helper {
 	struct event *evm;              /* callback event on master_fd. */
 };
 
-static stf_status ikev2_parent_inI2outR2_auth_tail( struct msg_digest *md, bool pam_status);
-
 static struct ikev2_pam_helper *pluto_v2_pam_helpers = NULL;
+#endif
+
+static stf_status ikev2_parent_inI2outR2_auth_tail( struct msg_digest *md, bool pam_status);
 
 static crypto_req_cont_func ikev2_parent_outI1_continue;	/* type assertion */
 

--- a/programs/pluto/ikev2_parent.c
+++ b/programs/pluto/ikev2_parent.c
@@ -2431,7 +2431,6 @@ static stf_status ikev2_parent_inI2outR2_tail(
 {
 	struct msg_digest *md = dh->pcrc_md;
 	struct state *const st = md->st;
-	struct connection *c = st->st_connection;
 	unsigned char idhash_in[MAX_DIGEST_LEN];
 
 	/* extract calculated values from r */
@@ -2451,8 +2450,6 @@ static stf_status ikev2_parent_inI2outR2_tail(
 
 	if (!ikev2_decode_peer_id_and_certs(md))
 		return STF_FAIL + v2N_AUTHENTICATION_FAILED;
-
-	c = st->st_connection; /* in case we refined */
 
 	{
 		struct hmac_ctx id_ctx;


### PR DESCRIPTION
First commit fixes build without pam:
```
/tmp/libreswan/programs/pluto/ikev2_parent.c:82:24: error: field ‘pam’ has incomplete type
  struct pam_thread_arg pam; /* writable inside thread */
                        ^
/tmp/libreswan/programs/pluto/ikev2_parent.c: At top level:
/tmp/libreswan/programs/pluto/ikev2_parent.c:96:33: error: ‘pluto_v2_pam_helpers’ defined but not used [-Werror=unused-variable]
 static struct ikev2_pam_helper *pluto_v2_pam_helpers = NULL;
                                 ^
cc1: all warnings being treated as errors
```

second commit fixes build with gcc-4.9+
```
/tmp/libreswan/programs/pluto/ikev2_parent.c:2434:21: error: variable ‘c’ set but not used [-Werror=unused-but-set-variable]
  struct connection *c = st->st_connection;
                     ^
cc1: all warnings being treated as errors
../../../mk/depend.mk:28: recipe for target 'ikev2_parent.o' failed
```