### PR TITLE
Fix ocsp-method=post

### DIFF
--- a/programs/pluto/fetch.h
+++ b/programs/pluto/fetch.h
@@ -25,3 +25,4 @@ extern long curl_timeout;
 extern bool crl_strict;
 extern bool ocsp_strict;
 extern bool ocsp_enable;
+extern bool ocsp_post;

--- a/programs/pluto/nss_cert_verify.h
+++ b/programs/pluto/nss_cert_verify.h
@@ -38,8 +38,10 @@ extern bool cert_VerifySubjectAltName(const CERTCertificate *cert, const char *n
 /* rev_opts index */
 #define RO_OCSP 0
 #define RO_OCSP_S 1
-#define RO_CRL_S 2
-#define RO_SZ 3
+#define RO_OCSP_P 2
+#define RO_CRL_S 3
+#define RO_SZ 4
+
 
 #define VERIFY_RET_OK       0x0001
 #define VERIFY_RET_REVOKED  0x0002

--- a/programs/pluto/nss_ocsp.c
+++ b/programs/pluto/nss_ocsp.c
@@ -105,8 +105,10 @@ bool init_nss_ocsp(const char *responder_url, const char *trust_cert_name,
 		return FALSE;
 	}
 
-	if (ocsp_post)
+	if (ocsp_post) {
 		rv = CERT_ForcePostMethodForOCSP(TRUE);
+		DBG(DBG_X509, DBG_log("OCSP will use POST method"));		
+	}
 	else
 		rv = CERT_ForcePostMethodForOCSP(FALSE);
 

--- a/programs/pluto/plutomain.c
+++ b/programs/pluto/plutomain.c
@@ -1010,6 +1010,7 @@ int main(int argc, char **argv)
 		case 'B':	/* --ocsp-method get|post */
 			if (streq(optarg, "post")) {
 				ocsp_method = OCSP_METHOD_POST;
+				ocsp_post = TRUE;
 			} else {
 				if (streq(optarg, "get")) {
 					ocsp_method = OCSP_METHOD_GET;
@@ -1191,6 +1192,7 @@ int main(int argc, char **argv)
 			ocsp_strict = cfg->setup.options[KBF_OCSP_STRICT];
 			ocsp_timeout = cfg->setup.options[KBF_OCSP_TIMEOUT];
 			ocsp_method = cfg->setup.options[KBF_OCSP_METHOD];
+			ocsp_post = (ocsp_method == OCSP_METHOD_POST);
 			ocsp_cache_size = cfg->setup.options[KBF_OCSP_CACHE_SIZE];
 			ocsp_cache_min_age = cfg->setup.options[KBF_OCSP_CACHE_MIN];
 			ocsp_cache_max_age = cfg->setup.options[KBF_OCSP_CACHE_MAX];

--- a/programs/pluto/x509.c
+++ b/programs/pluto/x509.c
@@ -90,6 +90,7 @@
 bool crl_strict = FALSE;
 bool ocsp_strict = FALSE;
 bool ocsp_enable = FALSE;
+bool ocsp_post = FALSE;
 char *curl_iface = NULL;
 long curl_timeout = -1;
 
@@ -687,6 +688,7 @@ static lsw_cert_ret pluto_process_certs(struct state *st,
 
 	rev_opts[RO_OCSP] = ocsp_enable;
 	rev_opts[RO_OCSP_S] = ocsp_strict;
+	rev_opts[RO_OCSP_P] = ocsp_post;
 	rev_opts[RO_CRL_S] = crl_strict;
 
 	CERTCertificate *end_cert = NULL;

--- a/testing/cert_verify/usage_test
+++ b/testing/cert_verify/usage_test
@@ -90,6 +90,7 @@ parser.add_argument('--retry', '-x', action='store_true', default='', help='use 
 parser.add_argument('--ocsp', '-O', action='store_true', default='', help='ocsp checking')
 parser.add_argument('--crl', '-L', action='store_true', default='', help='ocsp checking')
 parser.add_argument('--strict', '-z', action='store_true', default='', help='strict checks')
+parser.add_argument('--forcepost', '-P', action='store_true', default='', help='force POST method for ocsp')
 args = parser.parse_args()
 
 ADD_CERT_FMT = "%s -A -d sql:%s -n '%s' -t '%s' -i %s"
@@ -234,6 +235,8 @@ class usageTest:
 			cmd = cmd + " -c"
 		if args.strict:
 			cmd = cmd + " -S"
+		if args.forcepost:
+			cmd = cmd + " -P"
 		if args.retry:
 			cmd = cmd + " -r"
 		if args.use_sub:

--- a/testing/cert_verify/verify.c
+++ b/testing/cert_verify/verify.c
@@ -200,7 +200,7 @@ static void set_rev_per_meth(CERTRevocationFlags *rev, PRUint64 *lflags,
 	rev->chainTests.cert_rev_flags_per_method = cflags;
 }
 
-static unsigned int rev_val_flags(PRBool strict)
+static unsigned int rev_val_flags(PRBool strict, PRBool post)
 {
 	unsigned int flags = 0;
 	flags |= CERT_REV_M_TEST_USING_THIS_METHOD;
@@ -208,12 +208,16 @@ static unsigned int rev_val_flags(PRBool strict)
 		flags |= CERT_REV_M_REQUIRE_INFO_ON_MISSING_SOURCE;
 		flags |= CERT_REV_M_FAIL_ON_MISSING_FRESH_INFO;
 	}
+	if (post) {
+		flags |= CERT_REV_M_FORCE_POST_METHOD_FOR_OCSP;
+	}
 	return flags;
 }
 
 static void set_rev_params(CERTRevocationFlags *rev, PRBool crl,
 						     PRBool ocsp,
-						     PRBool strict)
+						     PRBool strict,
+						     PRBool post)
 {
 	CERTRevocationTests *rt = &rev->leafTests;
 	PRUint64 *rf = rt->cert_rev_flags_per_method;
@@ -222,11 +226,11 @@ static void set_rev_params(CERTRevocationFlags *rev, PRBool crl,
 	rt->number_of_preferred_methods = 0;
 
 	if (crl) {
-		rf[cert_revocation_method_crl] = rev_val_flags(strict);
+		rf[cert_revocation_method_crl] = rev_val_flags(strict, post);
 		rt->number_of_defined_methods++;
 	}
 	if (ocsp) {
-		rf[cert_revocation_method_ocsp] = rev_val_flags(strict);
+		rf[cert_revocation_method_ocsp] = rev_val_flags(strict, post);
 		rt->number_of_defined_methods++;
 	}
 }
@@ -241,6 +245,7 @@ int main(int argc, char *argv[])
 	PRBool crlcheck = PR_FALSE;
 	PRBool ocspcheck = PR_FALSE;
 	PRBool strict = PR_FALSE;
+	PRBool post = PR_FALSE;
 	CERTCertDBHandle *handle = NULL;
 	CERTCertificate **certout = NULL;
 	CERTVerifyLog vfy_log;
@@ -255,7 +260,7 @@ int main(int argc, char *argv[])
 	certs[1] = &c2;
 
 	int numcerts = 0;
-	while ((opt = getopt(argc, argv, "u:d:e:pn:s:coSr")) != -1) {
+	while ((opt = getopt(argc, argv, "u:d:e:pn:s:coSPr")) != -1) {
 		switch (opt) {
 			/* usage type */
 		case 'u':
@@ -281,6 +286,9 @@ int main(int argc, char *argv[])
 			break;
 		case 'p':
 			use_pkix = 1;
+			break;
+		case 'P':
+			post = PR_TRUE;
 			break;
 		case 'n':
 			rightca_nick = optarg;
@@ -320,6 +328,8 @@ int main(int argc, char *argv[])
 		CERT_DisableOCSPDefaultResponder(handle);
 		if (strict)
 			CERT_SetOCSPFailureMode(ocspMode_FailureIsNotAVerificationFailure);
+		if (post)
+			CERT_ForcePostMethodForOCSP(PR_TRUE);
 	}
 
 	rv = CERT_ImportCerts(handle, 0, numcerts, certs, &certout, PR_FALSE,
@@ -369,7 +379,7 @@ int main(int argc, char *argv[])
 		cvin[in_idx++].value.scalar.b = PR_TRUE;
 
 		set_rev_per_meth(&rev, revFlagsLeaf, revFlagsChain);
-		set_rev_params(&rev, crlcheck, ocspcheck, strict);
+		set_rev_params(&rev, crlcheck, ocspcheck, strict, post);
 		cvin[in_idx].type = cert_pi_end;
 
 		cvout[0].type = cert_po_errorLog;


### PR DESCRIPTION
This patch attempts to fix the "ocsp-method=get|post" selection that had no effect after switching to NSS CERT_PKIXVerifyCert().

Previously, the OCSP GET method was used even with "ocsp-method=post" set in ipsec.conf. With this patch, only the OCSP method POST is used for validation when configured so.

It is done so by setting the CERT_REV_M_FORCE_POST_METHOD_FOR_OCSP flag in NSS.

I would appreciate a code review, any feedback welcomed.

