### PR TITLE
Declare the build dependency on nss-tools

### DIFF
--- a/packaging/fedora/libreswan.spec
+++ b/packaging/fedora/libreswan.spec
@@ -54,6 +54,7 @@ BuildRequires: libseccomp-devel
 BuildRequires: libselinux-devel
 BuildRequires: nspr-devel
 BuildRequires: nss-devel >= %{nss_version}
+BuildRequires: nss-tools >= %{nss_version}
 BuildRequires: openldap-devel
 BuildRequires: pam-devel
 BuildRequires: pkgconfig


### PR DESCRIPTION
The Fedora .spec file relies on certutil, and that is provided by the
nss-tools package; this makes sure the latter is installed.

Signed-off-by: Stephen Kitt <skitt@redhat.com>