### PR TITLE
seamless nss cert rotation for existing tunnels

### DIFF
--- a/include/whack.h
+++ b/include/whack.h
@@ -333,6 +333,9 @@ struct whack_message {
 	/* for WHACK_REREAD */
 	u_char whack_reread;
 
+	/* for WHACK_ROTATE_CERT */
+	bool whack_rotate_cert;
+
 	/* for connalias string */
 	char *connalias;
 

--- a/programs/auto/auto.8.xml
+++ b/programs/auto/auto.8.xml
@@ -84,6 +84,12 @@ connection</replaceable></arg>
     <arg choice='opt'>--purgeocsp </arg>
 
 </cmdsynopsis>
+<cmdsynopsis>
+  <command>ipsec</command>
+    <arg choice='plain'><replaceable>auto</replaceable></arg>
+    <arg choice='plain'>--rotatecert</arg>
+    <arg choice='plain'><replaceable>connection</replaceable></arg>
+</cmdsynopsis>
 </refsect1>
 <refsect1 id='description'><title>DESCRIPTION</title>
 <para><emphasis remap='I'>Auto</emphasis>
@@ -103,8 +109,9 @@ is
 <option>--down</option>,
 <option>--route</option>,
 <option>--unroute</option>,
+<option>--ondemand</option>,
 or
-<option>--ondemand</option>.
+<option>--rotatecert</option>.
 The
 <option>--ready</option>,
 <option>--rereadsecrets</option>,
@@ -198,6 +205,12 @@ operation is equivalent to running first with
 and then with
 <option>--route</option>, causing same effect as connection configuration option
 <option>auto=ondemand</option>.</para>
+
+<para>The
+<option>--rotatecert</option>
+operation is used to rotate cert without tearing down the connection and
+bringing it up. The operation asks <emphasis remap='I'>pluto</emphasis>
+to reload cert and key associated with the connection.</para>
 
 <para>The
 <option>--ready</option>

--- a/programs/auto/auto.in
+++ b/programs/auto/auto.in
@@ -31,6 +31,7 @@ usage="Usage:
 	${me} [--showonly] [--utc] --{listcacerts|listgroups}
 	${me} [--showonly] [--utc] --{listcrls|listall}
 	${me} [--showonly] [--utc] --purgeocsp
+	${me} [--showonly] --rotatecert connectionname
 
 	other options: [--config ipsecconfigfile] [--verbose] [--ctlsocket <file>]"
 
@@ -80,7 +81,7 @@ do
 	    verbose=" --verbose "
 	    ;;
 	--up|--down|--add|--delete|--replace|--route|--unroute|\
-	--start|--ondemand)
+	--start|--ondemand|--rotatecert)
 	    if [ " ${op}" != " " ]; then
 		echo "${usage}" >&2
 		exit 2
@@ -119,7 +120,7 @@ done
 names=
 case "${op}$#:$1:$2" in
     2:*:up|2:*:down|2:*:add|2:*:delete|2:*:replace|2:*:start|\
-    2:*:route|2:*:unroute)
+    2:*:route|2:*:unroute|2:*:rotatecert)
 	echo "${me}: warning: obsolete command syntax used" >&2
 	names="$1"
 	op="--$2"
@@ -239,6 +240,10 @@ case "${op}" in
     --replace)
 	${showonly} ipsec whack --ctlsocket "${CTLSOCKET}" --name ${names} --delete
 	${showonly} ipsec addconn --ctlsocket "${CTLSOCKET}" ${verbose} ${config} ${names}
+	exit
+	;;
+    --rotatecert)
+	${showonly} ipsec whack --ctlsocket "${CTLSOCKET}" --name ${names} --rotatecert
 	exit
 	;;
 esac

--- a/programs/pluto/Makefile
+++ b/programs/pluto/Makefile
@@ -220,6 +220,7 @@ OBJS += nss_ocsp.o nss_crl_import.o
 OBJS += nss_err.o
 OBJS += root_certs.o
 OBJS += pluto_timing.o
+OBJS += cert_rotation.o
 
 # Archives
 OBJS += $(LIBRESWANLIB)

--- a/programs/pluto/cert_rotation.c
+++ b/programs/pluto/cert_rotation.c
@@ -1,0 +1,96 @@
+#include <nss.h>
+
+#include "cert_rotation.h"
+#include "connections.h"
+#include "constants.h"
+#include "defs.h"
+#include "keys.h"
+#include "log.h"
+#include "nss_cert_load.h"
+#include "whack.h"
+
+static inline cert_t backup_cert(struct end *dst)
+{
+	cert_t backup;
+
+	backup.ty = dst->cert.ty;
+	backup.u.nss_cert = dst->cert.u.nss_cert;
+
+	return backup;
+}
+
+static inline void restore_cert(struct end *dst, cert_t cert)
+{
+	// restore old certs
+	dst->cert.ty = cert.ty;
+	dst->cert.u.nss_cert = cert.u.nss_cert;
+}
+
+static inline void release_cert(cert_t cert)
+{
+	if (cert.u.nss_cert != NULL)
+		CERT_DestroyCertificate(cert.u.nss_cert);
+}
+
+// This function attempts to load a new cert if NSS DB has a new one
+static bool attempt_new_cert(struct fd *whackfd, struct end *dst)
+{
+	const char *nickname;
+	enum whack_pubkey_type pubkey_type;
+
+	nickname = cert_nickname(&dst->cert);
+	if (nickname == NULL) {
+		whack_comment(whackfd, "No cert nickname found");
+		return false;
+	}
+
+	pubkey_type = WHACK_PUBKEY_CERTIFICATE_NICKNAME;
+	if (!load_end_cert_and_preload_secret(whackfd, dst->leftright,
+					      nickname, pubkey_type, dst)) {
+		whack_comment(whackfd, "New cert attempt failed for %s", nickname);
+		return false;
+	}
+
+	return true;
+}
+
+static void rotate_end_cert(struct fd *whackfd, struct end *dst)
+{
+	cert_t old_cert;
+
+	if (dst->cert.u.nss_cert == NULL)
+		whack_comment(whackfd, "No cert exists for %s; nothing to do",
+			      dst->leftright);
+	else {
+		old_cert = backup_cert(dst);
+
+		if (!attempt_new_cert(whackfd, dst)) {
+			whack_comment(whackfd, "Cert rotation failed for %s",
+				      dst->leftright);
+			restore_cert(dst, old_cert);
+			return;
+		}
+
+		whack_comment(whackfd, "Cert rotation complete for %s",
+			      dst->leftright);
+		release_cert(old_cert);
+	}
+}
+
+void rotate_cert(struct fd *whackfd, const struct whack_message *wm)
+{
+	struct connection *conn;
+	struct end *dst;
+
+	conn = conn_by_name(wm->name, false);
+	if (conn == NULL)  {
+		whack_comment(whackfd, "No connection '%s' found", wm->name);
+		return;
+	}
+
+	dst = &conn->spd.this;
+	rotate_end_cert(whackfd, dst);
+
+	dst = &conn->spd.that;
+	rotate_end_cert(whackfd, dst);
+}

--- a/programs/pluto/cert_rotation.h
+++ b/programs/pluto/cert_rotation.h
@@ -1,0 +1,9 @@
+#ifndef CERT_ROTATION_H
+#define CERT_ROTATION_H
+
+struct fd;
+struct whack_message;
+
+extern void rotate_cert(struct fd *whackfd, const struct whack_message *wm);
+
+#endif // CERT_ROTATION_H

--- a/programs/pluto/connections.c
+++ b/programs/pluto/connections.c
@@ -97,11 +97,6 @@ struct connection *connections = NULL;
 #define MINIMUM_IPSEC_SA_RANDOM_MARK 65536
 static uint32_t global_marks = MINIMUM_IPSEC_SA_RANDOM_MARK;
 
-static bool load_end_cert_and_preload_secret(struct fd *whackfd,
-					     const char *which, const char *pubkey,
-					     enum whack_pubkey_type pubkey_type,
-					     struct end *dst_end);
-
 static bool idr_wildmatch(const struct end *this, const struct id *b);
 
 /*
@@ -942,10 +937,10 @@ static bool check_connection_end(const struct whack_end *this,
 	return TRUE; /* happy */
 }
 
-static bool load_end_cert_and_preload_secret(struct fd *whackfd,
-					     const char *which, const char *pubkey,
-					     enum whack_pubkey_type pubkey_type,
-					     struct end *dst_end)
+bool load_end_cert_and_preload_secret(struct fd *whackfd,
+				      const char *which, const char *pubkey,
+				      enum whack_pubkey_type pubkey_type,
+				      struct end *dst_end)
 {
 	struct logger logger[] = { GLOBAL_LOGGER(whackfd), };
 	dst_end->cert.ty = CERT_NONE;

--- a/programs/pluto/connections.h
+++ b/programs/pluto/connections.h
@@ -155,6 +155,7 @@ extern void fmt_policy_prio(policy_prio_t pp, char buf[POLICY_PRIO_BUF]);
 #include "ip_endpoint.h"
 #include "ip_selector.h"
 #include "ip_protoport.h"
+#include "whack.h"
 
 struct virtual_t;	/* opaque type */
 
@@ -598,5 +599,10 @@ extern void liveness_action(struct connection *c, enum ike_version ike_version);
 extern uint32_t calculate_sa_prio(const struct connection *c, bool oe_shunt);
 
 so_serial_t get_newer_sa_from_connection(struct state *st);
+
+extern bool load_end_cert_and_preload_secret(struct fd *whackfd,
+					     const char *which, const char *pubkey,
+					     enum whack_pubkey_type pubkey_type,
+					     struct end *dst_end);
 
 #endif

--- a/programs/pluto/rcv_whack.c
+++ b/programs/pluto/rcv_whack.c
@@ -188,6 +188,8 @@ static void whack_impair_action(enum impair_action action, unsigned event,
 	}
 }
 
+#include "cert_rotation.h"
+
 static int whack_route_connection(struct connection *c,
 				  struct fd *whackfd,
 				  void *unused_arg UNUSED)
@@ -712,6 +714,9 @@ static bool whack_process(struct fd *whackfd, const struct whack_message *const 
 		libreswan_log("shutting down");
 		return true; /* shutting down */
 	}
+
+	if (m->whack_rotate_cert)
+		rotate_cert(whackfd, m);
 
 	return false; /* don't shut down */
 }

--- a/programs/whack/whack.c
+++ b/programs/whack/whack.c
@@ -205,6 +205,8 @@ static void help(void)
 #endif
 		"shutdown: whack --shutdown\n"
 		"\n"
+		"rotatecert: whack --rotatecert --name <connection_name>\n"
+		"\n"
 		"Libreswan %s\n",
 		ipsec_version_code());
 }
@@ -505,6 +507,11 @@ enum option_enums {
 
 /* === end of correspondence with POLICY_* === */
 
+/* cert rotation options */
+#   define CROPT_FIRST CR_ROTATECERT
+	CR_ROTATECERT,
+#   define CROPT_LAST CR_ROTATECERT
+
 #   define DBGOPT_FIRST DBGOPT_NONE
 	DBGOPT_NONE,
 	DBGOPT_ALL,
@@ -644,6 +651,10 @@ static const struct option long_opts[] = {
 	/* options for a connection description */
 
 	{ "to", no_argument, NULL, CD_TO + OO },
+
+	/* option for cert rotation */
+
+	{ "rotatecert", no_argument, NULL, CR_ROTATECERT + OO },
 
 #define PS(o, p)	{ o, no_argument, NULL, CDP_SINGLETON + POLICY_##p##_IX + OO }
 	PS("psk", PSK),
@@ -927,6 +938,7 @@ int main(int argc, char **argv)
 	assert(END_LAST - END_FIRST < LELEM_ROOF);
 	assert(CD_LAST - CD_FIRST < LELEM_ROOF);
 	assert(ALGO_LAST - ALGO_FIRST < LELEM_ROOF);
+	assert(CROPT_LAST - CROPT_FIRST < LELEM_ROOF);
 
 	zero(&msg);	/* ??? pointer fields might not be NULLed */
 
@@ -2337,6 +2349,10 @@ int main(int argc, char **argv)
 			continue;
 		}
 
+		case CR_ROTATECERT:	/* --rotatecert */
+			msg.whack_rotate_cert = TRUE;
+			continue;
+
 		default:
 			bad_case(c);
 		}
@@ -2505,7 +2521,7 @@ int main(int argc, char **argv)
 	      msg.whack_addresspool_status ||
 	      msg.whack_fips_status || msg.whack_brief_status || msg.whack_clear_stats || msg.whack_options ||
 	      msg.whack_shutdown || msg.whack_purgeocsp || msg.whack_seccomp_crashtest || msg.whack_show_states ||
-	      msg.whack_rekey_ike || msg.whack_rekey_ipsec))
+	      msg.whack_rekey_ike || msg.whack_rekey_ipsec || msg.whack_rotate_cert))
 		diag("no action specified; try --help for hints");
 
 	/* do the logic for --redirect command */


### PR DESCRIPTION
Libreswan does not support seamless cert rotation. Therefore, when
a new cert is issued and inserted into NSS DB, a tunnel should be
torn down and set up again or pluto needs to be restarted in order
to pick up the new cert. This causes temporary disruption for an
existing tunnel. This patch enables a new feature that allows
rotation of cert without bringing down any active tunnel by
replacing an old cert with a new one in pluto.