### PR TITLE
Use pkg-config recommended by the environment

### DIFF
--- a/mk/defaults/linux.mk
+++ b/mk/defaults/linux.mk
@@ -41,7 +41,9 @@ ifeq ($(LINUX_VARIANT),fedora)
 endif
 #(info USE_GLIBC_KERN_FLIP_HEADERS=$(USE_GLIBC_KERN_FLIP_HEADERS))
 
+PKG_CONFIG?=pkg-config
+
 ifndef NSS_CFLAGS
-  NSS_CFLAGS := $(shell pkg-config --cflags nss)
+  NSS_CFLAGS := $(shell $(PKG_CONFIG) --cflags nss)
   export NSS_CFLAGS
 endif


### PR DESCRIPTION
This should help with cross-building.  See suggestions from Helmut
Grohne on https://bugs.debian.org/958355

Signed-off-by: Daniel Kahn Gillmor <dkg@fifthhorseman.net>