### PR TITLE
do not .gitignore debian/*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ OBJ.*
 *.pyc
 *.o
 TAGS
-debian/*
 tags
 modobj
 modobj24


### PR DESCRIPTION
I really appreciate that libreswan upstream has stopped shipping a
conflicting debian/ directory.  This makes it easier for me to import
and package new upstream versions without dealing with conflicting
changes between the packaging as shipped in debian, and the upstream
master.

However, i track the Debian packaging git for the same reason that
upstream does -- i'm even sharing upstream's git history, and the
debian pacakging is just managed on a different branch than main
development.

But since upstream placed debian/* in ~/.gitignore for the master
branch, it forces me as a debian maintainer into an awkward divergence
from upstream -- i actually *do not* want to exclude the debian/
directory from git.  I just don't want upstream to put anything there.

So this patchset removes the line from .gitignore.  It will help
reduce the friction i have to overcome to publish new versions in
debian.