### PR TITLE
Fix spelling (nit-picks)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -140,7 +140,7 @@ v3.30 (February 13, 2020)
 * IKEv2: Refuse SHA1 for RFC 7427 Digital Signatures as per RFC 8247 [Sahana]
 * IKEv2: Use IKEv2 fragment size values (not IKEv1) [Andrew]
 * IKEv2: On initiator, do not retransmit on IKE_AUTH processing failure [Paul]
-* IKEv1: Re-implement CVE-2019-10155 fix to prevent future occurances [Andrew]
+* IKEv1: Re-implement CVE-2019-10155 fix to prevent future occurences [Andrew]
 * IKEv1: do not assert on bad virtual private entry [Paul]
 * pluto: Simplify plutodebug= options to: base, cpu-usage, crypt, private and tmi
          (maps old values to new ones for compatibility) [Andrew]
@@ -301,7 +301,7 @@ v3.28 (May 20, 2019)
 * FIPS: Fixup FIPS_IKE_SA_LIFETIME_MAXIMUM to 24h as per NIST SP 800-77 [Paul]
 * FIPS: Force IKE maximum lifetime of 24h (default is 1h) [Paul/Vukasin]
 * XFRM: Use netlink for last remaining obsolete PF_KEY API API calls [Antony]
-* XFRM: Clean up and aadd logging to IPsec SA for nic-offload= [Hugh/Paul]
+* XFRM: Clean up and add logging to IPsec SA for nic-offload= [Hugh/Paul]
 * XFRM: Set default XFRM_LIFETIME_DEFAULT to 30 (was 300) [Paul]
 * libswan: Fix leaks in badly formed secrets/ppk_id [Vukasin Karadzic]
 * libswan: Don't crash on mangled PSK or PPK secrets [Vukasin Karadzic]

--- a/configs/d.ipsec.conf/enable-tcp.xml
+++ b/configs/d.ipsec.conf/enable-tcp.xml
@@ -2,7 +2,7 @@
   <term><emphasis remap='B'>enable-tcp</emphasis></term>
   <listitem>
 <para>
-Normally, IKE negotation and ESP encapsulation happens over UDP. This option enables
+Normally, IKE negotiation and ESP encapsulation happens over UDP. This option enables
 support for IKE and ESP over TCP as per RFC 8229. Acceptable values are 
 <emphasis remap='B'>no</emphasis>(the default), 
 <emphasis remap='B'>yes</emphasis> meaning only TCP will be used, or

--- a/configs/d.ipsec.conf/global-redirect.xml
+++ b/configs/d.ipsec.conf/global-redirect.xml
@@ -13,7 +13,7 @@
   <listitem>
 <para>Where to send remote peers to via the <emphasis remap='B'>global-redirect</emphasis> option. This can be a list, or a single entry, of IP addresses or hostnames (FQDNs).
 	If there is a list of entries, they must be separated with comma's. One specified entry means all peers will be redirected
-	to it, while multiple specified entries means peers will be evenly distributed accross the specified servers.
+	to it, while multiple specified entries means peers will be evenly distributed across the specified servers.
 </para>
   </listitem>
   </varlistentry>

--- a/configs/d.ipsec.conf/protostack.xml
+++ b/configs/d.ipsec.conf/protostack.xml
@@ -1,7 +1,7 @@
   <varlistentry>
   <term><emphasis remap='B'>protostack</emphasis></term>
   <listitem>
-<para>decide which protocol stack is going to be used. Valid values are "xfrm" and  "bsd". This option should no longer be set, as the stack is currently auto-detected. The values "klips, "mast", "netkey", "native", "kame" and "auto" are obsolte. The option is kept only because it is suspected that Linux and BSD will get userspace stacks with IPsec support soon (such as dpdk).
+<para>decide which protocol stack is going to be used. Valid values are "xfrm" and  "bsd". This option should no longer be set, as the stack is currently auto-detected. The values "klips, "mast", "netkey", "native", "kame" and "auto" are obsolete. The option is kept only because it is suspected that Linux and BSD will get userspace stacks with IPsec support soon (such as dpdk).
 </para>
   </listitem>
   </varlistentry>

--- a/configs/ipsec.conf.in
+++ b/configs/ipsec.conf.in
@@ -12,7 +12,7 @@ config setup
 	#
 	# Debugging should only be used to find bugs, not configuration issues!
 	# "base" regular debug, "tmi" is excessive (!) and "private" will log
-	# senstive key material (not available in FIPS mode). The "cpu-usage"
+	# sensitive key material (not available in FIPS mode). The "cpu-usage"
 	# value logs timing information and should not be used with other
 	# debug options as it will defeat getting accurate timing information.
 	# Default is "none"

--- a/configs/ipsec.secrets.5.xml
+++ b/configs/ipsec.secrets.5.xml
@@ -25,7 +25,7 @@ a list of secrets. Currently supported secrets are preshared secrets
 (PSKs), postquantum preshared keys (PPKs) and XAUTH passwords.  As of
 libreswan version 4.0, the secrets entries for raw RSA keys are no longer
 needed and ignored. All private keys from public keypairs (RSA or ECDSA)
-are stored completely in the NSS databas and :RSA entries are no longer
+are stored completely in the NSS database and :RSA entries are no longer
 required to locate these.</para>
 
 <para>These secrets are used by

--- a/docs/README.XAUTH
+++ b/docs/README.XAUTH
@@ -17,7 +17,7 @@ Addresspool support added by Antony Antony in Libreswan
 
 Installation:
 
-1.  If you want to be able to yse PAM to authenticate XAUTH users, you need
+1.  If you want to be able to use PAM to authenticate XAUTH users, you need
     to also set USE_XAUTHPAM=true in Makefile.inc.
 
 2.  Build & Install as normal.

--- a/include/crypt_mac.h
+++ b/include/crypt_mac.h
@@ -26,7 +26,7 @@
  * See also ike_alg_init() for runtime check that the array is big
  * enough.
  *
- * XXX: the field names (noteably the counter intuitive .ptr) are
+ * XXX: the field names (notably the counter intuitive .ptr) are
  * chosen so that this structure is "hunk" like and works with hunk()
  * macros.
  *

--- a/include/ike_alg_prf_ikev1_ops.h
+++ b/include/ike_alg_prf_ikev1_ops.h
@@ -135,7 +135,7 @@ struct prf_ikev1_ops {
 					   struct logger *logger);
 
 	/*
-	 * Setion 5.5 - CHILD (IPSEC) SA keys & Quick Mode
+	 * Section 5.5 - CHILD (IPSEC) SA keys & Quick Mode
 	 *
 	 * If PFS is not needed, and KE payloads are not exchanged,
 	 * the new keying material is defined as

--- a/include/ip_encap.h
+++ b/include/ip_encap.h
@@ -20,7 +20,7 @@
  * IKETCP.
  *
  * XXX: Confusingly mode (TUNNEL, TRANSPORT) is also (understandably)
- * refered to as encapsulation :-(
+ * referred to as encapsulation :-(
  */
 
 #ifndef IP_ENCAP_H

--- a/include/ipsecconf/keywords.h
+++ b/include/ipsecconf/keywords.h
@@ -291,7 +291,7 @@ enum keyword_numeric_conn_field {
 enum keyword_valid {
 	kv_config = LELEM(0),           /* may be present in config section */
 	kv_conn   = LELEM(1),           /* may be present in conn section */
-	kv_leftright = LELEM(2),        /* comes in leftFOO and rightFOO varients */
+	kv_leftright = LELEM(2),        /* comes in leftFOO and rightFOO variants */
 	kv_alias  = LELEM(5),           /* is an alias for another keyword */
 	kv_policy = LELEM(6),           /* is a policy affecting verb, processed specially */
 	kv_processed = LELEM(7),        /* is processed, do not output literal string */

--- a/include/jambuf.h
+++ b/include/jambuf.h
@@ -65,7 +65,7 @@
  *
  *   TOTAL < ROOF => ARRAY[TOTAL] == '\0'
  *
- * When TOTAL>=ROOF, overflow has occured and no further characters are
+ * When TOTAL>=ROOF, overflow has occurred and no further characters are
  * written.
  *
  * When TOTAL==ROOF-1 the buffer is full.  Technically there is still

--- a/include/lswlog.h
+++ b/include/lswlog.h
@@ -400,7 +400,7 @@ void lswbuf(struct jambuf *log)
  * When evaluating ASSERTION, do not wrap it in parentheses as it will
  * suppress the warning for 'foo = bar'.
  *
- * Because static analizer tools are easily confused, explicitly
+ * Because static analyzer tools are easily confused, explicitly
  * return the assertion result.
  */
 

--- a/include/lswnss.h
+++ b/include/lswnss.h
@@ -44,7 +44,7 @@ void lsw_nss_shutdown(void);
 
 /*
  * Any code that could call back into lsw_nss_get_password() needs to
- * pass in a context parameter - the logger is it.  Otherwize the
+ * pass in a context parameter - the logger is it.  Otherwise the
  * password code can't log!
  *
  * Just a wrapper but type checked.

--- a/include/pluto_constants.h
+++ b/include/pluto_constants.h
@@ -576,7 +576,7 @@ extern enum_names perspective_names;
  * (to a request) as determined by the IKEv2 "R (Response)" flag.
  *
  * Since either end can initiate a request either end can set the
- * R(Repsonse) flag.
+ * R(Response) flag.
  *
  * During a CHILD_SA exchange it is the request initiator (receives
  * the MESSAGE_RESPONSE) and request responder (receives the

--- a/lib/libbsdpfkey/pfkey.c
+++ b/lib/libbsdpfkey/pfkey.c
@@ -207,7 +207,7 @@ setsupportedmap(struct sadb_supported *sup)
 /*
  * check key length against algorithm specified.
  * This function is called with SADB_EXT_SUPPORTED_{AUTH,ENCRYPT} as the
- * augument, and only calls to ipsec_check_keylen2();
+ * argument, and only calls to ipsec_check_keylen2();
  * keylen is the unit of bit.
  * OUT:
  *	-1: invalid.
@@ -365,7 +365,7 @@ pfkey_get_softrate(u_int type)
  * sending SADB_GETSPI message to the kernel.
  * OUT:
  *	positive: success and return length sent.
- *	-1	: error occured, and set errno.
+ *	-1	: error occurred, and set errno.
  */
 int
 pfkey_send_getspi_nat(int so, u_int satype, u_int mode, struct sockaddr *src,
@@ -487,7 +487,7 @@ pfkey_send_getspi_nat(int so, u_int satype, u_int mode, struct sockaddr *src,
 	}
 #endif
 
-	/* proccessing spi range */
+	/* processing spi range */
 	if (need_spirange) {
 		struct sadb_spirange spirange;
 
@@ -536,7 +536,7 @@ pfkey_send_getspi(int so, u_int satype, u_int mode, struct sockaddr *src,
  * The length of key material is a_keylen + e_keylen.
  * OUT:
  *	positive: success and return length sent.
- *	-1	: error occured, and set errno.
+ *	-1	: error occurred, and set errno.
  */
 int
 pfkey_send_update2(struct pfkey_send_sa_args *sa_parms)
@@ -555,7 +555,7 @@ pfkey_send_update2(struct pfkey_send_sa_args *sa_parms)
  * The length of key material is a_keylen + e_keylen.
  * OUT:
  *	positive: success and return length sent.
- *	-1	: error occured, and set errno.
+ *	-1	: error occurred, and set errno.
  */
 int
 pfkey_send_add2(struct pfkey_send_sa_args *sa_parms)
@@ -573,7 +573,7 @@ pfkey_send_add2(struct pfkey_send_sa_args *sa_parms)
  * sending SADB_DELETE message to the kernel.
  * OUT:
  *	positive: success and return length sent.
- *	-1	: error occured, and set errno.
+ *	-1	: error occurred, and set errno.
  */
 int
 pfkey_send_delete(int so, u_int satype, u_int mode, struct sockaddr *src,
@@ -593,7 +593,7 @@ pfkey_send_delete(int so, u_int satype, u_int mode, struct sockaddr *src,
  *
  * OUT:
  *	positive: success and return length sent
- *	-1	: error occured, and set errno
+ *	-1	: error occurred, and set errno
  */
 /*ARGSUSED*/
 int
@@ -674,7 +674,7 @@ pfkey_send_delete_all(int so, u_int satype, u_int mode UNUSED, struct sockaddr *
  * sending SADB_GET message to the kernel.
  * OUT:
  *	positive: success and return length sent.
- *	-1	: error occured, and set errno.
+ *	-1	: error occurred, and set errno.
  */
 int
 pfkey_send_get(int so, u_int satype, u_int mode, struct sockaddr *src,
@@ -691,7 +691,7 @@ pfkey_send_get(int so, u_int satype, u_int mode, struct sockaddr *src,
  * sending SADB_REGISTER message to the kernel.
  * OUT:
  *	positive: success and return length sent.
- *	-1	: error occured, and set errno.
+ *	-1	: error occurred, and set errno.
  */
 int
 pfkey_send_register(int so, u_int satype)
@@ -731,7 +731,7 @@ pfkey_send_register(int so, u_int satype)
  * sadb_supported returned into ipsec_supported.
  * OUT:
  *	 0: success and return length sent.
- *	-1: error occured, and set errno.
+ *	-1: error occurred, and set errno.
  */
 int
 pfkey_recv_register(int so)
@@ -767,10 +767,10 @@ pfkey_recv_register(int so)
  * sadb_supported returned into ipsec_supported.
  * NOTE: sadb_msg_len must be host order.
  * IN:
- *	tlen: msg length, it's to makeing sure.
+ *	tlen: msg length, it's to make sure.
  * OUT:
  *	 0: success and return length sent.
- *	-1: error occured, and set errno.
+ *	-1: error occurred, and set errno.
  */
 int
 pfkey_set_supported(struct sadb_msg *msg, int tlen)
@@ -832,7 +832,7 @@ pfkey_set_supported(struct sadb_msg *msg, int tlen)
  * sending SADB_FLUSH message to the kernel.
  * OUT:
  *	positive: success and return length sent.
- *	-1	: error occured, and set errno.
+ *	-1	: error occurred, and set errno.
  */
 int
 pfkey_send_flush(int so, u_int satype)
@@ -849,7 +849,7 @@ pfkey_send_flush(int so, u_int satype)
  * sending SADB_DUMP message to the kernel.
  * OUT:
  *	positive: success and return length sent.
- *	-1	: error occured, and set errno.
+ *	-1	: error occurred, and set errno.
  */
 int
 pfkey_send_dump(int so, u_int satype)
@@ -869,8 +869,8 @@ pfkey_send_dump(int so, u_int satype)
  *	flag:	set promisc off if zero, set promisc on if non-zero.
  * OUT:
  *	positive: success and return length sent.
- *	-1	: error occured, and set errno.
- *	0     : error occured, and set errno.
+ *	-1	: error occurred, and set errno.
+ *	0     : error occurred, and set errno.
  *	others: a pointer to new allocated buffer in which supported
  *	        algorithms is.
  */
@@ -890,7 +890,7 @@ pfkey_send_promisc_toggle(int so, int flag)
  * sending SADB_X_SPDADD message to the kernel.
  * OUT:
  *	positive: success and return length sent.
- *	-1	: error occured, and set errno.
+ *	-1	: error occurred, and set errno.
  */
 int
 pfkey_send_spdadd(int so, struct sockaddr *src, u_int prefs,
@@ -912,7 +912,7 @@ pfkey_send_spdadd(int so, struct sockaddr *src, u_int prefs,
  * sending SADB_X_SPDADD message to the kernel.
  * OUT:
  *	positive: success and return length sent.
- *	-1	: error occured, and set errno.
+ *	-1	: error occurred, and set errno.
  */
 int
 pfkey_send_spdadd2(int so, struct sockaddr *src, u_int prefs,
@@ -934,7 +934,7 @@ pfkey_send_spdadd2(int so, struct sockaddr *src, u_int prefs,
  * sending SADB_X_SPDUPDATE message to the kernel.
  * OUT:
  *	positive: success and return length sent.
- *	-1	: error occured, and set errno.
+ *	-1	: error occurred, and set errno.
  */
 int
 pfkey_send_spdupdate(int so, struct sockaddr *src, u_int prefs,
@@ -956,7 +956,7 @@ pfkey_send_spdupdate(int so, struct sockaddr *src, u_int prefs,
  * sending SADB_X_SPDUPDATE message to the kernel.
  * OUT:
  *	positive: success and return length sent.
- *	-1	: error occured, and set errno.
+ *	-1	: error occurred, and set errno.
  */
 int
 pfkey_send_spdupdate2(int so, struct sockaddr *src, u_int prefs,
@@ -978,7 +978,7 @@ pfkey_send_spdupdate2(int so, struct sockaddr *src, u_int prefs,
  * sending SADB_X_SPDDELETE message to the kernel.
  * OUT:
  *	positive: success and return length sent.
- *	-1	: error occured, and set errno.
+ *	-1	: error occurred, and set errno.
  */
 int
 pfkey_send_spddelete(int so, struct sockaddr *src, u_int prefs,
@@ -1005,7 +1005,7 @@ pfkey_send_spddelete(int so, struct sockaddr *src, u_int prefs,
  * sending SADB_X_SPDDELETE message to the kernel.
  * OUT:
  *	positive: success and return length sent.
- *	-1	: error occured, and set errno.
+ *	-1	: error occurred, and set errno.
  */
 int
 pfkey_send_spddelete2(int so, u_int32_t spid)
@@ -1022,7 +1022,7 @@ pfkey_send_spddelete2(int so, u_int32_t spid)
  * sending SADB_X_SPDGET message to the kernel.
  * OUT:
  *	positive: success and return length sent.
- *	-1	: error occured, and set errno.
+ *	-1	: error occurred, and set errno.
  */
 int
 pfkey_send_spdget(int so, u_int32_t spid)
@@ -1039,7 +1039,7 @@ pfkey_send_spdget(int so, u_int32_t spid)
  * sending SADB_X_SPDSETIDX message to the kernel.
  * OUT:
  *	positive: success and return length sent.
- *	-1	: error occured, and set errno.
+ *	-1	: error occurred, and set errno.
  */
 int
 pfkey_send_spdsetidx(int so, struct sockaddr *src, u_int prefs,
@@ -1066,7 +1066,7 @@ pfkey_send_spdsetidx(int so, struct sockaddr *src, u_int prefs,
  * sending SADB_SPDFLUSH message to the kernel.
  * OUT:
  *	positive: success and return length sent.
- *	-1	: error occured, and set errno.
+ *	-1	: error occurred, and set errno.
  */
 int
 pfkey_send_spdflush(int so)
@@ -1083,7 +1083,7 @@ pfkey_send_spdflush(int so)
  * sending SADB_SPDDUMP message to the kernel.
  * OUT:
  *	positive: success and return length sent.
- *	-1	: error occured, and set errno.
+ *	-1	: error occurred, and set errno.
  */
 int
 pfkey_send_spddump(int so)
@@ -1102,7 +1102,7 @@ pfkey_send_spddump(int so)
  * sending SADB_X_MIGRATE message to the kernel.
  * OUT:
  *	positive: success and return length sent.
- *	-1	: error occured, and set errno.
+ *	-1	: error occurred, and set errno.
  */
 int
 pfkey_send_migrate(int so, struct sockaddr *local, struct sockaddr *remote,
@@ -1865,7 +1865,7 @@ pfkey_close(int so)
  * receive sadb_msg data, and return pointer to new buffer allocated.
  * Must free this buffer later.
  * OUT:
- *	NULL	: error occured.
+ *	NULL	: error occurred.
  *	others	: a pointer to sadb_msg structure.
  *
  * XXX should be rewritten to pass length explicitly

--- a/lib/libbsdpfkey/pfkey_dump.c
+++ b/lib/libbsdpfkey/pfkey_dump.c
@@ -221,7 +221,7 @@ static struct val2str str_alg_comp[] = {
 };
 
 /*
- * dump SADB_MSG formated.  For debugging, you should use kdebug_sadb().
+ * dump SADB_MSG formatted.  For debugging, you should use kdebug_sadb().
  */
 
 void
@@ -534,7 +534,7 @@ pfkey_spdump1(struct sadb_msg *m, int withports)
 	m_sec_ctx = (struct sadb_x_sec_ctx *)mhp[SADB_X_EXT_SEC_CTX];
 #endif
 #ifdef __linux__
-	/* *bsd indicates per-socket policies by omiting src and dst 
+	/* *bsd indicates per-socket policies by omitting src and dst 
 	 * extensions. Linux always includes them, but we can catch it
 	 * by checkin for policy id.
 	 */

--- a/lib/libswan/alg_byname.c
+++ b/lib/libswan/alg_byname.c
@@ -151,7 +151,7 @@ const struct ike_alg *encrypt_alg_byname(struct proposal_parser *parser,
 				    parser->protocol->name,
 				    encrypt->common.fqn,
 				    key_bit_length);
-				/* reverse: table in decending order with trailing zeros */
+				/* reverse: table in descending order with trailing zeros */
 				const char *sep = " ";
 				for (int i = elemsof(encrypt->key_bit_lengths) - 1; i >= 0; i--) {
 					if (encrypt->key_bit_lengths[i] > 0) {

--- a/lib/libswan/chunk.c
+++ b/lib/libswan/chunk.c
@@ -95,7 +95,7 @@ chunk_t clone_bytes_as_chunk(const void *bytes, size_t sizeof_bytes, const char 
 chunk_t chunk_from_hex(const char *hex, const char *name)
 {
 	/*
-	 * The decoded buffer (consiting of can't be bigger than half the encoded
+	 * The decoded buffer (consisting of can't be bigger than half the encoded
 	 * string.
 	 */
 	chunk_t chunk = alloc_chunk((strlen(hex)+1)/2, name);

--- a/lib/libswan/crypt_symkey.c
+++ b/lib/libswan/crypt_symkey.c
@@ -608,7 +608,7 @@ PK11SymKey *key_from_symkey_bytes(PK11SymKey *source_key,
  * target=CKM_CONCATENATE_BASE_AND_DATA it used
  * target=hasher-to-ckm(hasher).
  *
- * hasher-to-ckm maped hasher->common.alg_id to CMK vis: OAKLEY_MD5 ->
+ * hasher-to-ckm mapped hasher->common.alg_id to CMK vis: OAKLEY_MD5 ->
  * CKM_MD5; OAKLEY_SHA1 -> CKM_SHA_1; OAKLEY_SHA2_256 -> CKM_SHA256;
  * OAKLEY_SHA2_384 -> CKM_SHA384; OAKLEY_SHA2_512 -> CKM_SHA512; only
  * in the default case it would set target to 0x80000000????

--- a/lib/libswan/netlink_attrib.c
+++ b/lib/libswan/netlink_attrib.c
@@ -1,5 +1,5 @@
 /*
- * netlink atrributes to message, for libreswan
+ * netlink attributes to message, for libreswan
  *
  * Copyright (C) 2018-2020 Antony Antony <antony@phenome.org>
  * A part of this came from iproute2 lib/libnetlink.c

--- a/lib/libswan/shunk.c
+++ b/lib/libswan/shunk.c
@@ -238,7 +238,7 @@ err_t shunk_to_uintmax(shunk_t input, shunk_t *output, unsigned base,
 		}
 	}
 
-	/* everyting consumed? */
+	/* everything consumed? */
 	if (output == NULL) {
 		if (cursor.len > 0) {
 			switch (base) {

--- a/lib/libswan/x509dn.c
+++ b/lib/libswan/x509dn.c
@@ -428,7 +428,7 @@ static err_t format_dn(struct jambuf *buf, chunk_t dn,
 			 * - a space (' ' U+0020) character occurring
 			 *   at the end of the string;
 			 *
-			 * Again note the singlar - a space - I guess
+			 * Again note the singular - a space - I guess
 			 * the parser tosses a run of un-escaped
 			 * spaces before a separator.
 			 */

--- a/mk/TODO.md
+++ b/mk/TODO.md
@@ -95,7 +95,7 @@ The following are quirks in the test infrastructure:
 
 - have *init.sh et.al. scripts always succeed.  This means that
   commands like ping that are expected to fail (demonstrating no
-  conectivity) will need a "!" prefix so the failure is success.
+  connectivity) will need a "!" prefix so the failure is success.
 
 - simplify fips check
 

--- a/mk/docker-targets.mk
+++ b/mk/docker-targets.mk
@@ -171,7 +171,7 @@ install-testing-deb-dep: install-deb-dep
 
 .PHONY: install-deb-dep
 # RUN_DEBS_OLD ?= $$(grep -qE 'jessie|xenial' /etc/os-release && echo "host iptables")
-# hard codde these two packages it fail on xenial and old ones.
+# hard code these two packages it fail on xenial and old ones.
 # on buster host is virtual package
 RUN_DEBS_OLD ?= bind9-host iptables
 RUN_DEBS ?= $$(test -f /usr/bin/apt-cache && apt-cache depends libreswan | awk '/Depends:/{print $$2}' | grep -v "<" | sort -u)
@@ -238,7 +238,7 @@ docker-image: dockerfile $(TWEAKS) docker-ssh-image docker-build
 	echo "done docker image tag $(DI_T) from $(DISTRO)-$(DISTRO_REL) with ssh"
 
 
-# NEW tragets to get docker handling 201906
+# NEW targets to get docker handling 201906
 .PHONY: docker-instance-name
 docker-instance-name:
 	echo $(DI_T)

--- a/mk/kvm-targets.mk
+++ b/mk/kvm-targets.mk
@@ -1061,7 +1061,7 @@ $(eval $(call kvm-hosts-domains,shutdown))
 # For kvm-uninstall, instead of trying to uninstall libreswan from the
 # $(KVM_BUILD_DOMAIN_CLONES), delete both $(KVM_BUILD_DOMAIN_CLONES) and
 # $(KVM_BUILD_DOMAIN) the install domains were cloned from.  This way,
-# in addition to giving kvm-install a 100% fresh start (no depdenence
+# in addition to giving kvm-install a 100% fresh start (no dependence
 # on 'make uninstall') the next test run also gets entirely new
 # domains.
 
@@ -1361,7 +1361,7 @@ Domains and networks:
           directory's test domains
         - uninstall dependencies: test domains
 
-Manually building and modifing the base domain and network:
+Manually building and modifying the base domain and network:
 
   Normally kvm-install et.al, below, are sufficient.  However ....
 

--- a/mk/rules.mk
+++ b/mk/rules.mk
@@ -12,7 +12,7 @@ $(builddir):
 # script transforms
 
 # Some Makefiles use $(buildir)/SCRIPT as the target while others use
-# just SCRIPT.  Accomodate both.
+# just SCRIPT.  Accommodate both.
 
 define transform_script
 	@echo  'IN' $< '->' $(builddir)/$@

--- a/programs/pluto/connections.c
+++ b/programs/pluto/connections.c
@@ -398,7 +398,7 @@ void update_ends_from_this_host_addr(struct end *this, struct end *that)
 		this->has_id_wildcards = FALSE;
 	}
 
-	/* propogate this HOST_ADDR to that. */
+	/* propagate this HOST_ADDR to that. */
 	if (address_is_unset(&that->host_nexthop) ||
 	    address_is_any(&that->host_nexthop)) {
 		that->host_nexthop = this->host_addr;

--- a/programs/pluto/iface.c
+++ b/programs/pluto/iface.c
@@ -305,7 +305,7 @@ static void add_new_ifaces(struct logger *logger)
 		 *
 		 * An explicit {left,right}IKEPORT must enable
 		 * ESPINUDP so that it can tunnel NAT.  This means
-		 * that incomming packets must add the ESP=0 prefix,
+		 * that incoming packets must add the ESP=0 prefix,
 		 * which in turn means that it can't interop with port
 		 * 500 as that port will never send the ESP=0 prefix.
 		 *

--- a/programs/pluto/iface_udp.c
+++ b/programs/pluto/iface_udp.c
@@ -359,7 +359,7 @@ static enum iface_status udp_read_packet(const struct iface_endpoint *ifp,
 
 	if (packet->len == 1 && packet->ptr[0] == 0xff) {
 		/**
-		 * NAT-T Keep-alive packets should be discared by kernel ESPinUDP
+		 * NAT-T Keep-alive packets should be discarded by kernel ESPinUDP
 		 * layer. But bogus keep-alive packets (sent with a non-esp marker)
 		 * can reach this point. Complain and discard them.
 		 * Possibly too if the NAT mapping vanished on the initiator NAT gw ?

--- a/programs/pluto/ikev2_auth.c
+++ b/programs/pluto/ikev2_auth.c
@@ -52,7 +52,7 @@ struct crypt_mac v2_calculate_sighash(const struct ike_sa *ike,
 	/*
 	 * NOTE: intermediate_auth is only initialized to quiet GCC.
 	 * It doesn't understand that all uses and references are
-	 * guarded indentically, with ike->sa.st_intermediate_used.
+	 * guarded identically, with ike->sa.st_intermediate_used.
 	 * Using a local copy ike->sa.st_intermediate_used doesn't help.
 	 * DHR 2020 Sept 12; GCC 10.2.1
 	 */

--- a/programs/pluto/ikev2_message.c
+++ b/programs/pluto/ikev2_message.c
@@ -120,7 +120,7 @@ struct pbs_out open_v2_message(struct pbs_out *message,
 	 * If there is no IKE SA, then, presumably, this is a response
 	 * to an initial exchange and the flag should be clear.
 	 *
-	 * The other possability is that this is a response to an
+	 * The other possibility is that this is a response to an
 	 * IKEv++ message, just assume this is the initial exchange
 	 * and the I flag should be clear (see 1.5.  Informational
 	 * Messages outside of an IKE SA).  The other option would be

--- a/programs/pluto/ikev2_parent.c
+++ b/programs/pluto/ikev2_parent.c
@@ -2646,7 +2646,7 @@ static stf_status ikev2_ike_sa_process_auth_request_no_keymat_continue(struct st
 	return STF_SKIP_COMPLETE_STATE_TRANSITION;
 }
 
-static dh_shared_secret_cb ikev2_ike_sa_process_intermediate_request_no_skeyid_continue;	/* type asssertion */
+static dh_shared_secret_cb ikev2_ike_sa_process_intermediate_request_no_skeyid_continue;	/* type assertion */
 
 stf_status ikev2_ike_sa_process_intermediate_request_no_skeyid(struct ike_sa *ike,
 						       struct child_sa *child,
@@ -6274,7 +6274,7 @@ void ikev2_addr_change(struct state *st)
 	{
 		/* keep this DEBUG, if a libreswan log, too many false +ve */
 		address_buf b;
-		dbg("#%lu no local gatway to reach %s",
+		dbg("#%lu no local gateway to reach %s",
 		    st->st_serialno, str_address(&that.addr, &b));
 		break;
 	}

--- a/programs/pluto/ikev2_spdb_struct.c
+++ b/programs/pluto/ikev2_spdb_struct.c
@@ -1553,7 +1553,7 @@ bool ikev2_emit_sa_proposals(struct pbs_out *pbs,
 	FOR_EACH_V2_PROPOSAL(propnum, proposal, proposals) {
 		/*
 		 * Initiator doesn't normally send a single
-		 * tranform=NONE.
+		 * transform=NONE.
 		 */
 		if (!emit_proposal(&sa_pbs, proposal, propnum, local_spi,
 				   (propnum < proposals->roof - 1
@@ -1585,12 +1585,12 @@ bool ikev2_emit_sa_proposal(pb_stream *pbs,
 	}
 
 	/*
-	 * Responder will include TRANFORM=NONE if it was sent by the
+	 * Responder will include TRANSFORM=NONE if it was sent by the
 	 * initiator.
 	 */
 	if (!emit_proposal(&sa_pbs, proposal, proposal->propnum,
 			   local_spi, v2_PROPOSAL_LAST,
-			   true/*allow-single-tranform=NONE*/)) {
+			   true/*allow-single-transform=NONE*/)) {
 		return FALSE;
 	}
 

--- a/programs/pluto/initiate.c
+++ b/programs/pluto/initiate.c
@@ -87,7 +87,7 @@ static void swap_ends(struct connection *c)
 
 	/*
 	 * in case of asymmetric auth c->policy contains left.authby
-	 * This magic will help responder to find connction during INIT
+	 * This magic will help responder to find connection during INIT
 	 */
 	if (sr->this.authby != sr->that.authby)
 	{

--- a/programs/pluto/kernel.c
+++ b/programs/pluto/kernel.c
@@ -3124,7 +3124,7 @@ bool migrate_ipsec_sa(struct state *st)
 		return true;
 
 	default:
-		dbg("Usupported kernel stack in migrate_ipsec_sa");
+		dbg("Unsupported kernel stack in migrate_ipsec_sa");
 		return false;
 	}
 }

--- a/programs/pluto/kernel_linux.c
+++ b/programs/pluto/kernel_linux.c
@@ -248,7 +248,7 @@ struct raw_iface *find_raw_ifaces6(struct logger *unused_logger UNUSED)
 		}
 		fclose(proc_sock);
 		/*
-		 * Sort the list by IPv6 address in assending order.
+		 * Sort the list by IPv6 address in ascending order.
 		 *
 		 * XXX: The code then inserts these interfaces in
 		 * _reverse_ order (why I don't know) - the loop-back

--- a/programs/pluto/kernel_xfrm.c
+++ b/programs/pluto/kernel_xfrm.c
@@ -249,7 +249,7 @@ static void init_netlink_route_fd(struct logger *logger)
 
 
 /*
- * init_netlink - Initialize the netlink inferface.  Opens the sockets and
+ * init_netlink - Initialize the netlink interface.  Opens the sockets and
  * then binds to the broadcast socket.
  */
 static void init_netlink(struct logger *logger)

--- a/programs/pluto/log.h
+++ b/programs/pluto/log.h
@@ -175,7 +175,7 @@ void rate_log(const struct msg_digest *md,
 /*
  * Whack only logging.
  *
- * None of these functions add a contex prefix (such as connection
+ * None of these functions add a context prefix (such as connection
  * name).  If that's really really needed then use
  * log_*(WHACK_STREAM,...) above.
  *

--- a/programs/pluto/packet.h
+++ b/programs/pluto/packet.h
@@ -175,7 +175,7 @@ struct packet_byte_stream {
 	 * logger.
 	 *
 	 * IKEv1 uses the global reply_stream which is a sure way to
-	 * break any lifetime guarentees
+	 * break any lifetime guarantees
 	 *
 	 * The input stream logger starts out with MD but then
 	 * switches to a state so more complicated; and its lifetime

--- a/programs/pluto/pam_conv.c
+++ b/programs/pluto/pam_conv.c
@@ -1,4 +1,4 @@
-/* PAM Authentication and Autherization related functions
+/* PAM Authentication and Authorization related functions
  *
  * Copyright (C) 2001-2002 Colubris Networks
  * Copyright (C) 2003 Sean Mathews - Nu Tech Software Solutions, inc.

--- a/programs/pluto/pam_conv.h
+++ b/programs/pluto/pam_conv.h
@@ -1,4 +1,4 @@
-/* PAM Authentication and Autherization related
+/* PAM Authentication and Authorization related
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the

--- a/programs/pluto/state.c
+++ b/programs/pluto/state.c
@@ -985,7 +985,7 @@ void delete_state_tail(struct state *st)
 	}
 
 	/*
-	 * IKEv2 IKE failures are logged in the state transition conpletion.
+	 * IKEv2 IKE failures are logged in the state transition completion.
 	 * IKEv1 IKE failures do not go through a transition, so we catch
 	 * these in delete_state()
 	 */
@@ -1113,7 +1113,7 @@ void delete_state_tail(struct state *st)
 		 *
 		 * ??? in IKEv2, we should not immediately delete:
 		 * we should use an Informational Exchange to
-		 * co-ordinate deletion.
+		 * coordinate deletion.
 		 * ikev2_delete_out doesn't really accomplish this.
 		 */
 		send_delete(st);

--- a/testing/baseconfigs/all/etc/inetd.conf
+++ b/testing/baseconfigs/all/etc/inetd.conf
@@ -1,4 +1,4 @@
-# /etc/inetd.conf:  see inetd(8) for further informations.
+# /etc/inetd.conf:  see inetd(8) for further information.
 #
 # Internet server configuration database
 #


### PR DESCRIPTION
Most of these changes are not likely to be user-visible.  A few
changes do clean up misspellings in the manpages or other
documentation, and there are a couple of spelling corrections in debug
messages too.