### PR TITLE
fix time_t printf on x32

### DIFF
--- a/programs/pluto/connections.c
+++ b/programs/pluto/connections.c
@@ -1581,11 +1581,11 @@ void add_connection(const struct whack_message *wm)
 		if (!deltaless(c->sa_rekey_margin, c->sa_ipsec_life_seconds)) {
 			deltatime_t new_rkm = deltatimescale(1, 2, c->sa_ipsec_life_seconds);
 
-			libreswan_log("conn: %s, rekeymargin (%lds) >= salifetime (%lds); reducing rekeymargin to %ld seconds",
+			libreswan_log("conn: %s, rekeymargin (%llds) >= salifetime (%llds); reducing rekeymargin to %lld seconds",
 				c->name,
-				(long) deltasecs(c->sa_rekey_margin),
-				(long) deltasecs(c->sa_ipsec_life_seconds),
-				(long) deltasecs(new_rkm));
+				(long long int) deltasecs(c->sa_rekey_margin),
+				(long long int) deltasecs(c->sa_ipsec_life_seconds),
+				(long long int) deltasecs(new_rkm));
 
 			c->sa_rekey_margin = new_rkm;
 		}
@@ -1600,13 +1600,13 @@ void add_connection(const struct whack_message *wm)
 		}
 #endif
 			if (deltasecs(c->sa_ike_life_seconds) > max_ike) {
-				loglog(RC_LOG_SERIOUS,"IKE lifetime limited to the maximum allowed %lds",
-					max_ike);
+				loglog(RC_LOG_SERIOUS,"IKE lifetime limited to the maximum allowed %llds",
+                                       (long long int) max_ike);
 				c->sa_ike_life_seconds = deltatime(max_ike);
 			}
 			if (deltasecs(c->sa_ipsec_life_seconds) > max_ipsec) {
-				loglog(RC_LOG_SERIOUS,"IPsec lifetime limited to the maximum allowed %lds",
-					max_ipsec);
+				loglog(RC_LOG_SERIOUS,"IPsec lifetime limited to the maximum allowed %llds",
+                                       (long long int) max_ipsec);
 				c->sa_ipsec_life_seconds = deltatime(max_ipsec);
 			}
 		}
@@ -1884,10 +1884,10 @@ void add_connection(const struct whack_message *wm)
 #endif
 
 		DBG(DBG_CONTROL,
-			DBG_log("ike_life: %lds; ipsec_life: %lds; rekey_margin: %lds; rekey_fuzz: %lu%%; keyingtries: %lu; replay_window: %u; policy: %s%s",
-				(long) deltasecs(c->sa_ike_life_seconds),
-				(long) deltasecs(c->sa_ipsec_life_seconds),
-				(long) deltasecs(c->sa_rekey_margin),
+			DBG_log("ike_life: %llds; ipsec_life: %llds; rekey_margin: %llds; rekey_fuzz: %lu%%; keyingtries: %lu; replay_window: %u; policy: %s%s",
+				(long long int) deltasecs(c->sa_ike_life_seconds),
+				(long long int) deltasecs(c->sa_ipsec_life_seconds),
+				(long long int) deltasecs(c->sa_rekey_margin),
 				c->sa_rekey_fuzz,
 				c->sa_keying_tries,
 				c->sa_replay_window,
@@ -4039,22 +4039,22 @@ void show_one_connection(const struct connection *c)
 	}
 
 	whack_log(RC_COMMENT,
-		"\"%s\"%s:   ike_life: %lds; ipsec_life: %lds; replay_window: %u; rekey_margin: %lds; rekey_fuzz: %lu%%; keyingtries: %lu;",
+		"\"%s\"%s:   ike_life: %llds; ipsec_life: %llds; replay_window: %u; rekey_margin: %llds; rekey_fuzz: %lu%%; keyingtries: %lu;",
 		c->name,
 		instance,
-		(long) deltasecs(c->sa_ike_life_seconds),
-		(long) deltasecs(c->sa_ipsec_life_seconds),
+		(long long int) deltasecs(c->sa_ike_life_seconds),
+		(long long int) deltasecs(c->sa_ipsec_life_seconds),
 		c->sa_replay_window,
-		(long) deltasecs(c->sa_rekey_margin),
+		(long long int) deltasecs(c->sa_rekey_margin),
 		c->sa_rekey_fuzz,
 		c->sa_keying_tries);
 
 	whack_log(RC_COMMENT,
-		"\"%s\"%s:   retransmit-interval: %ldms; retransmit-timeout: %lds;",
+		"\"%s\"%s:   retransmit-interval: %ldms; retransmit-timeout: %llds;",
 		c->name,
 		instance,
 		c->r_interval,
-		(long) deltasecs(c->r_timeout));
+		(long long int) deltasecs(c->r_timeout));
 
 	whack_log(RC_COMMENT,
 		  "\"%s\"%s:   sha2-truncbug:%s; initial-contact:%s; cisco-unity:%s; fake-strongswan:%s; send-vendorid:%s; send-no-esp-tfc:%s;",

--- a/programs/pluto/defs.c
+++ b/programs/pluto/defs.c
@@ -146,8 +146,9 @@ const char *check_expiry(realtime_t expiration_date, time_t warning_interval,
 			time_left /= secs_per_minute;
 			unit = "minute";
 		}
-		snprintf(buf, sizeof(buf), "warning (expires in %ld %s%s)",
-			time_left, unit, (time_left == 1) ? "" : "s");
+		snprintf(buf, sizeof(buf), "warning (expires in %lld %s%s)",
+                         (long long int) time_left, unit,
+                         (time_left == 1) ? "" : "s");
 		return buf;
 	}
 }

--- a/programs/pluto/ikev2.c
+++ b/programs/pluto/ikev2.c
@@ -1675,15 +1675,15 @@ time_t ikev2_replace_delay(struct state *st, enum event_type *pkind,
 		 */
 		if (IS_IKE_SA_ESTABLISHED(st)) {
 			delay = deltasecs(c->sa_ike_life_seconds);
-			DBG(DBG_LIFECYCLE, DBG_log("ikev2_replace_delay() picked up estalibhsed ike_life:%lu", delay));
+			DBG(DBG_LIFECYCLE, DBG_log("ikev2_replace_delay() picked up estalibhsed ike_life:%lld", (long long int) delay));
 		} else {
 			delay = PLUTO_HALFOPEN_SA_LIFE;
-			DBG(DBG_LIFECYCLE, DBG_log("ikev2_replace_delay() picked up half-open SA ike_life:%lu", delay));
+			DBG(DBG_LIFECYCLE, DBG_log("ikev2_replace_delay() picked up half-open SA ike_life:%lld", (long long int) delay));
 		}
 	} else {
 		/* Delay is what the user said, no negotiation. */
 		delay = deltasecs(c->sa_ipsec_life_seconds);
-		DBG(DBG_LIFECYCLE, DBG_log("ikev2_replace_delay() picked up salifetime=%lu", delay));
+		DBG(DBG_LIFECYCLE, DBG_log("ikev2_replace_delay() picked up salifetime=%lld", (long long int) delay));
 	}
 
 	/* By default, we plan to rekey.
@@ -1900,7 +1900,7 @@ static void success_v2_state_transition(struct msg_digest *md)
 						EVENT_RELEASE_WHACK_DELAY, st);
 				kind = EVENT_SA_REPLACE;
 				delay = ikev2_replace_delay(st, &kind, st->st_original_role);
-				DBG(DBG_LIFECYCLE, DBG_log("ikev2 case EVENT_v2_RETRANSMIT: for %lu seconds", delay));
+				DBG(DBG_LIFECYCLE, DBG_log("ikev2 case EVENT_v2_RETRANSMIT: for %lld seconds", (long long int) delay));
 				event_schedule(kind, delay, st);
 
 			}  else {
@@ -1913,8 +1913,8 @@ static void success_v2_state_transition(struct msg_digest *md)
 			break;
 		case EVENT_SA_REPLACE: /* IKE or Child SA replacement event */
 			delay = ikev2_replace_delay(st, &kind, st->st_original_role);
-			DBG(DBG_LIFECYCLE, DBG_log("ikev2 case EVENT_SA_REPLACE for %s state for %lu seconds",
-				IS_IKE_SA(st) ? "parent" : "child", delay));
+			DBG(DBG_LIFECYCLE, DBG_log("ikev2 case EVENT_SA_REPLACE for %s state for %lld seconds",
+                            IS_IKE_SA(st) ? "parent" : "child", (long long int) delay));
 			delete_event(st);
 			event_schedule(kind, delay, st);
 			break;

--- a/programs/pluto/pending.c
+++ b/programs/pluto/pending.c
@@ -335,11 +335,11 @@ bool pending_check_timeout(const struct connection *c)
 		DBG(DBG_DPD, {
 			deltatime_t waited = monotimediff(mononow(), p->pend_time);
 			char cib[CONN_INST_BUF];
-			DBG_log("checking connection \"%s\"%s for stuck phase 2s (waited %lds, patience 3*%lds)",
+			DBG_log("checking connection \"%s\"%s for stuck phase 2s (waited %llds, patience 3*%llds)",
 				c->name,
 				fmt_conn_instance(c, cib),
-				(long) deltasecs(waited),
-				(long) deltasecs(c->dpd_timeout));
+				(long long int) deltasecs(waited),
+				(long long int) deltasecs(c->dpd_timeout));
 			});
 
 		if (deltasecs(c->dpd_timeout) > 0) {

--- a/programs/pluto/plutomain.c
+++ b/programs/pluto/plutomain.c
@@ -939,7 +939,7 @@ int main(int argc, char **argv)
 			continue;
 
 		case 'x':	/* --crlcheckinterval <seconds> */
-			ugh = ttoulb(optarg, 0, 10, TIME_T_MAX, &u);
+			ugh = ttoulb(optarg, 0, 10, (unsigned long) TIME_T_MAX, &u);
 			if (ugh != NULL)
 				break;
 			crl_check_interval = deltatime(u);
@@ -1785,12 +1785,12 @@ void show_setup_plutomain(void)
 		pluto_vendorid);
 
 	whack_log(RC_COMMENT,
-		"nhelpers=%d, uniqueids=%s, perpeerlog=%s, shuntlifetime=%lus, xfrmlifetime=%ds",
+		"nhelpers=%d, uniqueids=%s, perpeerlog=%s, shuntlifetime=%llds, xfrmlifetime=%llds",
 		nhelpers,
 		uniqueIDs ? "yes" : "no",
 		!log_to_perpeer ? "no" : base_perpeer_logdir,
-		deltasecs(pluto_shunt_lifetime),
-		pluto_xfrmlifetime
+                (long long int) deltasecs(pluto_shunt_lifetime),
+                (long long int) pluto_xfrmlifetime
 	);
 
 	whack_log(RC_COMMENT,
@@ -1801,10 +1801,10 @@ void show_setup_plutomain(void)
 			(pluto_ddos_mode == DDOS_FORCE_BUSY) ? "busy" : "unlimited");
 
 	whack_log(RC_COMMENT,
-		"ikeport=%d, strictcrlpolicy=%s, crlcheckinterval=%lu, listen=%s, nflog-all=%d",
+		"ikeport=%d, strictcrlpolicy=%s, crlcheckinterval=%lld, listen=%s, nflog-all=%d",
 		pluto_port,
 		crl_strict ? "yes" : "no",
-		deltasecs(crl_check_interval),
+                (long long int) deltasecs(crl_check_interval),
 		pluto_listen != NULL ? pluto_listen : "<any>",
 		pluto_nflog_group
 		);

--- a/programs/pluto/state.c
+++ b/programs/pluto/state.c
@@ -1942,9 +1942,9 @@ void fmt_state(struct state *st, const monotime_t n,
 
 			/* ??? why is printing -1 better than 0? */
 			snprintf(dpdbuf, sizeof(dpdbuf),
-				 "; lastdpd=%lds(seq in:%u out:%u)",
+				 "; lastdpd=%llds(seq in:%u out:%u)",
 				 st->st_last_dpd.mono_secs != UNDEFINED_TIME ?
-					(long)deltasecs(monotimediff(mononow(), st->st_last_dpd)) : (long)-1,
+					(long long int)deltasecs(monotimediff(mononow(), st->st_last_dpd)) : (long long int)-1,
 				 st->st_dpd_seqno,
 				 st->st_dpd_expectseqno);
 		} else if (dpd_active_locally(st) && st->st_ikev2) {
@@ -1954,9 +1954,9 @@ void fmt_state(struct state *st, const monotime_t n,
 
 				if (pst != NULL) {
 					snprintf(dpdbuf, sizeof(dpdbuf),
-						"; lastlive=%lds",
+						"; lastlive=%llds",
 						pst->st_last_liveness.mono_secs != UNDEFINED_TIME ?
-						deltasecs(monotimediff(mononow(), pst->st_last_liveness)) :
+                                                 (long long int) deltasecs(monotimediff(mononow(), pst->st_last_liveness)) :
 						0);
 				}
 			}
@@ -2011,8 +2011,8 @@ void fmt_state(struct state *st, const monotime_t n,
 		if (c->spd.eroute_owner == st->st_serialno &&
 		    st->st_outbound_count != 0) {
 			snprintf(lastused, sizeof(lastused),
-				 " used %lds ago;",
-				 (long) deltasecs(monotimediff(mononow(),
+				 " used %llds ago;",
+				 (long long int) deltasecs(monotimediff(mononow(),
 						  st->st_outbound_time)));
 		}
 

--- a/programs/pluto/timer.c
+++ b/programs/pluto/timer.c
@@ -459,9 +459,9 @@ static void ikev2_log_v2_sa_expired(struct state *st, enum event_type type)
 			/* because we cannot tell the difference sending out to a dead SA? */
 			if (get_sa_info(st, TRUE, &last_used_age)) {
 				snprintf(story, sizeof(story),
-					"last used %lds ago < %ld ",
-					(long)deltasecs(last_used_age),
-					(long)deltasecs(c->sa_rekey_margin));
+					"last used %llds ago < %lld ",
+					(long long int)deltasecs(last_used_age),
+					(long long int)deltasecs(c->sa_rekey_margin));
 			} else {
 				snprintf(story, sizeof(story),
 					"unknown usage - get_sa_info() failed");
@@ -482,10 +482,10 @@ static void ikev2_expire_parent(struct state *st, deltatime_t last_used_age)
 
 	/* we observed no traffic, let IPSEC SA and IKE SA expire */
 	DBG(DBG_LIFECYCLE,
-		DBG_log("not replacing unused IPSEC SA #%lu: last used %lds ago > %ld let it and the parent #%lu expire",
+		DBG_log("not replacing unused IPSEC SA #%lu: last used %llds ago > %lld let it and the parent #%lu expire",
 			st->st_serialno,
-			(long)deltasecs(last_used_age),
-			(long)deltasecs(c->sa_rekey_margin),
+			(long long int)deltasecs(last_used_age),
+			(long long int)deltasecs(c->sa_rekey_margin),
 			pst->st_serialno));
 
 	delete_event(pst);
@@ -763,9 +763,9 @@ static void timer_event_cb(evutil_socket_t fd UNUSED, const short event UNUSED, 
 			 * at stake.
 			 */
 			DBG(DBG_LIFECYCLE, DBG_log(
-					"not replacing stale %s SA: inactive for %lds",
+					"not replacing stale %s SA: inactive for %llds",
 					IS_IKE_SA(st) ? "ISAKMP" : "IPsec",
-					(long)deltasecs(monotimediff(mononow(),
+					(long long int)deltasecs(monotimediff(mononow(),
 						st->st_outbound_time))));
 		} else {
 			ikev2_log_v2_sa_expired(st, type);
@@ -911,10 +911,10 @@ void timer_list(void)
 		int type = ev->ev_type;
 		struct state *st = ev->ev_state;
 
-		whack_log(RC_LOG, "event %s is schd: %ld (in %lds) #%lu",
+		whack_log(RC_LOG, "event %s is schd: %lld (in %llds) #%lu",
 			enum_show(&timer_event_names, type),
-			(long)ev->ev_time.mono_secs,
-			(long)deltasecs(monotimediff(ev->ev_time, nw)),
+			(long long int)ev->ev_time.mono_secs,
+			(long long int)deltasecs(monotimediff(ev->ev_time, nw)),
 			st == NULL ? SOS_NOBODY : st->st_serialno);
 
 		if (st != NULL && st->st_connection != NULL) {
@@ -939,8 +939,8 @@ static void event_schedule_tv(enum event_type type, const struct timeval delay, 
 	struct pluto_event *ev = alloc_thing(struct pluto_event, en);
 	DBG(DBG_LIFECYCLE, DBG_log("%s: new %s-pe@%p", __func__, en, ev));
 
-	DBG(DBG_LIFECYCLE, DBG_log("event_schedule_tv called for about %lu seconds and change",
-		delay.tv_sec));
+	DBG(DBG_LIFECYCLE, DBG_log("event_schedule_tv called for about %lld seconds and change",
+	    (long long int) delay.tv_sec));
 
 	/*
 	 * Scheduling a month into the future is most likely a bug.
@@ -1028,7 +1028,7 @@ void event_schedule(enum event_type type, time_t delay_sec, struct state *st)
 {
 	struct timeval delay;
 
-	DBG(DBG_LIFECYCLE, DBG_log("event_schedule called for %lu seconds", delay_sec));
+	DBG(DBG_LIFECYCLE, DBG_log("event_schedule called for %lld seconds", (long long int) delay_sec));
 
 	/* unexpectedly far away, pexpect will flag in test cases */
 	pexpect(delay_sec < 3600 * 24 * 31);


### PR DESCRIPTION
On the x32 architecture (x86_64 with 32-bit address space and ints,
but with 64-bit time_t), we see errors like the following:

programs/pluto/connections.c: In function 'add_connection':
programs/pluto/connections.c:1603:74: error: format '%ld' expects argument of type 'long int', but argument 3 has type 'time_t {aka long long int}' [-Werror=format=]
     loglog(RC_LOG_SERIOUS,"IKE lifetime limited to the maximum allowed %lds",
                                                                          ^
programs/pluto/connections.c:1608:76: error: format '%ld' expects argument of type 'long int', but argument 3 has type 'time_t {aka long long int}' [-Werror=format=]
     loglog(RC_LOG_SERIOUS,"IPsec lifetime limited to the maximum allowed %lds",
                                                                            ^

This patch should make the time_t printf work portably by always
casting it to a long long int where it gets printed.

The use of TIME_T_MAX in ttolub also produces a warning:

linux/include/libreswan.h:60:21: error: large integer implicitly truncated to unsigned type [-Werror=overflow]
 #define TIME_T_MAX  ((time_t) ((1ull << (sizeof(time_t) * BITS_PER_BYTE - 1)) - 1))
                     ^
programs/pluto/plutomain.c:942:32: note: in expansion of macro 'TIME_T_MAX'
    ugh = ttoulb(optarg, 0, 10, TIME_T_MAX, &u);
                                ^~~~~~~~~~

This patch also resolves this warning.