### PR TITLE
libipsecconf: refactor the yes/no/auto option

### DIFF
--- a/include/pluto_constants.h
+++ b/include/pluto_constants.h
@@ -859,19 +859,19 @@ enum routing_t {
 #define shunt_erouted(rs) (erouted(rs) && (rs) != RT_ROUTED_TUNNEL)
 
 enum certpolicy {
-	cert_neversend   = 1,
-	cert_sendifasked = 2,   /* the default */
-	cert_alwayssend  = 3,
+	CERT_NEVERSEND   = 1,
+	CERT_SENDIFASKED = 2,   /* the default */
+	CERT_ALWAYSSEND  = 3,
 };
 
 /* this is the default setting. */
-#define cert_defaultcertpolicy cert_alwayssend
+#define cert_defaultcertpolicy CERT_ALWAYSSEND
 
 enum ikev1_natt_policy {
-	natt_both = 0, /* the default */
-	natt_rfc = 1,
-	natt_drafts = 2, /* Workaround for Cisco NAT-T bug */
-	natt_none = 3 /* Workaround for forcing non-encaps */
+	NATT_BOTH = 0, /* the default */
+	NATT_RFC = 1,
+	NATT_DRAFTS = 2, /* Workaround for Cisco NAT-T bug */
+	NATT_NONE = 3 /* Workaround for forcing non-encaps */
 };
 
 enum four_options {
@@ -881,34 +881,28 @@ enum four_options {
 	fo_insist  = 3          /* propose, and only accept if peer agrees */
 };
 
-enum esn_options {
-	esn_no = 1, /* default */
-	esn_yes = 2,
-	esn_either = 3,
-};
-
-enum encaps_options {
-	encaps_auto = 1, /* default */
-	encaps_no = 2,
-	encaps_yes = 3,
-};
-
-enum nic_offload_options {
-	nic_offload_no = 1,
-	nic_offload_yes = 2,
-	nic_offload_auto = 3,
-};
-
 enum ynf_options {
 	ynf_no   = 0,
 	ynf_yes  = 1,
 	ynf_force = 2,
 };
 
+enum yna_options {
+	yna_auto = 1, /* default */
+	yna_no = 2,
+	yna_yes = 3,
+};
+
+enum esn_options {
+	ESN_NO = 1, /* default */
+	ESN_YES = 2,
+	ESN_EITHER = 3,
+};
+
 enum saref_tracking {
-	sat_yes = 0,            /* SAref tracking via _updown - the default */
-	sat_no = 1,             /* no SAref tracking - third party will handle this */
-	sat_conntrack = 2,      /* Saref tracking using connmark optimizations */
+	SAT_YES = 0,            /* SAref tracking via _updown - the default */
+	SAT_NO = 1,             /* no SAref tracking - third party will handle this */
+	SAT_CONNTRACK = 2,      /* Saref tracking using connmark optimizations */
 };
 
 /* Policies for establishing an SA

--- a/include/whack.h
+++ b/include/whack.h
@@ -167,7 +167,7 @@ struct whack_message {
 	unsigned long sa_replay_window;
 	deltatime_t r_timeout; /* in secs */
 	deltatime_t r_interval; /* in msec */
-	enum nic_offload_options nic_offload;
+	enum yna_options nic_offload;
 
 	/* For IKEv1 RFC 3706 - Dead Peer Detection */
 	deltatime_t dpd_delay;
@@ -179,7 +179,7 @@ struct whack_message {
 	enum keyword_remotepeertype remotepeertype;
 
 	/* Force the use of NAT-T on a connection */
-	enum encaps_options encaps;
+	enum yna_options encaps;
 
 	/* Option to allow per-conn setting of sending of NAT-T keepalives - default is enabled  */
 	bool nat_keepalive;

--- a/lib/libipsecconf/confread.c
+++ b/lib/libipsecconf/confread.c
@@ -130,8 +130,8 @@ void ipsecconf_default_values(struct starter_config *cfg)
 
 	cfg->conn_default.options[KBF_IKEPAD] = TRUE;
 
-	cfg->conn_default.options[KBF_IKEV1_NATT] = natt_both;
-	cfg->conn_default.options[KBF_ENCAPS] = encaps_auto;
+	cfg->conn_default.options[KBF_IKEV1_NATT] = NATT_BOTH;
+	cfg->conn_default.options[KBF_ENCAPS] = yna_auto;
 
 	/* Network Manager support */
 #ifdef HAVE_NM
@@ -153,7 +153,7 @@ void ipsecconf_default_values(struct starter_config *cfg)
 		POLICY_IKE_FRAG_ALLOW |      /* ike_frag=yes */
 		POLICY_ESN_NO;      	     /* esn=no */
 
-	cfg->conn_default.options[KBF_NIC_OFFLOAD] = nic_offload_auto;
+	cfg->conn_default.options[KBF_NIC_OFFLOAD] = yna_auto;
 	cfg->conn_default.options[KBF_IKELIFETIME] = IKE_SA_LIFETIME_DEFAULT;
 
 	cfg->conn_default.options[KBF_REPLAY_WINDOW] = IPSEC_SA_DEFAULT_REPLAY_WINDOW;
@@ -1290,16 +1290,16 @@ static bool load_conn(
 		conn->policy &= ~(POLICY_ESN_NO | POLICY_ESN_YES);
 
 		switch (conn->options[KBF_ESN]) {
-		case esn_yes:
+		case ESN_YES:
 			conn->policy |= POLICY_ESN_YES;
 			break;
 
-		case esn_no:
+		case ESN_NO:
 			/* this is the default for now */
 			conn->policy |= POLICY_ESN_NO;
 			break;
 
-		case esn_either:
+		case ESN_EITHER:
 			conn->policy |= POLICY_ESN_NO | POLICY_ESN_YES;
 			break;
 		}
@@ -1328,17 +1328,17 @@ static bool load_conn(
 		conn->policy &= ~(POLICY_SAREF_TRACK | POLICY_SAREF_TRACK_CONNTRACK);
 
 		switch (conn->options[KBF_SAREFTRACK]) {
-		case sat_yes:
+		case SAT_YES:
 			/* this is the default */
 			conn->policy |= POLICY_SAREF_TRACK;
 			break;
 
-		case sat_conntrack:
+		case SAT_CONNTRACK:
 			conn->policy |= POLICY_SAREF_TRACK |
 					POLICY_SAREF_TRACK_CONNTRACK;
 			break;
 
-		case sat_no:
+		case SAT_NO:
 			break;
 		}
 	}

--- a/lib/libipsecconf/keywords.c
+++ b/lib/libipsecconf/keywords.c
@@ -98,27 +98,31 @@ static const struct keyword_enum_value kw_ynf_values[] = {
 	{ "insist",    ynf_force },
 	{ "force",     ynf_force },
 };
+
 static const struct keyword_enum_values kw_ynf_list = VALUES_INITIALIZER(kw_ynf_values);
 
-static const struct keyword_enum_value kw_esn_values[] = {
-	{ "yes",     esn_yes  },
-	{ "no",    esn_no },
-	{ "either",   esn_either },
+/* Values for yes/no/auto, used by encapsulation and nic-offload */
+static const struct keyword_enum_value kw_yna_values[] = {
+	{ "yes",	yna_yes  },
+	{ "no",		yna_no },
+	{ "auto",	yna_auto },
 };
-static const struct keyword_enum_values kw_esn_list = VALUES_INITIALIZER(kw_esn_values);
+static const struct keyword_enum_values kw_yna_list = VALUES_INITIALIZER(kw_yna_values);
 
-static const struct keyword_enum_value kw_encaps_values[] = {
-	{ "yes",     encaps_yes  },
-	{ "no",    encaps_no },
-	{ "auto",   encaps_auto },
+static const struct keyword_enum_value kw_esn_values[] = {
+	{ "yes",	ESN_YES  },
+	{ "no",		ESN_NO },
+	{ "either",	ESN_EITHER },
 };
-static const struct keyword_enum_values kw_encaps_list = VALUES_INITIALIZER(kw_encaps_values);
+
+static const struct keyword_enum_values kw_esn_list = VALUES_INITIALIZER(kw_esn_values);
 
 static const struct keyword_enum_value kw_ddos_values[] = {
 	{ "auto",      DDOS_AUTO },
 	{ "busy",      DDOS_FORCE_BUSY },
 	{ "unlimited", DDOS_FORCE_UNLIMITED },
 };
+
 static const struct keyword_enum_values kw_ddos_list = VALUES_INITIALIZER(kw_ddos_values);
 
 #ifdef HAVE_SECCOMP
@@ -127,6 +131,7 @@ static const struct keyword_enum_value kw_seccomp_values[] = {
 	{ "disabled", SECCOMP_DISABLED },
 	{ "tolerant", SECCOMP_TOLERANT },
 };
+
 static const struct keyword_enum_values kw_seccomp_list = VALUES_INITIALIZER(kw_seccomp_values);
 #endif
 
@@ -136,6 +141,7 @@ static const struct keyword_enum_value kw_auth_lr_values[] = {
        { "rsasig",    AUTH_RSASIG },
        { "null",      AUTH_NULL },
  };
+
 static const struct keyword_enum_values kw_auth_lr_list = VALUES_INITIALIZER(kw_auth_lr_values);
 
 /*
@@ -243,9 +249,9 @@ static const struct keyword_enum_values kw_proto_stack = VALUES_INITIALIZER(kw_p
  * Values for sareftrack={yes, no, conntrack }
  */
 static const struct keyword_enum_value kw_sareftrack_values[] = {
-	{ "yes",          sat_yes },
-	{ "no",           sat_no },
-	{ "conntrack",    sat_conntrack },
+	{ "yes",          SAT_YES },
+	{ "no",           SAT_NO },
+	{ "conntrack",    SAT_CONNTRACK },
 };
 
 static const struct keyword_enum_values kw_sareftrack_list = VALUES_INITIALIZER(kw_sareftrack_values);
@@ -319,10 +325,10 @@ static const struct keyword_enum_values kw_phase2types_list = VALUES_INITIALIZER
  * Values for {left/right}sendcert={never,sendifasked,always,forcedtype}
  */
 static const struct keyword_enum_value kw_sendcert_values[] = {
-	{ "never",        cert_neversend },
-	{ "sendifasked",  cert_sendifasked },
-	{ "alwayssend",   cert_alwayssend },
-	{ "always",       cert_alwayssend },
+	{ "never",        CERT_NEVERSEND},
+	{ "sendifasked",  CERT_SENDIFASKED },
+	{ "alwayssend",   CERT_ALWAYSSEND },
+	{ "always",       CERT_ALWAYSSEND },
 };
 
 static const struct keyword_enum_values kw_sendcert_list = VALUES_INITIALIZER(kw_sendcert_values);
@@ -331,10 +337,10 @@ static const struct keyword_enum_values kw_sendcert_list = VALUES_INITIALIZER(kw
  * Values for nat-ikev1-method={drafts,rfc,both,none}
  */
 static const struct keyword_enum_value kw_ikev1natt_values[] = {
-	{ "both",       natt_both },
-	{ "rfc",        natt_rfc },
-	{ "drafts",     natt_drafts },
-	{ "none",       natt_none },
+	{ "both",       NATT_BOTH },
+	{ "rfc",        NATT_RFC },
+	{ "drafts",     NATT_DRAFTS },
+	{ "none",       NATT_NONE },
 };
 
 static const struct keyword_enum_values kw_ikev1natt_list = VALUES_INITIALIZER(kw_ikev1natt_values);
@@ -353,16 +359,6 @@ static const struct keyword_enum_value kw_ocsp_method_values[] = {
 	{ "post",     OCSP_METHOD_POST },
 };
 static const struct keyword_enum_values kw_ocsp_method_list = VALUES_INITIALIZER(kw_ocsp_method_values);
-
-#ifdef USE_NIC_OFFLOAD
-static const struct keyword_enum_value kw_nic_offload_values[] = {
-	{ "no",   nic_offload_no  },
-	{ "yes",  nic_offload_yes },
-	{ "auto",    nic_offload_auto },
-};
-
-static const struct keyword_enum_values kw_nic_offload_list = VALUES_INITIALIZER(kw_nic_offload_values);
-#endif
 
 /* MASTER KEYWORD LIST
  * Note: this table is terminated by an entry with keyname == NULL.
@@ -590,10 +586,10 @@ const struct keyword_def ipsec_conf_keywords[] = {
   { "modecfgwins2",  kv_conn,  kt_obsolete,  KBF_WARNIGNORE, NULL, NULL, },
 
 #ifdef USE_NIC_OFFLOAD
-  { "nic-offload",  kv_conn,  kt_enum,  KBF_NIC_OFFLOAD,  &kw_nic_offload_list, NULL, },
+  { "nic-offload",  kv_conn,  kt_enum,  KBF_NIC_OFFLOAD,  &kw_yna_list, NULL, },
 #endif
 
-  { "encapsulation",  kv_conn,  kt_enum,  KBF_ENCAPS,  &kw_encaps_list, NULL, },
+  { "encapsulation",  kv_conn,  kt_enum,  KBF_ENCAPS,  &kw_yna_list, NULL, },
   { "forceencaps",  kv_conn, kt_obsolete, KBF_WARNIGNORE, NULL, NULL, },
 
   { "cat",  kv_conn | kv_leftright,  kt_bool,  KNCF_CAT, NULL, NULL, },

--- a/lib/libipsecconf/starterwhack.c
+++ b/lib/libipsecconf/starterwhack.c
@@ -394,7 +394,7 @@ static void set_whack_end(char *lr,
 	if (l->options_set[KNCF_SENDCERT])
 		w->sendcert = l->options[KNCF_SENDCERT];
 	else
-		w->sendcert = cert_alwayssend;
+		w->sendcert = CERT_ALWAYSSEND;
 
 	if (l->options_set[KNCF_AUTH])
 		w->authby = l->options[KNCF_AUTH];
@@ -610,7 +610,7 @@ static int starter_whack_basic_add_conn(struct starter_config *cfg,
 	if (conn->options_set[KBF_ENCAPS])
                msg.encaps = conn->options[KBF_ENCAPS];
 	else
-               msg.encaps = encaps_auto;
+               msg.encaps = yna_auto;
 
 	if (conn->options_set[KBF_NAT_KEEPALIVE])
 		msg.nat_keepalive = conn->options[KBF_NAT_KEEPALIVE];
@@ -620,7 +620,7 @@ static int starter_whack_basic_add_conn(struct starter_config *cfg,
 	if (conn->options_set[KBF_IKEV1_NATT])
 		msg.ikev1_natt = conn->options[KBF_IKEV1_NATT];
 	else
-		msg.ikev1_natt = natt_both;
+		msg.ikev1_natt = NATT_BOTH;
 
 
 	/* Activate sending out own vendorid */

--- a/lib/libswan/constants.c
+++ b/lib/libswan/constants.c
@@ -742,16 +742,16 @@ enum_names ikev2_cert_type_names = {
  * certificate request payload policy
  */
 static const char *const certpolicy_type_name[] = {
-	"cert_neversend",
-	"cert_sendifasked",
-	"cert_alwayssend",
+	"CERT_NEVERSEND",
+	"CERT_SENDIFASKED",
+	"CERT_ALWAYSSEND",
 };
 
 enum_names certpolicy_type_names = {
-	cert_neversend,
-	cert_alwayssend,
+	CERT_NEVERSEND,
+	CERT_ALWAYSSEND,
 	ARRAY_REF(certpolicy_type_name),
-	NULL, /* prefix */
+	"CERT_", /* prefix */
 	NULL
 };
 

--- a/programs/pluto/connections.c
+++ b/programs/pluto/connections.c
@@ -514,7 +514,7 @@ static err_t default_end(struct end *e, ip_address *dflt_nexthop)
 		ugh = addrtosubnet(&e->host_addr, &e->client);
 
 	if (e->sendcert == 0)
-		e->sendcert = cert_sendifasked;
+		e->sendcert = CERT_SENDIFASKED;
 
 	return ugh;
 }
@@ -687,13 +687,13 @@ size_t format_end(char *buf,
 			const char *send_cert = "+UNKNOWN";
 
 			switch (this->sendcert) {
-			case cert_neversend:
+			case CERT_NEVERSEND:
 				send_cert = "+S-C";
 				break;
-			case cert_sendifasked:
+			case CERT_SENDIFASKED:
 				send_cert = "+S?C";
 				break;
-			case cert_alwayssend:
+			case CERT_ALWAYSSEND:
 				send_cert = "+S=C";
 				break;
 			}
@@ -4258,8 +4258,8 @@ void show_one_connection(const struct connection *c)
 		  bool_str(c->vti_shared)
 #ifdef USE_NIC_OFFLOAD
 		  ,
-		  (c->nic_offload == nic_offload_auto) ? "auto" :
-			bool_str(c->nic_offload == nic_offload_yes)
+		  (c->nic_offload == yna_auto) ? "auto" :
+			bool_str(c->nic_offload == yna_yes)
 #endif
 	);
 
@@ -4284,12 +4284,12 @@ void show_one_connection(const struct connection *c)
 		enum_name(&dpd_action_names, c->dpd_action),
 		(long) deltasecs(c->dpd_delay),
 		(long) deltasecs(c->dpd_timeout),
-		(c->encaps == encaps_auto) ? "auto" :
-		    bool_str(c->encaps == encaps_yes),
+		(c->encaps == yna_auto) ? "auto" :
+		    bool_str(c->encaps == yna_yes),
 		bool_str(c->nat_keepalive),
-		(c->ikev1_natt == natt_both) ? "both" :
-		 (c->ikev1_natt == natt_rfc) ? "rfc" :
-		 (c->ikev1_natt == natt_drafts) ? "drafts" : "none"
+		(c->ikev1_natt == NATT_BOTH) ? "both" :
+		 (c->ikev1_natt == NATT_RFC) ? "rfc" :
+		 (c->ikev1_natt == NATT_DRAFTS) ? "drafts" : "none"
 		);
 
 	if (!lmod_empty(c->extra_debugging)) {

--- a/programs/pluto/connections.h
+++ b/programs/pluto/connections.h
@@ -242,7 +242,7 @@ struct connection {
 	deltatime_t r_timeout; /* max time (in secs) for one packet exchange attempt */
 	reqid_t sa_reqid;
 	int encapsulation;
-	enum nic_offload_options nic_offload;
+	enum yna_options nic_offload;
 
 	/* RFC 3706 DPD */
 	deltatime_t dpd_delay;		/* time between checks */
@@ -256,7 +256,7 @@ struct connection {
 	bool mobike;			/* Allow MOBIKE */
 	bool send_vendorid;		/* Send our vendorid? Security vs Debugging help */
 	enum ikev1_natt_policy ikev1_natt; /* whether or not to send IKEv1 draft/rfc NATT VIDs */
-	enum encaps_options encaps; /* encapsulation mode of auto/yes/no - formerly forceencaps=yes/no */
+	enum yna_options encaps; /* encapsulation mode of auto/yes/no - formerly forceencaps=yes/no */
 
 	/* Network Manager support */
 #ifdef HAVE_NM

--- a/programs/pluto/ikev1.c
+++ b/programs/pluto/ikev1.c
@@ -2423,7 +2423,7 @@ void complete_v1_state_transition(struct msg_digest **mdp, stf_status result)
 		/* in aggressive mode, there will be no reply packet in transition
 		 * from STATE_AGGR_R1 to STATE_AGGR_R2
 		 */
-		if (nat_traversal_enabled && st->st_connection->ikev1_natt != natt_none) {
+		if (nat_traversal_enabled && st->st_connection->ikev1_natt != NATT_NONE) {
 			/* adjust our destination port if necessary */
 			nat_traversal_change_port_lookup(md, st);
 		}
@@ -3111,7 +3111,7 @@ void doi_log_cert_thinking(u_int16_t auth,
 		} else if (certtype == CERT_NONE) {
 			DBG(DBG_CONTROL,
 				DBG_log("I did not send a certificate because I do not have one."));
-		} else if (policy == cert_sendifasked) {
+		} else if (policy == CERT_SENDIFASKED) {
 			DBG(DBG_CONTROL,
 				DBG_log("I did not send my certificate because I was not asked to."));
 		}

--- a/programs/pluto/ikev1_aggr.c
+++ b/programs/pluto/ikev1_aggr.c
@@ -345,9 +345,10 @@ static stf_status aggr_inI1_outR1_continue2_tail(struct msg_digest *md,
 	 */
 	send_cert = st->st_oakley.auth == OAKLEY_RSA_SIG &&
 		    mycert.ty != CERT_NONE && mycert.u.nss_cert != NULL &&
-		    ((c->spd.this.sendcert == cert_sendifasked &&
+		    ((c->spd.this.sendcert == CERT_SENDIFASKED &&
 		      st->hidden_variables.st_got_certrequest) ||
-		     c->spd.this.sendcert == cert_alwayssend);
+		     c->spd.this.sendcert == CERT_ALWAYSSEND
+		     );
 
 	send_authcerts = (send_cert && c->send_ca != CA_SEND_NONE);
 
@@ -702,9 +703,9 @@ static stf_status aggr_inR1_outI2_tail(struct msg_digest *md)
 	send_cert = st->st_oakley.auth == OAKLEY_RSA_SIG &&
 		    mycert.ty != CERT_NONE && mycert.u.nss_cert != NULL &&
 		    ((c->spd.this.sendcert ==
-			cert_sendifasked &&
+			CERT_SENDIFASKED &&
 		      st->hidden_variables.st_got_certrequest) ||
-		     c->spd.this.sendcert == cert_alwayssend);
+		     c->spd.this.sendcert == CERT_ALWAYSSEND);
 
 	send_authcerts = (send_cert && c->send_ca != CA_SEND_NONE);
 
@@ -1145,8 +1146,8 @@ static stf_status aggr_outI1_tail(struct state *st,
 	cert_t mycert = c->spd.this.cert;
 	bool send_cr = mycert.ty != CERT_NONE && mycert.u.nss_cert != NULL &&
 			!has_preloaded_public_key(st) &&
-		    (c->spd.this.sendcert == cert_sendifasked ||
-		     c->spd.this.sendcert == cert_alwayssend);
+		    (c->spd.this.sendcert == CERT_SENDIFASKED ||
+		     c->spd.this.sendcert == CERT_ALWAYSSEND);
 
 	DBG(DBG_CONTROL,
 		DBG_log("aggr_outI1_tail for #%lu",
@@ -1233,7 +1234,7 @@ static stf_status aggr_outI1_tail(struct state *st,
 	if (c->spd.this.xauth_client || c->spd.this.xauth_server)
 		numvidtosend++;
 
-	if (nat_traversal_enabled && c->ikev1_natt != natt_none)
+	if (nat_traversal_enabled && c->ikev1_natt != NATT_NONE)
 		numvidtosend++;
 
 	if (c->cisco_unity)
@@ -1255,7 +1256,7 @@ static stf_status aggr_outI1_tail(struct state *st,
 			return STF_INTERNAL_ERROR;
 	}
 
-	if (nat_traversal_enabled && c->ikev1_natt != natt_none) {
+	if (nat_traversal_enabled && c->ikev1_natt != NATT_NONE) {
 		int np = --numvidtosend > 0 ? ISAKMP_NEXT_VID : ISAKMP_NEXT_NONE;
 
 		if (!nat_traversal_insert_vid(np, &rbody, st)) {

--- a/programs/pluto/ikev1_main.c
+++ b/programs/pluto/ikev1_main.c
@@ -115,7 +115,7 @@ void main_outI1(int whack_sock,
 	if (c->policy & POLICY_IKE_FRAG_ALLOW)
 		numvidtosend++;
 
-	if (nat_traversal_enabled && c->ikev1_natt != natt_none)
+	if (nat_traversal_enabled && c->ikev1_natt != NATT_NONE)
 		numvidtosend++;
 
 	if (c->cisco_unity) {
@@ -261,7 +261,7 @@ void main_outI1(int whack_sock,
 		}
 	}
 
-	if (nat_traversal_enabled && c->ikev1_natt != natt_none) {
+	if (nat_traversal_enabled && c->ikev1_natt != NATT_NONE) {
 		int np = --numvidtosend > 0 ?
 			ISAKMP_NEXT_VID : ISAKMP_NEXT_NONE;
 
@@ -1343,9 +1343,9 @@ static stf_status main_inR2_outI3_continue_tail(struct msg_digest *md,
 	 */
 	send_cert = st->st_oakley.auth == OAKLEY_RSA_SIG &&
 		mycert.ty != CERT_NONE && mycert.u.nss_cert != NULL &&
-		((st->st_connection->spd.this.sendcert == cert_sendifasked &&
+		((st->st_connection->spd.this.sendcert == CERT_SENDIFASKED &&
 		  st->hidden_variables.st_got_certrequest) ||
-		 st->st_connection->spd.this.sendcert == cert_alwayssend);
+		 st->st_connection->spd.this.sendcert == CERT_ALWAYSSEND);
 
 	send_authcerts = (send_cert &&
 			  st->st_connection->send_ca != CA_SEND_NONE);
@@ -1714,9 +1714,9 @@ stf_status main_inI3_outR3(struct state *st, struct msg_digest *md)
 
 	send_cert = st->st_oakley.auth == OAKLEY_RSA_SIG &&
 		mycert.ty != CERT_NONE && mycert.u.nss_cert != NULL &&
-		((st->st_connection->spd.this.sendcert == cert_sendifasked &&
+		((st->st_connection->spd.this.sendcert == CERT_SENDIFASKED &&
 		  st->hidden_variables.st_got_certrequest) ||
-		 st->st_connection->spd.this.sendcert == cert_alwayssend);
+		 st->st_connection->spd.this.sendcert == CERT_ALWAYSSEND);
 
 	send_authcerts = (send_cert &&
 			  st->st_connection->send_ca != CA_SEND_NONE);
@@ -2623,7 +2623,7 @@ bool accept_delete(struct msg_digest *md,
 				/* note: this code is cloned for handling self_delete */
 				loglog(RC_LOG_SERIOUS, "received Delete SA payload: deleting ISAKMP State #%lu",
 					dst->st_serialno);
-				if (nat_traversal_enabled && dst->st_connection->ikev1_natt != natt_none)
+				if (nat_traversal_enabled && dst->st_connection->ikev1_natt != NATT_NONE)
 					nat_traversal_change_port_lookup(md, dst);
 				delete_state(dst);
 			}
@@ -2661,7 +2661,7 @@ bool accept_delete(struct msg_digest *md,
 				struct connection *rc = dst->st_connection;
 				struct connection *oldc = push_cur_connection(rc);
 
-				if (nat_traversal_enabled && dst->st_connection->ikev1_natt != natt_none)
+				if (nat_traversal_enabled && dst->st_connection->ikev1_natt != NATT_NONE)
 					nat_traversal_change_port_lookup(md, dst);
 
 				if (rc->newest_ipsec_sa == dst->st_serialno &&
@@ -2734,7 +2734,7 @@ void accept_self_delete(struct msg_digest *md)
 	/* note: this code is cloned from handling ISAKMP non-self_delete */
 	loglog(RC_LOG_SERIOUS, "received Delete SA payload: self-deleting ISAKMP State #%lu",
 		st->st_serialno);
-	if (nat_traversal_enabled && st->st_connection->ikev1_natt != natt_none)
+	if (nat_traversal_enabled && st->st_connection->ikev1_natt != NATT_NONE)
 		nat_traversal_change_port_lookup(md, st);
 	delete_state(st);
 	md->st = st = NULL;

--- a/programs/pluto/ipsec_doi.c
+++ b/programs/pluto/ipsec_doi.c
@@ -564,8 +564,8 @@ void fmt_ipsec_sa_established(struct state *st, char *sadetails, size_t sad_len)
 				    c->spd.that.host_port));
 
 		DBG(DBG_NATT, DBG_log("NAT-T: encaps is '%s'",
-			    c->encaps == encaps_auto ? "auto" :
-				bool_str(c->encaps == encaps_yes)));
+			    c->encaps == yna_auto ? "auto" :
+				bool_str(c->encaps == yna_yes)));
 
 		snprintf(b, sad_len - (b - sadetails),
 			 "%sESP%s%s%s=>0x%08lx <0x%08lx xfrm=%s_%d-%s",

--- a/programs/pluto/kernel.c
+++ b/programs/pluto/kernel.c
@@ -1759,12 +1759,12 @@ static bool del_spi(ipsec_spi_t spi, int proto,
 static void setup_esp_nic_offload(struct kernel_sa *sa, struct connection *c,
 		bool *nic_offload_fallback)
 {
-	if (c->nic_offload == nic_offload_no ||
+	if (c->nic_offload == yna_no ||
 	    c->interface == NULL || c->interface->ip_dev == NULL ||
 	    c->interface->ip_dev->id_rname == NULL)
 		return;
 
-	if (c->nic_offload == nic_offload_auto) {
+	if (c->nic_offload == yna_auto) {
 		if (!c->interface->ip_dev->id_nic_offload)
 			return;
 

--- a/programs/pluto/nat_traversal.c
+++ b/programs/pluto/nat_traversal.c
@@ -198,7 +198,7 @@ bool ikev2_out_nat_v2n(u_int8_t np, pb_stream *outs, struct msg_digest *md)
 	u_int16_t lport = st->st_localport;
 
 	/* if encapsulation=yes, force NAT-T detection by using wrong port for hash calc */
-	if (st->st_connection->encaps == encaps_yes) {
+	if (st->st_connection->encaps == yna_yes) {
 		DBG(DBG_NATT, DBG_log("NAT-T: encapsulation=yes, so mangling hash to force NAT-T detection"));
 		lport = 0;
 	}
@@ -265,18 +265,18 @@ bool nat_traversal_insert_vid(u_int8_t np, pb_stream *outs, const struct state *
 	 * when they see NATT payloads.
 	 */
 	switch (st->st_connection->ikev1_natt) {
-	case natt_rfc:
+	case NATT_RFC:
 		DBG(DBG_NATT, DBG_log("skipping VID_NATT drafts"));
 		if (!out_vid(np, outs, VID_NATT_RFC))
 			return FALSE;
 		break;
-	case natt_both:
+	case NATT_BOTH:
 		DBG(DBG_NATT, DBG_log("sending draft and RFC NATT VIDs"));
 		if (!out_vid(ISAKMP_NEXT_VID, outs, VID_NATT_RFC))
 			return FALSE;
 		/* FALL THROUGH */
-	case natt_drafts:
-		if (st->st_connection->ikev1_natt == natt_drafts) {
+	case NATT_DRAFTS:
+		if (st->st_connection->ikev1_natt == NATT_DRAFTS) {
 			DBG(DBG_NATT, DBG_log("skipping VID_NATT_RFC"));
 		}
 		if (!out_vid(ISAKMP_NEXT_VID, outs, VID_NATT_IETF_03))
@@ -286,7 +286,7 @@ bool nat_traversal_insert_vid(u_int8_t np, pb_stream *outs, const struct state *
 		if (!out_vid(np, outs, VID_NATT_IETF_02))
 			return FALSE;
 		break;
-	case natt_none:
+	case NATT_NONE:
 		/* This should never be reached, but makes compiler happy */
 		DBG(DBG_NATT, DBG_log("not sending any NATT VID's"));
 		break;
@@ -350,7 +350,7 @@ static void natd_lookup_common(struct state *st,
 
 	/* update NAT-T settings for local policy */
 	switch (st->st_connection->encaps) {
-	case encaps_auto:
+	case yna_auto:
 		DBG(DBG_NATT, DBG_log("NAT_TRAVERSAL encaps using auto-detect"));
 		if (!found_me) {
 			DBG(DBG_NATT, DBG_log("NAT_TRAVERSAL this end is behind NAT"));
@@ -373,12 +373,12 @@ static void natd_lookup_common(struct state *st,
 		}
 		break;
 
-	case encaps_no:
+	case yna_no:
 		st->hidden_variables.st_nat_traversal |= LEMPTY;
 		DBG(DBG_NATT, DBG_log("NAT_TRAVERSAL local policy prohibits encapsulation"));
 		break;
 
-	case encaps_yes:
+	case yna_yes:
 		DBG(DBG_NATT, DBG_log("NAT_TRAVERSAL local policy enforces encapsulation"));
 
 		DBG(DBG_NATT, DBG_log("NAT_TRAVERSAL forceencaps enabled"));
@@ -502,7 +502,7 @@ bool ikev1_nat_traversal_add_natd(u_int8_t np, pb_stream *outs,
 		secondport = p;
 	}
 
-	if (st->st_connection->encaps == encaps_yes) {
+	if (st->st_connection->encaps == yna_yes) {
 		DBG(DBG_NATT,
 			DBG_log("NAT-T: encapsulation=yes, so mangling hash to force NAT-T detection"));
 		firstport = secondport = 0;

--- a/programs/pluto/x509.c
+++ b/programs/pluto/x509.c
@@ -1309,9 +1309,9 @@ bool ikev2_send_cert_decision(struct state *st)
 		return FALSE;
 	}
 
-	if ((c->spd.this.sendcert != cert_sendifasked ||
+	if ((c->spd.this.sendcert != CERT_SENDIFASKED ||
 	      !st->hidden_variables.st_got_certrequest) &&
-			c->spd.this.sendcert != cert_alwayssend)
+			c->spd.this.sendcert != CERT_ALWAYSSEND)
 	{
 		DBG(DBG_X509,
 			DBG_log("IKEv2 CERT: no cert requested or told not to send"));

--- a/programs/whack/whack.c
+++ b/programs/whack/whack.c
@@ -896,7 +896,7 @@ int main(int argc, char **argv)
 	msg.modecfg_dns = NULL;
 	msg.modecfg_banner = NULL;
 
-	msg.nic_offload = nic_offload_auto;
+	msg.nic_offload = yna_auto;
 	msg.sa_ike_life_seconds = deltatime(IKE_SA_LIFETIME_DEFAULT);
 	msg.sa_ipsec_life_seconds = deltatime(IPSEC_SA_LIFETIME_DEFAULT);
 	msg.sa_rekey_margin = deltatime(SA_REPLACEMENT_MARGIN_DEFAULT);
@@ -1407,12 +1407,12 @@ int main(int argc, char **argv)
 
 		case END_SENDCERT:
 			if (streq(optarg, "yes") || streq(optarg, "always")) {
-				msg.right.sendcert = cert_alwayssend;
+				msg.right.sendcert = CERT_ALWAYSSEND;
 			} else if (streq(optarg,
 					 "no") || streq(optarg, "never")) {
-				msg.right.sendcert = cert_neversend;
+				msg.right.sendcert = CERT_NEVERSEND;
 			} else if (streq(optarg, "ifasked")) {
-				msg.right.sendcert = cert_sendifasked;
+				msg.right.sendcert = CERT_SENDIFASKED;
 			} else {
 				diagq("whack sendcert value is not legal",
 				      optarg);
@@ -1684,27 +1684,27 @@ int main(int argc, char **argv)
 
 		/* backwards compatibility */
 		case CD_FORCEENCAPS:
-			msg.encaps = encaps_yes;
+			msg.encaps = yna_yes;
 			continue;
 
 		case CD_ENCAPS:
 			if (streq(optarg, "auto"))
-				msg.encaps = encaps_auto;
+				msg.encaps = yna_auto;
 			else if (streq(optarg, "yes"))
-				msg.encaps = encaps_yes;
+				msg.encaps = yna_yes;
 			else if (streq(optarg, "no"))
-				msg.encaps = encaps_no;
+				msg.encaps = yna_no;
 			else
 				diag("--encaps options are 'auto', 'yes' or 'no'");
 			continue;
 
 		case CD_NIC_OFFLOAD:  /* --nic-offload */
 			if (streq(optarg, "no"))
-				msg.nic_offload = nic_offload_no;
+				msg.nic_offload = yna_no;
 			else if (streq(optarg, "yes"))
-				msg.nic_offload = nic_offload_yes;
+				msg.nic_offload = yna_yes;
 			else if (streq(optarg, "auto"))
-				msg.nic_offload = nic_offload_auto;
+				msg.nic_offload = yna_auto;
 			else
 				diag("--nic-offload options are 'no', 'yes' or 'auto'");
 			continue;
@@ -1715,11 +1715,11 @@ int main(int argc, char **argv)
 
 		case CD_IKEV1_NATT:	/* --ikev1_natt */
 			if (streq(optarg, "both"))
-				msg.ikev1_natt = natt_both;
+				msg.ikev1_natt = NATT_BOTH;
 			else if (streq(optarg, "rfc"))
-				msg.ikev1_natt = natt_rfc;
+				msg.ikev1_natt = NATT_RFC;
 			else if (streq(optarg, "drafts"))
-				msg.ikev1_natt = natt_drafts;
+				msg.ikev1_natt = NATT_DRAFTS;
 			else
 				diag("--ikev1-natt options are 'both', 'rfc' or 'drafts'");
 			continue;

--- a/testing/enumcheck/OUTPUT.enumcheck.txt
+++ b/testing/enumcheck/OUTPUT.enumcheck.txt
@@ -33,22 +33,22 @@ pluto enum_names:
          lswlog_enum_short 4: OK
 
   certpolicy_type_names:
-    1 -> cert_neversend
+    1 -> CERT_NEVERSEND
          lswlog_enum 1: OK
-         search cert_neversend: OK
-         match cert_neversend: OK
+         search CERT_NEVERSEND: OK
+         match CERT_NEVERSEND: OK
          short_name 1:  OK
          lswlog_enum_short 1: OK
-    2 -> cert_sendifasked
+    2 -> CERT_SENDIFASKED
          lswlog_enum 2: OK
-         search cert_sendifasked: OK
-         match cert_sendifasked: OK
+         search CERT_SENDIFASKED: OK
+         match CERT_SENDIFASKED: OK
          short_name 2:  OK
          lswlog_enum_short 2: OK
-    3 -> cert_alwayssend
+    3 -> CERT_ALWAYSSEND
          lswlog_enum 3: OK
-         search cert_alwayssend: OK
-         match cert_alwayssend: OK
+         search CERT_ALWAYSSEND: OK
+         match CERT_ALWAYSSEND: OK
          short_name 3:  OK
          lswlog_enum_short 3: OK
 


### PR DESCRIPTION
encapsulation and nic-offload can both be configured with
yes/no/auto option, and there was a separate enum for
both. This is made into one universal enum yna_values
(yna_list/yna_options), where yna stands for yes/no/auto.
It will also be useful for other options that will offer
yes/no/auto values.