### PR TITLE
Replace/remove deprecated libselinux functions

### DIFF
--- a/contrib/labeled-ipsec/getpeercon_server.c
+++ b/contrib/labeled-ipsec/getpeercon_server.c
@@ -64,7 +64,7 @@ int main(int argc, char *argv[])
 		srv_sock_path = argv[1];
 
 	{
-		security_context_t ctx;
+		char *ctx;
 		int rc = getcon(&ctx);
 
 		fprintf(stderr, "-> running as %s\n",
@@ -142,7 +142,7 @@ int main(int argc, char *argv[])
 		struct sockaddr_in6 *const cli_sock_6addr = (struct sockaddr_in6 *)&cli_sock_saddr;
 		socklen_t cli_sock_addr_len;
 		char cli_sock_addr_str[INET6_ADDRSTRLEN + 1];
-		security_context_t ctx;
+		char *ctx;
 		char *ctx_str;
 
 		//fflush(stdout);

--- a/programs/pluto/security_selinux.c
+++ b/programs/pluto/security_selinux.c
@@ -30,13 +30,13 @@ void init_avc(void)
 		libreswan_log("selinux support is enabled.");
 	}
 
-	if (avc_init("libreswan", NULL, NULL, NULL, NULL) == 0)
+	if (avc_open(NULL, 0) == 0)
 		selinux_ready = 1;
 	else
 		libreswan_log("selinux: could not initialize avc.");
 }
 
-int within_range(security_context_t sl, security_context_t range)
+int within_range(char *sl, security_context_t range)
 {
 	int rtn = 1;
 	security_id_t slsid;
@@ -62,7 +62,6 @@ int within_range(security_context_t sl, security_context_t range)
 	rtn = avc_context_to_sid(range, &rangesid);
 	if (rtn != 0) {
 		dbg("within_range: Unable to retrieve sid for range context (%s)", range);
-		sidput(slsid);
 		return 0;
 	}
 
@@ -74,8 +73,6 @@ int within_range(security_context_t sl, security_context_t range)
 	rtn = avc_has_perm(slsid, rangesid, tclass, av, NULL, &avd);
 	if (rtn != 0) {
 		dbg("within_range: The sl (%s) is not within range of (%s)", sl, range);
-		sidput(slsid);
-		sidput(rangesid);
 		return 0;
 	}
 	dbg("within_range: The sl (%s) is within range of (%s)", sl, range);

--- a/programs/pluto/security_selinux.h
+++ b/programs/pluto/security_selinux.h
@@ -20,6 +20,6 @@
 #include <selinux/context.h>
 
 void init_avc(void);
-int within_range(security_context_t sl, security_context_t range);
+int within_range(char *sl, security_context_t range);
 
 #endif /* _SECURITY_SELINUX_H */


### PR DESCRIPTION
In libselinux 3.1 some deprecated functions were removed, making
libreswan fail to build.
This is a proposed fix based on libselinux documentation on the
deprecated functions.