### PR TITLE
KLIPS: kernel 4.1 requires HAVE_USER_NS

### DIFF
--- a/linux/include/libreswan/ipsec_kversion.h
+++ b/linux/include/libreswan/ipsec_kversion.h
@@ -556,8 +556,10 @@ typedef struct ctl_table ctl_table;
 # define DEFINE_RWLOCK(x) rwlock_t x = RW_LOCK_UNLOCKED
 #endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 1, 0)
+#  define HAVE_USER_NS
 /* CONFIG_USER_NS is now on in Fedora 20 kernels */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0)
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 5, 0)
 # if defined(CONFIG_USER_NS)
 #  define HAVE_USER_NS
 # endif


### PR DESCRIPTION
Newer linux kernels always use the same interface to uids, whether they use
user namespaces or not.

This solves a build failure on linux 4.1.13 where the config dit not include CONFIG_USER_NS.
I haven't checked kernel versions before 4.1.