### PR TITLE
Update ipsec.conf.in

### DIFF
--- a/initsystems/upstart/ipsec.conf.in
+++ b/initsystems/upstart/ipsec.conf.in
@@ -22,7 +22,7 @@ script
     @FINALSBINDIR@/ipsec --checknss
     @FINALSBINDIR@/ipsec --checknflog
     @FINALSBINDIR@/ipsec _stackmanager start
-    @FINALLIBEXECDIR@/pluto --config @FINALCONFFILE@ --nofork $PLUTO_OPTIONS
+    exec @FINALLIBEXECDIR@/pluto --config @FINALCONFFILE@ --nofork $PLUTO_OPTIONS
 end script
 
 pre-stop script


### PR DESCRIPTION
Without the "exec", you have a shell hanging around, and upstart thinks the shell's PID is the main process. This may confuse the pre-stop part. If you "exec" pluto, then it takes over the PID of the shell that starts it, and upstart monitors the correct PID. Then, when it is shut down in the pre-stop, upstart should not try to restart it. Let me know if it works.