### PR TITLE
If cert_VerifySubjectAltName fails, be sure to log what it was (the name) that the code was looking for

### DIFF
--- a/programs/pluto/nss_cert_verify.c
+++ b/programs/pluto/nss_cert_verify.c
@@ -619,7 +619,7 @@ bool cert_VerifySubjectAltName(const CERTCertificate *cert, const char *name)
 	SECStatus rv = CERT_FindCertExtension(cert, SEC_OID_X509_SUBJECT_ALT_NAME,
 			&subAltName);
 	if (rv != SECSuccess) {
-		DBG(DBG_X509, DBG_log("certificate contains no subjectAltName extension"));
+		DBG(DBG_X509, DBG_log("certificate contains no subjectAltName extension, was looking for %s", name));
 		return FALSE;
 	}
 
@@ -632,7 +632,7 @@ bool cert_VerifySubjectAltName(const CERTCertificate *cert, const char *name)
 	CERTGeneralName *nameList = CERT_DecodeAltNameExtension(arena, &subAltName);
 
 	if (nameList == NULL) {
-		loglog(RC_LOG_SERIOUS, "certificate subjectAltName extension failed to decode");
+		loglog(RC_LOG_SERIOUS, "certificate subjectAltName extension failed to decode, was looking for %s", name);
 		PORT_FreeArena(arena, PR_FALSE);
 		return FALSE;
 	}
@@ -724,7 +724,7 @@ bool cert_VerifySubjectAltName(const CERTCertificate *cert, const char *name)
 		current = CERT_GetNextGeneralName(current);
 	} while (current != nameList);
 
-	loglog(RC_LOG_SERIOUS, "No matching subjectAltName found");
+	loglog(RC_LOG_SERIOUS, "No matching subjectAltName found, was looking for %s", name);
 	/* Don't free nameList, it's part of the arena. */
 	PORT_FreeArena(arena, PR_FALSE);
 	return FALSE;


### PR DESCRIPTION
Rationale: from watching the mailing list, it seems somewhat difficult to get just the right stuff into your
certificates' subjectAltName fields (or at all) for certificate validation to pass.

Right now when cert_VerifySubjectAltName fails, it just logs `No matching subjectAltName found` giving no indication of what actual name it was trying to match.

More logging should make it easier for users to troubleshoot such issues:

`No matching subjectAltName found, was looking for <actual name or address here>`