### PR TITLE
_updown.*: Fix NetworkManager callback

### DIFF
--- a/programs/_updown.klips/_updown.klips.in
+++ b/programs/_updown.klips/_updown.klips.in
@@ -263,18 +263,6 @@ updateresolvconf() {
 		rm -f -- ${ORIG_RESOLV_CONF}
 		printf "${RESOLVE_CONF}" > ${ORIG_RESOLV_CONF}
 		return $?
-
-	else
-		echo "Updating resolv.conf is controlled by Network Manager"
-		libreswan_reason=connect
-		export libreswan_reason
-		export PLUTO_PEER_DOMAIN_INFO
-		export PLUTO_PEER_DNS_INFO
-		export PLUTO_PEER_BANNER
-		export PLUTO_MY_SOURCEIP
-		export PLUTO_PEER
-		/usr/libexec/nm-libreswan-service-helper
-		return 0
 	fi
 }
 
@@ -306,29 +294,27 @@ restoreresolvconf() {
 
 		rm -f -- "${LIBRESWAN_RESOLV_CONF}"
 		return 0
-	else
-		# Here disconnect signal is sent to NetworkManager
-		# whenever an already established connection is being terminated.
-		unset libreswan_reason
-		unset PLUTO_PEER_DOMAIN_INFO
-		unset PLUTO_PEER_DNS_INFO
-		unset PLUTO_PEER_BANNER
-		unset PLUTO_MY_SOURCEIP
-		unset PLUTO_PEER
-		echo "Restoring resolv.conf is controlled by Network Manager"
-		disconnectNM
 	fi
 }
 
-disconnectNM() {
-    # This will be called whenever a connection fails to establish
-    # due to a state (either phase 1, xauth phase, or phase 2) fails.
+notifyNM() {
+    # This will be called whenever a connection is established or
+    # fails to establish (either phase 1, xauth phase, or phase 2)
+    # or whenever an already established connection is being terminated.
     # This will send a singal to NetworkManager over dbus so that NM
-    # can clear up coonnections.
-    libreswan_reason=disconnect
-    export libreswan_reason
-    echo "sending disconnect signal to NetworkManager"
-    /usr/libexec/nm-libreswan-service-helper
+    # can keep track of the coonnections.
+
+    if [ -n "${PLUTO_NM_CONFIGURED}" -a "${PLUTO_NM_CONFIGURED}" != 0 ]; then
+        echo "sending $1 signal to NetworkManager"
+        libreswan_reason=$1
+        export libreswan_reason
+        export PLUTO_PEER_DOMAIN_INFO
+        export PLUTO_PEER_DNS_INFO
+        export PLUTO_PEER_BANNER
+        export PLUTO_MY_SOURCEIP
+        export PLUTO_PEER
+        /usr/libexec/nm-libreswan-service-helper
+    fi
     return 0
  }
 
@@ -623,16 +609,20 @@ case "${PLUTO_VERB}:${1}" in
 	uprule
 	# If you are doing a custom version, firewall commands go here.
 	updateresolvconf
+	# sending connect signal to NM, as something went wrong.
+	notifyNM connect
 	;;
     down-client:)
 	# connection to my client subnet going down
 	downrule
 	# If you are doing a custom version, firewall commands go here.
 	restoreresolvconf
+	# sending disconnect signal to NM, as something went wrong.
+	notifyNM disconnect
 	;;
     disconnectNM-host|disconnectNM-client)
 	# sending disconnect signal to NM, as something went wrong.
-	disconnectNM
+	notifyNM disconnect
 	;;
     #
     # IPv6

--- a/programs/_updown.mast/_updown.mast.in
+++ b/programs/_updown.mast/_updown.mast.in
@@ -374,18 +374,6 @@ updateresolvconf() {
 		rm -f -- ${ORIG_RESOLV_CONF}
 		printf "${RESOLVE_CONF}" > ${ORIG_RESOLV_CONF}
 		return $?
-
-	else
-		echo "Updating resolv.conf is controlled by Network Manager"
-		libreswan_reason=connect
-		export libreswan_reason
-		export PLUTO_PEER_DOMAIN_INFO
-		export PLUTO_PEER_DNS_INFO
-		export PLUTO_PEER_BANNER
-		export PLUTO_MY_SOURCEIP
-		export PLUTO_PEER
-		/usr/libexec/nm-libreswan-service-helper
-		return 0
 	fi
 }
 
@@ -417,29 +405,27 @@ restoreresolvconf() {
 
 		rm -f -- "${LIBRESWAN_RESOLV_CONF}"
 		return 0
-	else
-		# Here disconnect signal is sent to NetworkManager
-		# whenever an already established connection is being terminated.
-		unset libreswan_reason
-		unset PLUTO_PEER_DOMAIN_INFO
-		unset PLUTO_PEER_DNS_INFO
-		unset PLUTO_PEER_BANNER
-		unset PLUTO_MY_SOURCEIP
-		unset PLUTO_PEER
-		echo "Restoring resolv.conf is controlled by Network Manager"
-		disconnectNM
 	fi
 }
 
-disconnectNM() {
-    # This will be called whenever a connection fails to establish
-    # due to a state (either phase 1, xauth phase, or phase 2) fails.
+notifyNM() {
+    # This will be called whenever a connection is established or
+    # fails to establish (either phase 1, xauth phase, or phase 2)
+    # or whenever an already established connection is being terminated.
     # This will send a singal to NetworkManager over dbus so that NM
-    # can clear up coonnections.
-    libreswan_reason=disconnect
-    export libreswan_reason
-    echo "sending disconnect signal to NetworkManager"
-    /usr/libexec/nm-libreswan-service-helper
+    # can keep track of the coonnections.
+
+    if [ -n "${PLUTO_NM_CONFIGURED}" -a "${PLUTO_NM_CONFIGURED}" != 0 ]; then
+        echo "sending $1 signal to NetworkManager"
+        libreswan_reason=$1
+        export libreswan_reason
+        export PLUTO_PEER_DOMAIN_INFO
+        export PLUTO_PEER_DNS_INFO
+        export PLUTO_PEER_BANNER
+        export PLUTO_MY_SOURCEIP
+        export PLUTO_PEER
+        /usr/libexec/nm-libreswan-service-helper
+    fi
     return 0
 }
 
@@ -581,14 +567,18 @@ case "${PLUTO_VERB}:${1}" in
     up-client:)
 	# If you are doing a custom version, firewall commands go here.
 	updateresolvconf
+	# sending disconnect signal to NM, as something went wrong.
+	notifyNM connect
 	;;
     down-client:)
 	# If you are doing a custom version, firewall commands go here.
 	restoreresolvconf
+	# sending disconnect signal to NM, as something went wrong.
+	notifyNM disconnect
 	;;
     disconnectNM-host|disconnectNM-client)
 	# sending disconnect signal to NM, as something went wrong.
-	disconnectNM
+	notifyNM disconnect
 	;;
     #
     # IPv6

--- a/programs/_updown.netkey/_updown.netkey.in
+++ b/programs/_updown.netkey/_updown.netkey.in
@@ -263,18 +263,6 @@ updateresolvconf() {
 		rm -f -- ${ORIG_RESOLV_CONF}
 		printf "${RESOLVE_CONF}" > ${ORIG_RESOLV_CONF}
 		return $?
-
-	else
-		echo "Updating resolv.conf is controlled by Network Manager"
-		libreswan_reason=connect
-		export libreswan_reason
-		export PLUTO_PEER_DOMAIN_INFO
-		export PLUTO_PEER_DNS_INFO
-		export PLUTO_PEER_BANNER
-		export PLUTO_MY_SOURCEIP
-		export PLUTO_PEER
-		/usr/libexec/nm-libreswan-service-helper
-		return 0
 	fi
 }
 
@@ -306,29 +294,27 @@ restoreresolvconf() {
 
 		rm -f -- "${LIBRESWAN_RESOLV_CONF}"
 		return 0
-	else
-		# Here disconnect signal is sent to NetworkManager
-		# whenever an already established connection is being terminated.
-		unset libreswan_reason
-		unset PLUTO_PEER_DOMAIN_INFO
-		unset PLUTO_PEER_DNS_INFO
-		unset PLUTO_PEER_BANNER
-		unset PLUTO_MY_SOURCEIP
-		unset PLUTO_PEER
-		echo "Restoring resolv.conf is controlled by Network Manager"
-		disconnectNM
 	fi
 }
 
-disconnectNM() {
-    # This will be called whenever a connection fails to establish
-    # due to a state (either phase 1, xauth phase, or phase 2) fails.
+notifyNM() {
+    # This will be called whenever a connection is established or
+    # fails to establish (either phase 1, xauth phase, or phase 2)
+    # or whenever an already established connection is being terminated.
     # This will send a singal to NetworkManager over dbus so that NM
-    # can clear up coonnections.
-    libreswan_reason=disconnect
-    export libreswan_reason
-    echo "sending disconnect signal to NetworkManager"
-    /usr/libexec/nm-libreswan-service-helper
+    # can keep track of the coonnections.
+
+    if [ -n "${PLUTO_NM_CONFIGURED}" -a "${PLUTO_NM_CONFIGURED}" != 0 ]; then
+        echo "sending $1 signal to NetworkManager"
+        libreswan_reason=$1
+        export libreswan_reason
+        export PLUTO_PEER_DOMAIN_INFO
+        export PLUTO_PEER_DNS_INFO
+        export PLUTO_PEER_BANNER
+        export PLUTO_MY_SOURCEIP
+        export PLUTO_PEER
+        /usr/libexec/nm-libreswan-service-helper
+    fi
     return 0
 }
 
@@ -533,6 +519,8 @@ case "${PLUTO_VERB}" in
 	# connection to my client subnet coming up
 	# If you are doing a custom version, firewall commands go here.
 	updateresolvconf
+	# sending connect signal to NM, as something went wrong.
+	notifyNM connect
 	;;
     down-client)
 	# connection to my client subnet going down
@@ -540,10 +528,12 @@ case "${PLUTO_VERB}" in
 	delnflog
 	# If you are doing a custom version, firewall commands go here.
 	restoreresolvconf
+	# sending disconnect signal to NM, as something went wrong.
+	notifyNM disconnect
 	;;
     disconnectNM-host|disconnectNM-client)
 	# sending disconnect signal to NM, as something went wrong.
-	disconnectNM
+	notifyNM disconnect
 	;;
     #
     # IPv6


### PR DESCRIPTION
Letting NM know is not just specific to resolver configuration management, NM
always needs to know if setting up the connection succeeded or timed out.

Moreover, it's probably not a good idea to unset the variables upon disconnect
as it would be nice if NetworkManager could identify the connection that goes
down.