### PR TITLE
Bump WHACK_MAGIC

### DIFF
--- a/include/whack.h
+++ b/include/whack.h
@@ -63,7 +63,7 @@
  */
 
 #define WHACK_BASIC_MAGIC (((((('w' << 8) + 'h') << 8) + 'k') << 8) + 25)
-#define WHACK_MAGIC (((((('o' << 8) + 'h') << 8) + 'k') << 8) + 46)
+#define WHACK_MAGIC (((((('o' << 8) + 'h') << 8) + 'k') << 8) + 47)
 
 /*
  * Where, if any, is the pubkey coming from.


### PR DESCRIPTION
The changes to deltatime_t's definition in
5d83f9af1f9ccf16570bcb613447d91c81a0c95a and the addition of
whack_ddns result in changes to the transmitted messages, so
WHACK_MAGIC should be bumped.

Signed-off-by: Stephen Kitt <skitt@redhat.com>