### PR TITLE
Small bug fix in ikev2_parent.c

### DIFF
--- a/programs/pluto/ikev2_parent.c
+++ b/programs/pluto/ikev2_parent.c
@@ -3267,9 +3267,9 @@ static stf_status ikev2_parent_inR1outI2_tail(struct state *pst, struct msg_dige
 		}
 
 		if (cc->send_no_esp_tfc) {
+			notifies--;
 			int np = notifies != 0 ? ISAKMP_NEXT_v2N :
 				ISAKMP_NEXT_v2NONE;
-			notifies--;
 			if (!ship_v2N(np, ISAKMP_PAYLOAD_NONCRITICAL,
 					PROTO_v2_RESERVED,
 					&empty_chunk,


### PR DESCRIPTION
notifies variable was in one if branch decremented after the evaluation of np (next payload) variable, and
it should be decremented before it.