### PR TITLE
make --global-redirect and --global-redirect-to whackable

### DIFF
--- a/include/ipsecconf/keywords.h
+++ b/include/ipsecconf/keywords.h
@@ -57,7 +57,6 @@ enum keyword_string_config_field {
 	KSF_PLUTO_DNSSEC_ROOTKEY_FILE,
 	KSF_PLUTO_DNSSEC_ANCHORS,
 	KSF_PROTOSTACK,
-	KSF_GLOBAL_REDIRECT,
 	KSF_GLOBAL_REDIRECT_TO,
 	KSF_LISTEN,
 	KSF_OCSP_URI,
@@ -107,6 +106,7 @@ enum keyword_numeric_config_field {
 	KBF_NFLOG_ALL,		/* Enable global nflog device */
 	KBF_DDOS_MODE,		/* set DDOS mode */
 	KBF_SECCOMP,		/* set SECCOMP mode */
+	KBF_GLOBAL_REDIRECT,
 	KBF_ROOF
 };
 

--- a/include/names_constant.h
+++ b/include/names_constant.h
@@ -98,7 +98,6 @@ extern enum_names ikev2_ts_type_names;
 extern enum_names ikev2_cp_type_names;
 extern enum_names ikev2_cp_attribute_type_names;
 extern enum_names ikev2_redirect_gw_names;
-extern enum_names allow_global_redirect_names;
 
 extern enum_names dns_auth_level_names;
 

--- a/include/pluto_constants.h
+++ b/include/pluto_constants.h
@@ -113,12 +113,6 @@ enum keyword_xauthby {
 	XAUTHBY_ALWAYSOK = 2,
 };
 
-enum allow_global_redirect {
-	GLOBAL_REDIRECT_NO,
-	GLOBAL_REDIRECT_YES,
-	GLOBAL_REDIRECT_AUTO,
-};
-
 enum keyword_xauthfail {
 	XAUTHFAIL_HARD = 0,
 	XAUTHFAIL_SOFT = 1,

--- a/include/whack.h
+++ b/include/whack.h
@@ -341,6 +341,8 @@ struct whack_message {
 	bool vti_shared; /* use remote %any and skip cleanup on down? */
 
 	/* for RFC 5685 - IKEv2 Redirect mechanism */
+	enum yna_options global_redirect;
+	char *global_redirect_to;
 	char *redirect_to;
 	char *accept_redirect_to;
 

--- a/lib/libipsecconf/confread.c
+++ b/lib/libipsecconf/confread.c
@@ -105,6 +105,7 @@ static void ipsecconf_default_values(struct starter_config *cfg)
 
 	SOPT(KBF_SECCOMP, SECCOMP_DISABLED); /* will be enabled in the future */
 
+	SOPT(KBF_GLOBAL_REDIRECT, yna_no);
 # undef SOPT
 
 	cfg->setup.strings[KSF_PLUTO_DNSSEC_ROOTKEY_FILE] = clone_str(DEFAULT_DNSSEC_ROOTKEY_FILE, "dnssec rootkey file");

--- a/lib/libipsecconf/keywords.c
+++ b/lib/libipsecconf/keywords.c
@@ -387,7 +387,7 @@ const struct keyword_def ipsec_conf_keywords[] = {
   { "perpeerlogdir",  kv_config,  kt_dirname,  KSF_PERPEERDIR, NULL, NULL, },
   { "uniqueids",  kv_config,  kt_bool,  KBF_UNIQUEIDS, NULL, NULL, },
   { "shuntlifetime",  kv_config,  kt_time,  KBF_SHUNTLIFETIME, NULL, NULL, },
-  { "global-redirect", kv_config, kt_string, KSF_GLOBAL_REDIRECT, NULL, NULL },
+  { "global-redirect", kv_config, kt_enum, KBF_GLOBAL_REDIRECT, &kw_yna_list, NULL },
   { "global-redirect-to", kv_config, kt_string, KSF_GLOBAL_REDIRECT_TO, NULL, NULL, },
 
   { "crl-strict",  kv_config,  kt_bool,  KBF_CRL_STRICT, NULL, NULL, },

--- a/lib/libwhack/whacklib.c
+++ b/lib/libwhack/whacklib.c
@@ -138,6 +138,7 @@ err_t pack_whack_msg(struct whackpacker *wp)
 	    !pack_str(wp, &wp->msg->conn_mark_out) ||		/* string 32 */
 	    !pack_str(wp, &wp->msg->vti_iface) ||		/* string 33 */
 	    !pack_str(wp, &wp->msg->remote_host) ||		/* string 33 */
+	    !pack_str(wp, &wp->msg->global_redirect_to) ||  /* string 34 */
 	    !pack_str(wp, &wp->msg->redirect_to) ||		/* string 34 */
 	    !pack_str(wp, &wp->msg->accept_redirect_to) ||	/* string 35 */
 	    wp->str_roof - wp->str_next < (ptrdiff_t)wp->msg->keyval.len)	/* key */
@@ -209,6 +210,7 @@ err_t unpack_whack_msg(struct whackpacker *wp)
 	    !unpack_str(wp, &wp->msg->conn_mark_out) ||		/* string 32 */
 	    !unpack_str(wp, &wp->msg->vti_iface) ||		/* string 33 */
 	    !unpack_str(wp, &wp->msg->remote_host) ||		/* string 33 */
+	    !unpack_str(wp, &wp->msg->global_redirect_to) ||    /* string 34 */
 	    !unpack_str(wp, &wp->msg->redirect_to) ||		/* string 34 */
 	    !unpack_str(wp, &wp->msg->accept_redirect_to) ||	/* string 35 */
 	    wp->str_roof - wp->str_next != (ptrdiff_t)wp->msg->keyval.len)

--- a/programs/pluto/ikev2_parent.c
+++ b/programs/pluto/ikev2_parent.c
@@ -1085,8 +1085,8 @@ static stf_status ikev2_parent_inI1outR1_continue_tail(struct state *st,
 	 }
 
 	if (st->st_seen_redirect_sup &&
-	    (global_redirect == GLOBAL_REDIRECT_YES ||
-	     (global_redirect == GLOBAL_REDIRECT_AUTO && require_ddos_cookies())))
+	    (global_redirect == yna_yes ||
+	     (global_redirect == yna_auto && require_ddos_cookies())))
 	{
 		if (global_redirect_to == NULL) {
 			loglog(RC_LOG_SERIOUS, "global-redirect-to is not specified; can't redirect requests");

--- a/programs/pluto/ikev2_redirect.c
+++ b/programs/pluto/ikev2_redirect.c
@@ -36,7 +36,7 @@
 #include "ikev2_redirect.h"
 #include "initiate.h"
 
-enum allow_global_redirect global_redirect;
+enum yna_options global_redirect;
 char *global_redirect_to;
 
 /*

--- a/programs/pluto/ikev2_redirect.h
+++ b/programs/pluto/ikev2_redirect.h
@@ -20,7 +20,7 @@
 
 #include "packet.h"
 
-extern enum allow_global_redirect global_redirect;
+extern enum yna_options global_redirect;
 extern char *global_redirect_to;
 
 /*

--- a/programs/pluto/pluto_constants.c
+++ b/programs/pluto/pluto_constants.c
@@ -299,20 +299,6 @@ enum_names ikev2_asym_auth_name = {
 	NULL
 };
 
-static const char *const allow_global_redirect_name[] = {
-	"no",
-	"yes",
-	"auto",
-};
-
-enum_names allow_global_redirect_names = {
-	GLOBAL_REDIRECT_NO,
-	GLOBAL_REDIRECT_AUTO,
-	ARRAY_REF(allow_global_redirect_name),
-	NULL,
-	NULL
-};
-
 static const char *const policy_shunt_names[4] = {
 	"TRAP",
 	"PASS",

--- a/programs/pluto/plutomain.c
+++ b/programs/pluto/plutomain.c
@@ -1186,11 +1186,11 @@ int main(int argc, char **argv)
 		case 'Q':	/* --global-redirect */
 		{
 			if (streq(optarg, "yes")) {
-				global_redirect = GLOBAL_REDIRECT_YES;
+				global_redirect = yna_yes;
 			} else if (streq(optarg, "no")) {
-				global_redirect = GLOBAL_REDIRECT_NO;
+				global_redirect = yna_no;
 			} else if (streq(optarg, "auto")) {
-				global_redirect = GLOBAL_REDIRECT_AUTO;
+				global_redirect = yna_auto;
 			} else {
 				libreswan_log(
 					"invalid option argument for global-redirect (allowed arguments: yes, no, auto)");
@@ -1272,19 +1272,6 @@ int main(int argc, char **argv)
 				       cfg->setup.strings[KSF_OCSP_URI]);
 			set_cfg_string(&ocsp_trust_name,
 				       cfg->setup.strings[KSF_OCSP_TRUSTNAME]);
-
-			char *tmp_global_redirect = cfg->setup.strings[KSF_GLOBAL_REDIRECT];
-			if (tmp_global_redirect == NULL || streq(tmp_global_redirect, "no")) {
-				/* NULL means it is not specified so default is no */
-				global_redirect = GLOBAL_REDIRECT_NO;
-			} else if (streq(tmp_global_redirect, "yes")) {
-				global_redirect = GLOBAL_REDIRECT_YES;
-			} else if (streq(tmp_global_redirect, "auto")) {
-				global_redirect = GLOBAL_REDIRECT_AUTO;
-			} else {
-				global_redirect = GLOBAL_REDIRECT_NO;
-				libreswan_log("unknown argument for global-redirect option");
-			}
 
 			crl_check_interval = deltatime(
 				cfg->setup.options[KBF_CRL_CHECKINTERVAL]);
@@ -1389,6 +1376,7 @@ int main(int argc, char **argv)
 			set_cfg_string(&virtual_private,
 				cfg->setup.strings[KSF_VIRTUALPRIVATE]);
 
+			global_redirect = cfg->setup.options[KBF_GLOBAL_REDIRECT];
 			set_cfg_string(&global_redirect_to,
 				cfg->setup.strings[KSF_GLOBAL_REDIRECT_TO]);
 
@@ -2022,7 +2010,8 @@ void show_setup_plutomain(const struct fd *whackfd)
 
 	whack_comment(whackfd,
 		"global-redirect=%s, global-redirect-to=%s",
-		enum_name(&allow_global_redirect_names, global_redirect),
+		((global_redirect == yna_auto) ? "auto" :
+			(global_redirect == yna_yes) ? "yes" : "no"),
 		global_redirect_to != NULL ? global_redirect_to : "<unset>"
 		);
 

--- a/programs/whack/whack.c
+++ b/programs/whack/whack.c
@@ -104,6 +104,7 @@ static void help(void)
 		"	[--rekeymargin <seconds>] [--rekeyfuzz <percentage>] \\\n"
 		"	[--retransmit-timeout <seconds>] \\\n"
 		"	[--retransmit-interval <msecs>] \\\n"
+		"	[--global-redirect] [--global-redirect-to] \\\n"
 		"	[--send-redirect] [--redirect-to] \\\n"
 		"	[--accept-redirect] [--accept-redirect-to] \\\n"
 		"	[--keyingtries <count>] \\\n"
@@ -303,6 +304,9 @@ enum option_enums {
 	OPT_IKE_MSGERR,
 	OPT_REKEY_IKE,
 	OPT_REKEY_IPSEC,
+
+	OPT_GLOBAL_REDIRECT,
+	OPT_GLOBAL_REDIRECT_TO,
 
 	OPT_ACTIVE_REDIRECT,
 	OPT_ACTIVE_REDIRECT_PEER,
@@ -547,6 +551,9 @@ static const struct option long_opts[] = {
 	{ "unlisten", no_argument, NULL, OPT_UNLISTEN + OO },
 	{ "ike-socket-bufsize", required_argument, NULL, OPT_IKEBUF + OO + NUMERIC_ARG},
 	{ "ike-socket-errqueue-toggle", no_argument, NULL, OPT_IKE_MSGERR + OO },
+
+	{ "global-redirect", required_argument, NULL, OPT_GLOBAL_REDIRECT + OO },
+	{ "global-redirect-to", required_argument, NULL, OPT_GLOBAL_REDIRECT_TO + OO },
 
 	{ "redirect", no_argument, NULL, OPT_ACTIVE_REDIRECT + OO },
 	{ "peer-ip", required_argument, NULL, OPT_ACTIVE_REDIRECT_PEER + OO },
@@ -1274,6 +1281,21 @@ int main(int argc, char **argv)
 		/* --deleteuser --name <xauthusername> */
 		case OPT_DELETEUSER:
 			msg.whack_deleteuser = TRUE;
+			continue;
+
+		case OPT_GLOBAL_REDIRECT:	/* --global-redirect */
+			if (streq(optarg, "no"))
+				msg.global_redirect = yna_no;
+			else if (streq(optarg, "yes"))
+				msg.global_redirect = yna_yes;
+			else if (streq(optarg, "auto"))
+				msg.global_redirect = yna_auto;
+			else
+				diag("--global-redirect options are 'no', 'yes' or 'auto'");
+			continue;
+
+		case OPT_GLOBAL_REDIRECT_TO:	/* --redirect-to */
+			msg.global_redirect_to = strdup(optarg);
 			continue;
 
 		case OPT_ACTIVE_REDIRECT:	/* --redirect */
@@ -2408,6 +2430,7 @@ int main(int argc, char **argv)
 	if (!(msg.whack_connection || msg.whack_key ||
 	      msg.whack_delete ||msg.whack_deleteid || msg.whack_deletestate ||
 	      msg.whack_deleteuser || msg.active_redirect ||
+	      msg.global_redirect || msg.global_redirect_to ||
 	      msg.whack_initiate || msg.whack_oppo_initiate ||
 	      msg.whack_terminate ||
 	      msg.whack_route || msg.whack_unroute || msg.whack_listen ||


### PR DESCRIPTION
also refactored and removed unnecessary enum options.

a contentious part might the duplication of the `set_cfg_string` static function. there's probably a better way to do this.