### PR TITLE
Enable "systemctl help ipsec"

### DIFF
--- a/initsystems/systemd/ipsec.service.in
+++ b/initsystems/systemd/ipsec.service.in
@@ -2,6 +2,7 @@
 Description=Internet Key Exchange (IKE) Protocol Daemon for IPsec
 Wants=network-online.target
 After=network-online.target
+Documentation=man:ipsec(8) man:pluto(8) man:ipsec.conf(5)
 
 [Service]
 Type=@SD_TYPE@


### PR DESCRIPTION
The Documentation= key in a [Unit] section of a systemd .service file
is used by systemctl to provide an easy way for an administrator to
get access to documentation about a given service.  Search for
Documentation= in systemd.unit(5) for more details.