### PR TITLE
avoid another flex/gcc warning

### DIFF
--- a/lib/libipsecconf/Makefile
+++ b/lib/libipsecconf/Makefile
@@ -55,6 +55,10 @@ $(OBJS): $(builddir)/parser.tab.h
 #   On some architectures, yy_size_t is wider than int;
 #   which makes a mixed comparison OK.
 #
+# - flex 2.6.0-11 and gcc 4:5.3.1-3 on debian testing (2016-06-18)
+#   also warns about comparisons of different kinds, so we add a third
+#   fix.
+#
 # Avoid sed -i which somehow causes unwritable files
 # on fedora 20 with 9p filesystem mount.
 # Avoid creating the target file until it is done.
@@ -65,6 +69,7 @@ $(builddir)/lex.yy.c: parser.l
 	$(LEX) -o $@.tmp $<
 	sed -e 's/for ( i = 0; i < _yybytes_len; ++i )$$/for ( i = 0; (yy_size_t)i < (yy_size_t)_yybytes_len; ++i )/' \
 	    -e '/^extern int isatty.*$$/d' \
+	    -e 's/if ((int) ((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {$$/if (((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {/' \
 	    < $@.tmp > $@.sedtmp
 	rm $@.tmp
 	mv $@.sedtmp $@


### PR DESCRIPTION
flex 2.6.0-11 and gcc 4:5.3.1-3 on debian testing (2016-06-18) create
a warning about comparing different types.

We're already tweaking the flex-generated output in two ways, so we
just stick in a third bit of tweaking.

Without this patch, i see the following error when building in
lib/libipsecconf:

cc -g -O2 -fstack-protector-strong -Wformat -Werror=format-security -I/home/dkg/src/libreswan/libreswan/ports/linux/include -I/home/dkg/src/libreswan/libreswan/ports/linux/include -I/home/dkg/src/libreswan/libreswan/ports/linux/include -I../../OBJ.linux.x86_64/lib/libipsecconf -I. -I/home/dkg/src/libreswan/libreswan/linux/net/ipsec -I/home/dkg/src/libreswan/libreswan/linux/include -I/home/dkg/src/libreswan/libreswan -I/home/dkg/src/libreswan/libreswan/include -I/usr/include/nss -I/usr/include/nspr  -pthread  -m64 -g -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-all -fno-strict-aliasing -fPIE -DPIE -DFORCE_PR_ASSERT -DDNSSEC -DKLIPS -DLIBCURL -DLDAP_VER=3 -DHAVE_NM -DUSE_MD5 -DUSE_SHA2 -DUSE_SHA1 -DUSE_AES -DUSE_3DES -DUSE_CAMELLIA -DFIPSPRODUCTCHECK=\"/etc/system-fips\" -DIPSEC_CONF=\"/etc/ipsec.conf\" -DIPSEC_CONFDDIR=\"/etc/ipsec.d\" -DIPSEC_NSSDIR=\"/var/lib/libreswan/nss\" -DIPSEC_CONFDIR=\"/etc\" -DIPSEC_EXECDIR=\"/usr/lib/ipsec\" -DIPSEC_SBINDIR=\"/usr/sbin\" -DIPSEC_VARDIR=\"/var\" -DPOLICYGROUPSDIR=\"/etc/ipsec.d/policies\" -DSHARED_SECRETS_FILE=\"/etc/ipsec.secrets\" -DRETRANSMIT_INTERVAL_DEFAULT="500" -DUSE_FORK=1 -DUSE_VFORK=0 -DUSE_DAEMON=0 -DUSE_PTHREAD_SETSCHEDPRIO=1 -DGCC_LINT -DALLOW_MICROSOFT_BAD_PROPOSAL -Werror -Wall -Wextra -Wformat -Wformat-nonliteral -Wformat-security -Wundef -Wmissing-declarations -Wredundant-decls -Wnested-externs \
	-MMD -MF ../../OBJ.linux.x86_64/lib/libipsecconf/lex.yy.d \
	-o ../../OBJ.linux.x86_64/lib/libipsecconf/lex.yy.o \
	-c /home/dkg/src/libreswan/libreswan/OBJ.linux.x86_64/lib/libipsecconf/lex.yy.c
../../OBJ.linux.x86_64/lib/libipsecconf/lex.yy.c.tmp: In function ‘yy_get_next_buffer’:
../../OBJ.linux.x86_64/lib/libipsecconf/lex.yy.c.tmp:1723:44: error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]
cc1: all warnings being treated as errors
../../mk/depend.mk:28: recipe for target 'lex.yy.o' failed
make[4]: *** [lex.yy.o] Error 1
make[4]: Leaving directory '/home/dkg/src/libreswan/libreswan/lib/libipsecconf'