### PR TITLE
Automatically detect whether Curve25519 is available in NSS for USE_DH31

### DIFF
--- a/mk/userland-cflags.mk
+++ b/mk/userland-cflags.mk
@@ -240,7 +240,7 @@ ifeq ($(USE_DH24),true)
 USERLAND_CFLAGS += -DUSE_DH24
 endif
 
-USE_DH31 ?= true
+USE_DH31 ?= $(shell if printf '\#include <secoidt.h>\nint main() { return SEC_OID_CURVE25519; }\n'| $(CC) -x c $$(pkg-config --cflags nss) -o /dev/null -; then echo true; else echo false; fi )
 ifeq ($(USE_DH31),true)
 USERLAND_CFLAGS += -DUSE_DH31
 endif


### PR DESCRIPTION
currently, USE_DH31 defaults to true.

On some platforms, where older versions of NSS are in use, this should
default to false.

This patch automatically detects such systems and disables USE_DH31 on
those platforms.

It produces some amount of noise on stderr about CURVE_25519 during
the build on those older platforms, but that seems ok to me, since
those platforms should know that they're missing a modern feature.

If you prefer less noise, i'd be happy with any modification that does
a similar sort of autodetection.