### PR TITLE
sort all wildcarded object files for reproducibility

### DIFF
--- a/programs/algparse/Makefile
+++ b/programs/algparse/Makefile
@@ -22,7 +22,7 @@ OBJS += $(PROGRAM).o
 # XXX: For the moment build things by pulling in chunks of pluto.
 # What, if anything, should be moved to libswan or another library?
 #
-PLUTOOBJS += $(filter-out ike_alg_test.o, $(patsubst %.c,%.o,$(notdir $(wildcard $(top_srcdir)/programs/pluto/ike_alg*.c))))
+PLUTOOBJS += $(filter-out ike_alg_test.o, $(patsubst %.c,%.o,$(notdir $(sort $(wildcard $(top_srcdir)/programs/pluto/ike_alg*.c)))))
 PLUTOOBJS += crypt_symkey.o
 PLUTOOBJS += crypt_hash.o
 PLUTOOBJS += crypt_prf.o

--- a/programs/cavp/Makefile
+++ b/programs/cavp/Makefile
@@ -41,7 +41,7 @@ OBJS += acvp.o
 # What, if anything, should be moved to libswan or another library?
 #
 CFLAGS += -I$(top_srcdir)/programs/pluto
-PLUTOOBJS += $(patsubst %.c,%.o,$(notdir $(wildcard $(top_srcdir)/programs/pluto/ike_alg*.c)))
+PLUTOOBJS += $(patsubst %.c,%.o,$(notdir $(sort $(wildcard $(top_srcdir)/programs/pluto/ike_alg*.c))))
 PLUTOOBJS += crypt_symkey.o
 PLUTOOBJS += crypt_hash.o
 PLUTOOBJS += test_buffer.o

--- a/programs/spi/Makefile
+++ b/programs/spi/Makefile
@@ -25,7 +25,7 @@ OBJS += $(PROGRAM).o
 # What, if anything, should be moved to libswan or another library?
 #
 CFLAGS += -I$(top_srcdir)/programs/pluto
-PLUTOOBJS += $(patsubst %.c,%.o,$(notdir $(wildcard $(top_srcdir)/programs/pluto/ike_alg*.c)))
+PLUTOOBJS += $(patsubst %.c,%.o,$(notdir $(sort $(wildcard $(top_srcdir)/programs/pluto/ike_alg*.c))))
 PLUTOOBJS += crypt_symkey.o
 PLUTOOBJS += crypt_hash.o
 PLUTOOBJS += test_buffer.o


### PR DESCRIPTION
Without this sort, the linker may assemble the final object files in
the order in which their source files are found in the filesystem (or
however make chooses to interpret the $(wildcard ...) function).

By sorting the results lexicographically, we aim to assemble
byte-identical output files, regardless of the filesystem order or
other possible non-determinism introduced by make.

(i've applied this patch to the debian packaging of libreswan between versions 3.27-3 and 3.27-4;  results: 3.27-3 is non-deterministically unreproducible, and 3.27-4 appears to be reliably reproducible)