### PR TITLE
Initialize libunbound in addcon also when dnssec-enable=no

### DIFF
--- a/lib/libswan/unbound.c
+++ b/lib/libswan/unbound.c
@@ -186,9 +186,6 @@ bool unbound_event_init(struct event_base *eb, bool do_dnssec,
 void unbound_sync_init(bool do_dnssec, const char *rootfile,
 			const char *trusted)
 {
-	if (!do_dnssec)
-		return;
-
 	passert(dns_ctx == NULL); /* block re-entry to the function */
 	dns_ctx = ub_ctx_create();
 	passert(dns_ctx != NULL);


### PR DESCRIPTION
When compiled with `USE_DNSSEC`, but with `dnssec-enable=no` in ipsec.conf,
the assertion `dns_ctx != NULL` in `unbound_resolve()` fails, causing
addcon to abort:

```
addconn: ABORT: ASSERTION FAILED: dns_ctx != NULL (in unbound_resolve()
at unbound.c:209)
```