### PR TITLE
section intro line needs whitespace between "type" and "name"

### DIFF
--- a/programs/configs/d.ipsec.conf/connsections.xml
+++ b/programs/configs/d.ipsec.conf/connsections.xml
@@ -58,7 +58,7 @@ is ignored and unused. For compatibility with openswan, specify:</para>
 <para>A section
 begins with a line of the form:</para>
 
-<para><emphasis remap='I'>type</emphasis> <emphasis remap='I'>name</emphasis></para>
+<para><emphasis remap='I'>type</emphasis>&nbsp;<emphasis remap='I'>name</emphasis></para>
 
 <para>where
 <emphasis remap='I'>type</emphasis>


### PR DESCRIPTION
xmlto 0.0.25-2 (debian stable) apparently elides the space between
"type" and "name", which makes this hard to read in the output text.
(i.e. it looks like "typename")

Also, we want this directive to always be on a single line no matter
how crazy narrow the terminal is.

This non-breaking space should solve both problems.