### PR TITLE
Default to Fedora 32 for Docker-based builds

### DIFF
--- a/mk/docker-targets.mk
+++ b/mk/docker-targets.mk
@@ -21,7 +21,7 @@ W4 = $(or $(word 4, $(subst -, ,$1)), $(value 2))
 
 FIRST_TARGET ?=$@	# keep track of original target
 DISTRO ?= fedora	# default distro
-DISTRO_REL ?= 30 	# default release
+DISTRO_REL ?= 32 	# default release
 
 D_USE_UNBOUND_EVENT_H_COPY ?= true
 D_USE_DNSSEC ?= false


### PR DESCRIPTION
Fedora 30 is no longer available, upgrade to 32.

Signed-off-by: Stephen Kitt <skitt@redhat.com>