### PR TITLE
ikev2: rename PPK_ID type names enum

### DIFF
--- a/include/names_constant.h
+++ b/include/names_constant.h
@@ -128,7 +128,7 @@ extern const struct af_info
 extern const struct af_info *aftoinfo(int af);
 
 extern enum_names pkk_names;
-extern enum_names ikev2_ppk_id_names;
+extern enum_names ikev2_ppk_id_type_names;
 
 extern enum_names spi_names;
 

--- a/lib/libswan/constants.c
+++ b/lib/libswan/constants.c
@@ -2079,7 +2079,7 @@ enum_names pkk_names = {
 /*
  * IKEv2 PPK ID types - draft-ietf-ipsecme-qr-ikev2-01
  */
-static const char *const ikev2_ppk_id_name[] = {
+static const char *const ikev2_ppk_id_type_name[] = {
 	/* 0 - Reserved */
 	"PPK_ID_OPAQUE",
 	"PPK_ID_FIXED",
@@ -2087,10 +2087,10 @@ static const char *const ikev2_ppk_id_name[] = {
 	/* 128 - 255 Private Use */
 };
 
-enum_names ikev2_ppk_id_names = {
+enum_names ikev2_ppk_id_type_names = {
 	PPK_ID_OPAQUE,
 	PPK_ID_FIXED,
-	ARRAY_REF(ikev2_ppk_id_name),
+	ARRAY_REF(ikev2_ppk_id_type_name),
 	"PPK_ID_", /* prefix */
 	NULL
 };
@@ -2574,7 +2574,7 @@ static const enum_names *en_checklist[] = {
 	&ikev2_trans_type_names,
 	&ikev2_trans_attr_descs,
 	&pkk_names,
-	&ikev2_ppk_id_names,
+	&ikev2_ppk_id_types_names,
 };
 
 void check_enum_names(enum_names *checklist[], size_t tl)

--- a/programs/pluto/ikev2_ppk.c
+++ b/programs/pluto/ikev2_ppk.c
@@ -86,7 +86,7 @@ bool extract_ppk_id(pb_stream *pbs, struct ppk_id_payload *payl)
 	}
 
 	DBG(DBG_CONTROL, DBG_log("received PPK_ID type: %s",
-		enum_name(&ikev2_ppk_id_names, dst[0])));
+		enum_name(&ikev2_ppk_id_type_names, dst[0])));
 
 	idtype = (int)dst[0];
 	switch (idtype) {
@@ -97,7 +97,7 @@ bool extract_ppk_id(pb_stream *pbs, struct ppk_id_payload *payl)
 	case PPK_ID_OPAQUE:
 	default:
 		loglog(RC_LOG_SERIOUS, "PPK_ID type %d (%s) not supported",
-			idtype, enum_name(&ikev2_ppk_id_names, idtype));
+			idtype, enum_name(&ikev2_ppk_id_type_names, idtype));
 		return FALSE;
 	}
 

--- a/programs/pluto/packet.c
+++ b/programs/pluto/packet.c
@@ -945,7 +945,7 @@ struct_desc ikev2_id_r_desc = {
  * Reserved for private use  128-255
  */
 static field_desc ikev2_ppk_id_fields[] = {
-	{ ft_enum, 8 / BITS_PER_BYTE, "PPK ID type", &ikev2_ppk_id_names },
+	{ ft_enum, 8 / BITS_PER_BYTE, "PPK ID type", &ikev2_ppk_id_type_names },
 	{ ft_end,  0, NULL, NULL }
 };
 


### PR DESCRIPTION
rename ikev2_ppk_id_names into ikev2_ppk_id_type_names.
Technically, these names are the names of type of PPK_ID.