### PR TITLE
Fix the required packages for Debian/Ubuntu

### DIFF
--- a/README
+++ b/README
@@ -49,11 +49,10 @@ There are a few packages required for Libreswan to compile from source:
 
 For Debian/Ubuntu
 
-	apt-get install libnss4-dev libnspr4-dev pkg-config libpam-dev \
+	apt-get install libnss3-dev libnspr4-dev pkg-config libpam-dev \
 		libcap-ng-dev libcap-ng-utils libselinux-dev \
-		libcurl3-nss-dev, libgmp3-dev flex bison gcc make \
-		libunbound-dev libnss3-tools libevent-dev xmlto \
-		libevent-dev
+		libcurl3-nss-dev libgmp3-dev flex bison gcc make \
+		libunbound-dev libnss3-tools libevent-dev xmlto
 
 	(there is no fipscheck library for these, set USE_FIPSCHECK=false)
 


### PR DESCRIPTION
I made these changes to this PR:
1. Change `libnss4-dev` to `libnss3-dev` because I can't find any `libnss4-dev` related packages in Ubuntu/Debian or Google. I built Libreswan 3.16 with `libnss3-dev` without any problems.
2. Remove the `,` after `libcurl3-nss-dev` because this is the incorrect argument for `apt-get`.
3. Remove the duplicate `libevent-dev`.