### PR TITLE
Fix addconn verbose output

### DIFF
--- a/programs/addconn/addconn.c
+++ b/programs/addconn/addconn.c
@@ -443,7 +443,7 @@ static int resolve_defaultroute_one(struct starter_end *host,
 				r_gateway,
 				r_interface,
 				r_source, rtmsg->rtm_table,
-				ignore ? "" : " (ignored)");
+				ignore ? " (ignored)" : "");
 		}
 
 		if (ignore)


### PR DESCRIPTION
This fixes an inverse logic bug when addconn is run with verbose output.
Introduced by 4fc07a76d91d502918abbd13c7c213905f7a4e41