### PR TITLE
Follow connaddrfamily when resolving addresses

### DIFF
--- a/programs/pluto/connections.c
+++ b/programs/pluto/connections.c
@@ -965,7 +965,7 @@ static bool extract_end(struct end *dst, const struct whack_end *src,
 
 		switch (dst->host_type) {
 		case KH_IPHOSTNAME:
-			er = ttoaddr(dst->host_addr_name, 0, AF_UNSPEC,
+			er = ttoaddr(dst->host_addr_name, 0, dst->host_addr.u.v4.sin_family,
 				&dst->host_addr);
 
 			/* The above call wipes out the port, put it again */


### PR DESCRIPTION
This fixes a bug where the v6 address for a hostname was incorrectly used when connaddrfamily=ipv4.