### PR TITLE
account for fragmentation on clients with small MTU sizes

### DIFF
--- a/include/pluto_constants.h
+++ b/include/pluto_constants.h
@@ -343,7 +343,7 @@ typedef enum {
 #define MIN_OUTPUT_UDP_SIZE		1024
 #define MAX_OUTPUT_UDP_SIZE            65536
 
-#define MAX_IKE_FRAGMENTS       16
+#define MAX_IKE_FRAGMENTS       32
 
 #define KERNEL_PROCESS_Q_PERIOD 1 /* seconds */
 #define DEFAULT_MAXIMUM_HALFOPEN_IKE_SA 50000 /* fairly arbitrary */


### PR DESCRIPTION
Some Windows clients will fragment IKE payloads on a ridiculously low MTU sizes (we have observed as low as 626 bytes in the field, although I would not be surprised to see 576). This can cause pluto to drop large IKE_AUTH packets with fragment counts of >16.

This often gets reported to Windows clients as error code 809 as the server never responds to the IKE_AUTH, despite receiving all of the fragments.