### PR TITLE
Include strerror in the error message when file open fails.

### DIFF
--- a/lib/libipsecconf/parser.l
+++ b/lib/libipsecconf/parser.l
@@ -172,8 +172,8 @@ static int parser_y_nextglobfile(struct ic_inputsource *iis)
 		char ebuf[128];
 
 		snprintf(ebuf, sizeof(ebuf),
-			"cannot open include filename: '%s'",
-			iis->fileglob.gl_pathv[fcnt]);
+			"cannot open include filename: '%s' err: '%s'",
+			iis->fileglob.gl_pathv[fcnt], strerror(errno));
 		yyerror(ebuf);
 		return -1;
 	}


### PR DESCRIPTION
I was seeing a weird error when running with multiple config
files. Never did track it down because my rebuilt part of libreswan
wouldn't run with the rest of the distro's version. Was easier to just
switch to using a single config file.