### PR TITLE
pluto: don't add duplicate entries to the bare_shunts table

### DIFF
--- a/programs/pluto/kernel.c
+++ b/programs/pluto/kernel.c
@@ -183,6 +183,22 @@ void record_and_initiate_opportunistic(const ip_subnet *ours,
 {
 	passert(samesubnettype(ours, his));
 
+	/* Check if there's a matching entry in the bare_shunts list. If so,
+	 * don't add a duplicate. The shunts list cannot have duplicates.
+	 */
+	{
+		ip_address src, dst;
+
+		networkof(ours, &src);
+		networkof(his, &dst);
+
+		/* existing bare hold? */
+		if (has_bare_hold(&src, &dst, transport_proto)) {
+			DBG(DBG_OPPO, DBG_log("record_and_initiate_opportunistic(): existing bare hold found; skip adding a duplicate bare shunt"));
+			return;
+		}
+	}
+
 	/* Add the kernel shunt to the pluto bare shunt list.
 	 * We need to do this because the %hold shunt was installed by kernel
 	 * and we want to keep track of it inside pluto.


### PR DESCRIPTION
Bit of a naive pull request maybe; this patch addresses the `fiddle_bare_shunt` duplicate shunt issue in #50 by preventing the duplicate from being added in the first place. Have tested it and I no longer get the `passrt` failure in `expire_bare_shunts()`.


See https://github.com/libreswan/libreswan/issues/50

Check for existing holds in the shunts list, and avoid adding if there's
a match.