### PR TITLE
fix ipsec auto replace operation

### DIFF
--- a/programs/auto/auto.in
+++ b/programs/auto/auto.in
@@ -236,6 +236,11 @@ case "${op}" in
 	${showonly} ipsec whack --ctlsocket "${CTLSOCKET}" --status
 	exit
 	;;
+    --replace)
+	${showonly} ipsec whack --ctlsocket "${CTLSOCKET}" --name ${names} --delete
+	${showonly} ipsec addconn --ctlsocket "${CTLSOCKET}" ${verbose} ${config} ${names}
+	exit
+	;;
 esac
 
 ${showonly} ipsec addconn --ctlsocket "${CTLSOCKET}" ${verbose} ${config} ${names}


### PR DESCRIPTION
Now the **ipsec auto --replace**  is equivalent to **ipsec addconn**.
After change connection's subnets, addconn can't delete the prev conn, the prev conn will cause "cannot install eroute".

### case1
|           | ipsec.conf                                                                         | conn name                 |
|-----------|------------------------------------------------------------------------------------|---------------------------|
| prev conn | conn mytunnel<br>  leftsubnet=172.19.1.0/24<br>  rightsubnet=192.168.1.0/24            | mytunnel                  |
| new conn  | conn mytunnel <br>  leftsubnet=172.19.1.0/24<br> rightsubnets=192.168.1.0/24,192.168.2.0/24 | mytunnel/0x1<br> mytunnel/0x2 |

When replace mytunnel, **addconn** can't delete "mytunnel", because  it finds conn by name  "mytunnel/0x1" or "mytunnel/0x2".

### case2
|           | ipsec.conf                                                                                     | conn name                             |
|-----------|------------------------------------------------------------------------------------------------|---------------------------------------|
| prev conn | conn mytunnel<br>leftsubnet=172.19.1.0/24<br>rightsubnets=192.168.1.0/24,192.168.2.0/24,192.168.3.0/24 | mytunnel/0x1<br>mytunnel/0x2<br>mytunnel/0x3 |
| new conn  | conn mytunnel<br>leftsubnet=172.19.1.0/24<br>rightsubnets=192.168.1.0/24,192.168.2.0/24             | mytunnel/0x1<br>mytunnel/0x2  |

When replace mytunnel ,**addconn** can't delete  "mytunnel/0x3".

