### PR TITLE
set redirect gw properly when redirect-to destination is a FQDN

### DIFF
--- a/programs/pluto/ikev2_redirect.c
+++ b/programs/pluto/ikev2_redirect.c
@@ -94,6 +94,7 @@ bool emit_redirect_notification_decoded_dest(
 
 	if (dest_ip == NULL) {
 		id = shunk1(dest_str);
+		gwi.gw_identity_type = GW_FQDN;
 	} else {
 		passert(dest_str == NULL);
 


### PR DESCRIPTION
If the destination passed to redirect-to option is a FQDN, the proper GW Ident Type was not initialized properly, causing redirects to fail.