### PR TITLE
pluto: ignore tentative and failed IPv6 addresses

### DIFF
--- a/programs/pluto/sysdep_linux.c
+++ b/programs/pluto/sysdep_linux.c
@@ -33,6 +33,8 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 
+#include <linux/if_addr.h>
+
 #include <libreswan.h>
 
 #include "sysdep.h"
@@ -295,7 +297,7 @@ struct raw_iface *find_raw_ifaces6(void)
 			unsigned int if_idx;            /* proc field, not used */
 			unsigned int plen;              /* proc field, not used */
 			unsigned int scope;             /* proc field, used to exclude link-local */
-			unsigned int dad_status;        /* proc field, not used */
+			unsigned int dad_status;        /* proc field */
 			/* ??? I hate and distrust scanf -- DHR */
 			int r = fscanf(proc_sock,
 				       "%4hx%4hx%4hx%4hx%4hx%4hx%4hx%4hx"
@@ -315,6 +317,9 @@ struct raw_iface *find_raw_ifaces6(void)
 			 * IPV6_ADDR_SCOPE_MASK	0x00f0U
 			 */
 			if ((scope & 0x00f0U) == 0x0020U)
+				continue;
+
+			if (dad_status & (IFA_F_TENTATIVE | IFA_F_DADFAILED))
 				continue;
 
 			snprintf(sb, sizeof(sb),


### PR DESCRIPTION
It's neither desired nor possible to bind a socket to them:

<pre>
Nov 04 10:20:56 belphegor pluto[1099]: ERROR: bind() for virbr2/virbr2 fd00:8086:1337:55::1:500 in process_raw_ifaces(). Errno 99: Cannot assign requested address

# ip -6 addr show dev virbr2
20: virbr2: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500
    inet6 fd00:8086:1337:55::1/64 scope global tentative
       valid_lft forever preferred_lft forever
# grep virbr2 /proc/net/if_inet6
fd008086133700550000000000000001 14 40 00 c0   virbr2
</pre>