### PR TITLE
Avoid adding integers to strings

### DIFF
--- a/lib/libswan/jam_nss_cka.c
+++ b/lib/libswan/jam_nss_cka.c
@@ -24,7 +24,8 @@
 size_t jam_nss_cka(struct jambuf *buf, CK_ATTRIBUTE_TYPE attribute)
 {
 	switch (attribute) {
-#define CASE(T) case T: return jam_string(buf, #T + strlen("CKA_"))
+		/* Not using #T + strlen("CKA_") because of clang's -Wstring-plus-int */
+#define CASE(T) case T: return jam_string(buf, &#T[strlen("CKA_")])
 		CASE(CKA_DERIVE);
 		CASE(CKA_FLAGS_ONLY);
 		CASE(CKA_WRAP);

--- a/lib/libswan/jam_nss_ckf.c
+++ b/lib/libswan/jam_nss_ckf.c
@@ -29,7 +29,8 @@ size_t jam_nss_ckf(struct jambuf *buf, CK_FLAGS flags)
 #define FLAG(F) \
 	if (flags & F) {					\
 		size += jam_string(buf, sep);			\
-		size += jam_string(buf, #F + strlen("CKF_"));	\
+		/* Not using #T + strlen("CKF_") because of clang's -Wstring-plus-int */
+		size += jam_string(buf, &#F[strlen("CKF_")]);	\
 		sep = "+";					\
 		flags ^= F;					\
 	}

--- a/lib/libswan/jam_nss_ckm.c
+++ b/lib/libswan/jam_nss_ckm.c
@@ -24,7 +24,8 @@
 size_t jam_nss_ckm(struct jambuf *buf, CK_MECHANISM_TYPE mechanism)
 {
 	switch (mechanism) {
-#define CASE(T) case T: return jam_string(buf, #T + strlen("CKM_"))
+		/* Not using #T + strlen("CKM_") because of clang's -Wstring-plus-int */
+#define CASE(T) case T: return jam_string(buf, &#T[strlen("CKM_")])
 
 		CASE(CKM_CONCATENATE_BASE_AND_DATA);
 		CASE(CKM_CONCATENATE_BASE_AND_KEY);

--- a/programs/pluto/ikev1_states.c
+++ b/programs/pluto/ikev1_states.c
@@ -33,7 +33,8 @@ struct finite_state v1_states[] = {
 #define S(KIND, STORY, CAT) [KIND - STATE_IKEv1_FLOOR] = {	\
 		.kind = KIND,					\
 		.name = #KIND,					\
-		.short_name = #KIND + 6/*STATE_*/,		\
+		/* Not using #KIND + 6 because of clang's -Wstring-plus-int */
+		.short_name = &#KIND[6]/*STATE_*/,		\
 		.story = STORY,					\
 		.category = CAT,				\
 	}

--- a/programs/pluto/ikev2_states.c
+++ b/programs/pluto/ikev2_states.c
@@ -41,7 +41,8 @@ struct finite_state v2_states[] = {
 #define S(KIND, STORY, CAT) [KIND - STATE_IKEv2_FLOOR] = {	\
 		.kind = KIND,					\
 		.name = #KIND,					\
-		.short_name = #KIND + 6/*STATE_*/,		\
+		/* Not using #KIND + 6 because of clang's -Wstring-plus-int */
+		.short_name = &#KIND[6]/*STATE_*/,		\
 		.story = STORY,					\
 		.category = CAT,				\
 	}
@@ -49,7 +50,8 @@ struct finite_state v2_states[] = {
 #define V2(KIND, STORY, CAT) [KIND - STATE_IKEv2_FLOOR] = {	\
 		.kind = KIND,					\
 		.name = #KIND,					\
-		.short_name = #KIND + 9/*STATE_V2_*/,		\
+		/* Not using #KIND + 9 because of clang's -Wstring-plus-int */
+		.short_name = &#KIND[9]/*STATE_V2_*/,		\
 		.story = STORY,					\
 		.category = CAT,				\
 	}


### PR DESCRIPTION
Although a common C idiom, clang warns about this:

lib/libswan/jam_nss_ckf.c:36:2: error: adding 'unsigned long' to a string does not append to the string [-Werror,-Wstring-plus-int]
        FLAG(CKF_SIGN);
        ^~~~~~~~~~~~~~
lib/libswan/jam_nss_ckf.c:32:30: note: expanded from macro 'FLAG'
                size += jam_string(buf, #F + strlen("CKF_"));   \
                                        ~~~^~~~~~~~~~~~~~~~

Fix this by using an array index instead.