### PR TITLE
Add and use PRINTF_LIKE_VA()

### DIFF
--- a/include/diag.h
+++ b/include/diag.h
@@ -28,7 +28,7 @@ enum pluto_exit_code;
 typedef struct diag *diag_t;
 
 diag_t diag(const char *message, ...) PRINTF_LIKE(1) MUST_USE_RESULT;
-diag_t diag_va_list(const char *fmt, va_list ap) MUST_USE_RESULT;
+diag_t diag_va_list(const char *fmt, va_list ap) PRINTF_LIKE_VA(1) MUST_USE_RESULT;
 diag_t diag_jambuf(struct jambuf *buf);
 
 void log_diag(lset_t rc_flags, struct logger *logger, diag_t *diag,

--- a/include/jambuf.h
+++ b/include/jambuf.h
@@ -147,7 +147,7 @@ void jambuf_set_pos(struct jambuf *buf, const jampos_t *pos);
  * trying to pretty-print a table of values.
  */
 
-size_t jam_va_list(struct jambuf *buf, const char *format, va_list ap);
+size_t jam_va_list(struct jambuf *buf, const char *format, va_list ap) PRINTF_LIKE_VA(2);
 size_t jam_raw_bytes(struct jambuf *buf, const void *bytes, size_t nr_bytes);
 
 /* wrap above */

--- a/include/lswalloc.h
+++ b/include/lswalloc.h
@@ -118,6 +118,6 @@ void *uninitialized_realloc(void *ptr, size_t size, const char *name);
 
 /* can't use vaprintf() as it calls malloc() directly */
 char *alloc_printf(const char *fmt, ...) PRINTF_LIKE(1) MUST_USE_RESULT;
-char *alloc_vprintf(const char *fmt, va_list ap) MUST_USE_RESULT;
+char *alloc_vprintf(const char *fmt, va_list ap)  PRINTF_LIKE_VA(1) MUST_USE_RESULT;
 
 #endif /* _LSW_ALLOC_H_ */

--- a/include/lswcdefs.h
+++ b/include/lswcdefs.h
@@ -37,6 +37,7 @@
 /* GCC magic for use in function definitions! */
 #ifdef GCC_LINT
 # define PRINTF_LIKE(n) __attribute__ ((format(printf, n, n + 1)))
+# define PRINTF_LIKE_VA(n) __attribute__((format(printf, n, 0)))
 # define STRFTIME_LIKE(n) __attribute__ ((format (strftime, n, 0)))
 # define NEVER_RETURNS __attribute__ ((noreturn))
 # define UNUSED __attribute__ ((unused))

--- a/include/lswlog.h
+++ b/include/lswlog.h
@@ -229,7 +229,7 @@ void llog(lset_t rc_flags,
 	  const char *format, ...) PRINTF_LIKE(3);
 
 void llog_va_list(lset_t rc_flags, const struct logger *logger,
-		 const char *message, va_list ap);
+		 const char *message, va_list ap) PRINTF_LIKE_VA(3);
 
 void jambuf_to_logger(struct jambuf *buf, const struct logger *logger, lset_t rc_flags);
 

--- a/lib/libswan/log_nss_error.c
+++ b/lib/libswan/log_nss_error.c
@@ -27,6 +27,7 @@
  * See https://bugzilla.mozilla.org/show_bug.cgi?id=172051
  */
 
+PRINTF_LIKE_VA(2)
 static void jam_va_nss_error(struct jambuf *buf, const char *message, va_list ap)
 {
 	jam(buf, "NSS: ");

--- a/programs/pluto/ikev2_msgid.c
+++ b/programs/pluto/ikev2_msgid.c
@@ -88,6 +88,7 @@ static void jam_wip_sa(struct jambuf *buf, const char *who,
 	}
 }
 
+PRINTF_LIKE_VA(4)
 static void jam_v2_msgid(struct jambuf *buf,
 			 struct ike_sa *ike, struct state *wip_sa,
 			 const char *fmt, va_list ap)

--- a/programs/pluto/log.c
+++ b/programs/pluto/log.c
@@ -325,6 +325,7 @@ static unsigned log_limit(void)
 	}
 }
 
+PRINTF_LIKE_VA(3)
 static void rate_log_raw(const char *prefix,
 			 struct logger *logger,
 			 const char *message,


### PR DESCRIPTION
Clang is more strict about checking printf-like format strings. Add a
PRINTF_LIKE_VA() macro that evaluates to the proper __attribute__(())
and use that where needed.