### PR TITLE
logging: dump NO_PPK_AUTH octets in PRIVATE

### DIFF
--- a/programs/pluto/ikev2_parent.c
+++ b/programs/pluto/ikev2_parent.c
@@ -3769,7 +3769,7 @@ stf_status ikev2_parent_inI2outR2_id_tail(struct msg_digest *md)
 					loglog(RC_LOG_SERIOUS, "Failed to extract %zd bytes of NO_PPK_AUTH from Notify payload", len);
 					return STF_FATAL;
 				}
-				DBG(DBG_CONTROL, DBG_dump_chunk("NO_PPK_AUTH:", no_ppk_auth));
+				DBG(DBG_PRIVATE, DBG_dump_chunk("NO_PPK_AUTH:", no_ppk_auth));
 				st->st_no_ppk_auth = no_ppk_auth;
 			} else {
 				libreswan_log("ignored received NO_PPK_AUTH - connection does not allow PPK");

--- a/programs/pluto/ikev2_psk.c
+++ b/programs/pluto/ikev2_psk.c
@@ -260,7 +260,7 @@ bool ikev2_create_psk_auth(enum keyword_authby authby,
 			return FALSE;
 	} else {
 		clonetochunk(*no_ppk_auth, signed_octets, hash_len, "NO_PPK_AUTH chunk");
-		DBG(DBG_CONTROL, DBG_dump_chunk("NO_PPK_AUTH payload", *no_ppk_auth));
+		DBG(DBG_PRIVATE, DBG_dump_chunk("NO_PPK_AUTH payload", *no_ppk_auth));
 	}
 
 	return TRUE;


### PR DESCRIPTION
Changed logging from DBG_CONTROL to DBG_PRIVATE, following the same
principle used for "normal" PSK octets