### PR TITLE
add missing include of limits.h for UINT_MAX

### DIFF
--- a/programs/pluto/connections.c
+++ b/programs/pluto/connections.c
@@ -41,6 +41,7 @@
 #include <arpa/inet.h>
 #include <resolv.h>
 #include <errno.h>
+#include <limits.h>
 
 #include "sysdep.h"
 #include "constants.h"


### PR DESCRIPTION
note: 'UINT_MAX' is defined in header '<limits.h>'; did you forget to '#include <limits.h>'?
   92 | # include "kernel_xfrm_interface.h"
  +++ |+#include <limits.h>

Fixes building on musl