### PR TITLE
Fix labeled IPsec

### DIFF
--- a/lib/libipsecconf/starterwhack.c
+++ b/lib/libipsecconf/starterwhack.c
@@ -657,7 +657,7 @@ static int starter_whack_basic_add_conn(struct starter_config *cfg,
 #endif
 
 #ifdef HAVE_LABELED_IPSEC
-	if (conn->options_set[KSCF_POLICY_LABEL]) {
+	if (conn->strings_set[KSCF_POLICY_LABEL]) {
 		msg.policy_label = conn->policy_label;
 		starter_log(LOG_LEVEL_DEBUG, "conn: \"%s\" policy_label=%s",
 			conn->name, msg.policy_label);

--- a/programs/pluto/ikev1_spdb_struct.c
+++ b/programs/pluto/ikev1_spdb_struct.c
@@ -56,8 +56,7 @@
 #include "nat_traversal.h"
 
 
-#ifndef USE_LABELED_IPSEC
-
+#ifndef HAVE_LABELED_IPSEC
 static bool parse_secctx_attr(pb_stream *pbs UNUSED, struct state *st UNUSED)
 {
 	/*


### PR DESCRIPTION
It appears that 998aa5f18bad901d6f5c834494d06ee405053b59 changed
policy_label from being an "option" to a "string", but forgot to change
the conditional for (optionally) sending the value to pluto.
Using 3.32 this results in addconn parsing the configuration file but
simply **never** sends this value to pluto.
This breaks Labeled IPSec support.

This was only tested as a patch against the debian package for 3.32-3