### PR TITLE
Adds intermediate exchange related parameters into nss version of psk_auth

### DIFF
--- a/lib/libswan/ike_alg_prf_ikev2_nss_ops.c
+++ b/lib/libswan/ike_alg_prf_ikev2_nss_ops.c
@@ -180,7 +180,8 @@ static PK11SymKey *child_sa_keymat(const struct prf_desc *prf_desc,
 static struct crypt_mac psk_auth(const struct prf_desc *prf_desc, chunk_t pss,
 				 chunk_t first_packet, chunk_t nonce,
 				 const struct crypt_mac *id_hash,
-				 struct logger *logger)
+				 struct logger *logger,
+				 bool use_intermediate, chunk_t intermediate_packet)
 {
 	PK11SymKey *prf_psk;
 
@@ -241,6 +242,9 @@ static struct crypt_mac psk_auth(const struct prf_desc *prf_desc, chunk_t pss,
 		crypt_prf_update_hunk(prf, "first-packet", first_packet);
 		crypt_prf_update_hunk(prf, "nonce", nonce);
 		crypt_prf_update_hunk(prf, "hash", *id_hash);
+		if (use_intermediate) {
+			crypt_prf_update_hunk(prf,"IntAuth", intermediate_packet);
+		}
 		signed_octets = crypt_prf_final_mac(&prf, NULL);
 	}
 	release_symkey(__func__, "prf-psk", &prf_psk);


### PR DESCRIPTION
Signed-off-by: Sahana Prasad <sahana@redhat.com>

Add missing intermediate parameters into psk_auth() function used by ike_alg_prf_ikev2_nss_ops