### PR TITLE
ikev2: renamed function names, to be more consistent

### DIFF
--- a/programs/pluto/ikev1_main.c
+++ b/programs/pluto/ikev1_main.c
@@ -612,7 +612,7 @@ bool ikev1_close_message(pb_stream *pbs, struct state *st)
 
 stf_status main_inI1_outR1(struct state *st, struct msg_digest *md)
 {
-	/* ??? this code looks a lot like the middle of ikev2parent_inI1outR1 */
+	/* ??? this code looks a lot like the middle of ikev2_parent_inI1outR1 */
 	struct payload_digest *const sa_pd = md->chain[ISAKMP_NEXT_SA];
 	struct connection *c;
 	pb_stream r_sa_pbs;

--- a/programs/pluto/ikev2.c
+++ b/programs/pluto/ikev2.c
@@ -296,7 +296,7 @@ static const struct state_v2_microcode v2_state_microcode_table[] = {
 	  .flags = SMF2_IKE_I_CLEAR | SMF2_MSG_R_SET | SMF2_SEND,
 	  .req_clear_payloads = P(N),
 	  .opt_clear_payloads = LEMPTY,
-	  .processor  = ikev2parent_inR1BoutI1B,
+	  .processor  = ikev2_parent_inR1BoutI1B,
 	  .recv_type  = ISAKMP_v2_SA_INIT,
 	  .timeout_event = EVENT_RETAIN, },
 
@@ -312,7 +312,7 @@ static const struct state_v2_microcode v2_state_microcode_table[] = {
 	  .flags = SMF2_IKE_I_CLEAR | SMF2_MSG_R_SET | SMF2_SEND,
 	  .req_clear_payloads = P(SA) | P(KE) | P(Nr),
 	  .opt_clear_payloads = P(CERTREQ),
-	  .processor  = ikev2parent_inR1outI2,
+	  .processor  = ikev2_parent_inR1outI2,
 	  .recv_type  = ISAKMP_v2_SA_INIT,
 	  .timeout_event = EVENT_v2_RETRANSMIT, },
 
@@ -328,7 +328,7 @@ static const struct state_v2_microcode v2_state_microcode_table[] = {
 	  .req_clear_payloads = P(SK),
 	  .req_enc_payloads = P(IDr) | P(AUTH) | P(SA) | P(TSi) | P(TSr),
 	  .opt_enc_payloads = P(CERT)|P(CP),
-	  .processor  = ikev2parent_inR2,
+	  .processor  = ikev2_parent_inR2,
 	  .recv_type  = ISAKMP_v2_AUTH,
 	  .timeout_event = EVENT_SA_REPLACE, },
 
@@ -341,7 +341,7 @@ static const struct state_v2_microcode v2_state_microcode_table[] = {
 	  .next_state = STATE_PARENT_R1,
 	  .flags = SMF2_IKE_I_SET | SMF2_MSG_R_CLEAR | SMF2_SEND,
 	  .req_clear_payloads = P(SA) | P(KE) | P(Ni),
-	  .processor  = ikev2parent_inI1outR1,
+	  .processor  = ikev2_parent_inI1outR1,
 	  .recv_type  = ISAKMP_v2_SA_INIT,
 	  .timeout_event = EVENT_v2_RESPONDER_TIMEOUT, },
 
@@ -361,7 +361,7 @@ static const struct state_v2_microcode v2_state_microcode_table[] = {
 	  .req_clear_payloads = P(SK),
 	  .req_enc_payloads = P(IDi) | P(AUTH) | P(SA) | P(TSi) | P(TSr),
 	  .opt_enc_payloads = P(CERT) | P(CERTREQ) | P(IDr) | P(CP),
-	  .processor  = ikev2parent_inI2outR2,
+	  .processor  = ikev2_parent_inI2outR2,
 	  .recv_type  = ISAKMP_v2_AUTH,
 	  .timeout_event = EVENT_SA_REPLACE, },
 
@@ -2321,13 +2321,13 @@ void complete_v2_state_transition(struct msg_digest **mdp,
 	 *
 	 * One condition for null state is when a new connection request packet
 	 * arrives and there is no suitable matching configuration.  For example,
-	 * ikev2parent_inI1outR1() will return (STF_FAIL + NO_PROPOSAL_CHOSEN) but
+	 * ikev2_parent_inI1outR1() will return (STF_FAIL + NO_PROPOSAL_CHOSEN) but
 	 * no state in this case.  While other failures may be better caught before
 	 * this function is called, we should be graceful here.  And for this
 	 * particular case, and similar failure cases, we want SEND_NOTIFICATION
 	 * (below) to let the peer know why we've rejected the request.
 	 *
-	 * Another case of null state is return from ikev2parent_inR1BoutI1B
+	 * Another case of null state is return from ikev2_parent_inR1BoutI1B
 	 * which returns STF_IGNORE.
 	 *
 	 * Another case occurs when we finish an Informational Exchange message

--- a/programs/pluto/ikev2.h
+++ b/programs/pluto/ikev2.h
@@ -11,7 +11,7 @@ typedef stf_status crypto_transition_fn(struct state *st, struct msg_digest *md,
 
 extern void process_v2_packet(struct msg_digest **mdp);
 
-extern void ikev2parent_outI1(int whack_sock,
+extern void ikev2_parent_outI1(int whack_sock,
 			      struct connection *c,
 			      struct state *predecessor,
 			      lset_t policy,
@@ -41,12 +41,11 @@ extern state_transition_fn ikev2_child_ike_inIoutR;
 extern state_transition_fn ikev2_child_inR;
 extern state_transition_fn ikev2_child_inIoutR;
 
-extern state_transition_fn ikev2parent_inI1outR1;
-extern state_transition_fn ikev2parent_inR1;
-extern state_transition_fn ikev2parent_inR1BoutI1B;
-extern state_transition_fn ikev2parent_inR1outI2;
-extern state_transition_fn ikev2parent_inI2outR2;
-extern state_transition_fn ikev2parent_inR2;
+extern state_transition_fn ikev2_parent_inI1outR1;
+extern state_transition_fn ikev2_parent_inR1BoutI1B;
+extern state_transition_fn ikev2_parent_inR1outI2;
+extern state_transition_fn ikev2_parent_inI2outR2;
+extern state_transition_fn ikev2_parent_inR2;
 extern crypto_transition_fn ikev2_child_out_cont;
 extern crypto_transition_fn ikev2_child_inR_tail;
 extern void ikev2_add_ipsec_child(int whack_sock, struct state *isakmp_sa,

--- a/programs/pluto/ikev2_parent.c
+++ b/programs/pluto/ikev2_parent.c
@@ -512,7 +512,7 @@ static stf_status ikev2_match_ke_group_and_proposal(struct msg_digest *md,
 }
 
 /*
- * Called by ikev2_parent_inI2outR2_tail() and ikev2parent_inR2()
+ * Called by ikev2_parent_inI2outR2_tail() and ikev2_parent_inR2()
  * Do the actual AUTH payload verification
  */
 static bool v2_check_auth(enum ikev2_auth_method atype,
@@ -689,7 +689,7 @@ static bool id_ipseckey_allowed(struct state *st, enum ikev2_auth_method atype)
  * Note: this is not called from demux.c, but from ipsecdoi_initiate().
  *
  */
-void ikev2parent_outI1(int whack_sock,
+void ikev2_parent_outI1(int whack_sock,
 		       struct connection *c,
 		       struct state *predecessor,
 		       lset_t policy,
@@ -1069,7 +1069,7 @@ static stf_status ikev2_parent_outI1_common(struct msg_digest *md,
 static crypto_req_cont_func ikev2_parent_inI1outR1_continue;	/* forward decl and type assertion */
 static crypto_transition_fn ikev2_parent_inI1outR1_continue_tail;	/* forward decl and type assertion */
 
-stf_status ikev2parent_inI1outR1(struct state *null_st, struct msg_digest *md)
+stf_status ikev2_parent_inI1outR1(struct state *null_st, struct msg_digest *md)
 {
 	passert(null_st == NULL);	/* initial responder -> no state */
 
@@ -1450,7 +1450,7 @@ static void ikev2_parent_inI1outR1_continue(struct state *st,
  * ikev2_parent_inI1outR1_tail: do what's left after all the crypto
  *
  * Called from:
- *	ikev2parent_inI1outR1: if KE and Nonce were already calculated
+ *	ikev2_parent_inI1outR1: if KE and Nonce were already calculated
  *	ikev2_parent_inI1outR1_continue: if they needed to be calculated
  */
 static stf_status ikev2_parent_inI1outR1_continue_tail(struct state *st,
@@ -1688,7 +1688,7 @@ static stf_status ikev2_parent_inI1outR1_continue_tail(struct state *st,
  *                     <--  HDR, N(COOKIE)
  * HDR, N(COOKIE), SAi1, KEi, Ni -->
  */
-stf_status ikev2parent_inR1BoutI1B(struct state *st, struct msg_digest *md)
+stf_status ikev2_parent_inR1BoutI1B(struct state *st, struct msg_digest *md)
 {
 	struct connection *c = st->st_connection;
 
@@ -1868,7 +1868,7 @@ stf_status ikev2parent_inR1BoutI1B(struct state *st, struct msg_digest *md)
 static crypto_req_cont_func ikev2_parent_inR1outI2_continue;	/* forward decl and type assertion */
 static crypto_transition_fn ikev2_parent_inR1outI2_tail;	/* forward decl and type assertion */
 
-stf_status ikev2parent_inR1outI2(struct state *st, struct msg_digest *md)
+stf_status ikev2_parent_inR1outI2(struct state *st, struct msg_digest *md)
 {
 	struct connection *c = st->st_connection;
 	struct payload_digest *ntfy;
@@ -1977,7 +1977,7 @@ stf_status ikev2parent_inR1outI2(struct state *st, struct msg_digest *md)
 							  &st->st_accepted_ike_proposal,
 							  c->ike_proposals);
 		if (ret != STF_OK) {
-			DBG(DBG_CONTROLMORE, DBG_log("ikev2_parse_parent_sa_body() failed in ikev2parent_inR1outI2()"));
+			DBG(DBG_CONTROLMORE, DBG_log("ikev2_parse_parent_sa_body() failed in ikev2_parent_inR1outI2()"));
 			return ret;
 		}
 		passert(st->st_accepted_ike_proposal != NULL);
@@ -3557,7 +3557,7 @@ static stf_status ikev2_start_pam_authorize(struct state *st)
 
 static crypto_req_cont_func ikev2_parent_inI2outR2_continue;	/* type asssertion */
 
-stf_status ikev2parent_inI2outR2(struct state *st, struct msg_digest *md UNUSED)
+stf_status ikev2_parent_inI2outR2(struct state *st, struct msg_digest *md UNUSED)
 {
 	/* for testing only */
 	if (DBGP(IMPAIR_SEND_NO_IKEV2_AUTH)) {
@@ -4557,7 +4557,7 @@ static stf_status ikev2_process_ts_and_rest(struct msg_digest *md)
  * https://tools.ietf.org/html/rfc7296#section-2.21.2
  */
 
-stf_status ikev2parent_inR2(struct state *st, struct msg_digest *md)
+stf_status ikev2_parent_inR2(struct state *st, struct msg_digest *md)
 {
 	unsigned char idhash_in[MAX_DIGEST_LEN];
 	struct payload_digest *ntfy;

--- a/programs/pluto/ipsec_doi.c
+++ b/programs/pluto/ipsec_doi.c
@@ -181,7 +181,7 @@ static initiator_function *pick_initiator(struct connection *c,
 	    (policy & c->policy & POLICY_IKEV2_ALLOW) &&
 	    !c->failed_ikev2) {
 		/* we may try V2, and we haven't failed */
-		return ikev2parent_outI1;
+		return ikev2_parent_outI1;
 	} else if (policy & c->policy & POLICY_IKEV1_ALLOW) {
 		/* we may try V1; Aggressive or Main Mode? */
 		return (policy & POLICY_AGGRESSIVE) ? aggr_outI1 : main_outI1;

--- a/testing/pluto/ikev2-22-retransmit/.gdbinit
+++ b/testing/pluto/ikev2-22-retransmit/.gdbinit
@@ -1,2 +1,2 @@
-b ikev2parent_inI2outR2
+b ikev2_parent_inI2outR2
 b ipsecdoi_replace


### PR DESCRIPTION
This was bugging me for a long time. Some transition functions were named ikev2_parent_* and some ikev2parent_*. I find the former nicer, so I changed all to that syntax.

Also:
In ikev2.h there was a declaration for a function extern state_transition_fn ikev2parent_inR1, but this 
function is not defined/implemented anywhere, so I deleted that line.