### PR TITLE
selinux: support dynamic class/perm discovery

### DIFF
--- a/programs/pluto/security_selinux.c
+++ b/programs/pluto/security_selinux.c
@@ -68,8 +68,8 @@ int within_range(security_context_t sl, security_context_t range)
 	/*
 	** Straight up test between sl and range
 	**/
-	tclass = SECCLASS_ASSOCIATION;
-	av = ASSOCIATION__POLMATCH;
+	tclass = string_to_security_class("association");
+	av = string_to_av_perm(tclass, "polmatch");
 	rtn = avc_has_perm(slsid, rangesid, tclass, av, NULL, &avd);
 	if (rtn != 0) {
 		DBG_log("within_range: The sl (%s) is not within range of (%s)", sl,

--- a/programs/pluto/security_selinux.h
+++ b/programs/pluto/security_selinux.h
@@ -16,8 +16,6 @@
 #define _SECURITY_SELINUX_H
 
 #include <selinux/selinux.h>
-#include <selinux/flask.h>
-#include <selinux/av_permissions.h>
 #include <selinux/avc.h>
 #include <selinux/context.h>
 


### PR DESCRIPTION
The older API has been deprecated which breaks Werror builds.

<pre>
  In file included from /home/lkundrak/fedora/libreswan/libreswan-3.15/programs/pluto/security_selinux.h:19:0,
                   from /home/lkundrak/fedora/libreswan/libreswan-3.15/programs/pluto/ikev1_spdb_struct.c:61:
   #warning "Please remove any #include's of this header in your source code."
   #warning "Instead, use string_to_security_class() to map the class name to a value."

  In file included from /home/lkundrak/fedora/libreswan/libreswan-3.15/programs/pluto/security_selinux.h:20:0,
                   from /home/lkundrak/fedora/libreswan/libreswan-3.15/programs/pluto/plutomain.c:103:
  /usr/include/selinux/av_permissions.h:1:2: error: #warning "Please remove any #include of this header in your source code." [-Werror=cpp]
   #warning "Please remove any #include of this header in your source code."
   #warning "Instead, use string_to_av_perm() to map the permission name to a value."
    ^
  cc1: all warnings being treated as errors
</pre>