### PR TITLE
Fix unknown rcode when checking IPsec secret

### DIFF
--- a/programs/verify/verify.in
+++ b/programs/verify/verify.in
@@ -364,7 +364,7 @@ def ipsecsecretcheck():
 			if line and "ERROR" in line:
 				print("  %s"%line)
 	elif "WARNING" in output:
-		print_result("WARNING","OBSOLETE")
+		print_result("WARN","OBSOLETE")
 		for line in output.split("\n"):
 			line = line.strip()
 			if line and "WARNING" in line:


### PR DESCRIPTION
When using a weak secret, a confusing message is shown by the `verify` command:

```console
$ ipsec verify
Verifying installed system and configuration files

Version check and ipsec on-path                         [OK]
Libreswan 3.22 (netkey) on 4.4.0-1047-aws
Checking for IPsec support in kernel                    [OK]
 NETKEY: Testing XFRM related proc values
         ICMP default/send_redirects                    [OK]
         ICMP default/accept_redirects                  [OK]
         XFRM larval drop                               [OK]
Pluto ipsec.conf syntax                                 [OK]
Two or more interfaces found, checking IP forwarding    [OK]
Checking rp_filter                                      [OK]
Checking that pluto is running                          [OK]
 Pluto listening for IKE on udp 500                     [OK]
 Pluto listening for IKE/NAT-T on udp 4500              [OK]
 Pluto ipsec.secret syntax                        INTERNAL ERROR - unknown rcode:WARNING
  003 WARNING: using a weak secret (PSK)
Checking 'ip' command                                   [OK]
Checking 'iptables' command                             [OK]
Checking 'prelink' command does not interfere with FIPS [OK]
Checking for obsolete ipsec.conf options                [OK]
