### PR TITLE
pluto: Fix potential operator precedence problem

### DIFF
--- a/programs/pluto/connections.c
+++ b/programs/pluto/connections.c
@@ -4090,8 +4090,8 @@ void show_one_connection(struct show *s,
 		  c->name, instance,
 		  prettypolicy(c->policy),
 		  NEVER_NEGOTIATE(c->policy) ? "+NEVER_NEGOTIATE" : "",
-		  c->spd.this.key_from_DNS_on_demand |
-			c->spd.that.key_from_DNS_on_demand ? "; " : "",
+		  (c->spd.this.key_from_DNS_on_demand |
+			c->spd.that.key_from_DNS_on_demand) ? "; " : "",
 		  c->spd.this.key_from_DNS_on_demand ? "+lKOD" : "",
 		  c->spd.that.key_from_DNS_on_demand ? "+rKOD" : "");
 


### PR DESCRIPTION
Clang complains here because the ternary :? operator has lower
precedence than the bitwise or:
```
programs/pluto/connections.c:4094:39: error: operator '?:' has lower precedence than '|'; '|' will be evaluated first [-Werror,-Wbitwise-conditional-parentheses]
                        c->spd.that.key_from_DNS_on_demand ? "; " : "",
                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
programs/pluto/connections.c:4094:39: note: place parentheses around the '|' expression to silence this warning
                        c->spd.that.key_from_DNS_on_demand ? "; " : "",
                                                           ^
                                                          )
programs/pluto/connections.c:4094:39: note: place parentheses around the '?:' expression to evaluate it first
                        c->spd.that.key_from_DNS_on_demand ? "; " : "",
                                                           ^
                        (                                             )
```

I assume the fix is what was meant here, i.g. print a semicolon if either of the `key_from_DNS_on_demand` fields are set.

