### PR TITLE
pluto: Use NULL when refering to pointers

### DIFF
--- a/programs/pluto/ikev1_spdb_struct.c
+++ b/programs/pluto/ikev1_spdb_struct.c
@@ -1275,7 +1275,7 @@ bool ikev1_out_sa(pb_stream *outs,
 						};
 
 						char *nbyte[1];
-						nbyte[0] = '\0';
+						nbyte[0] = NULL;
 
 						if (!out_struct(&attr,
 								attr_desc,


### PR DESCRIPTION
The code block here defines an array of `char*` pointers, but then sets
the first element to `'\0'`, which is a char an not a pointer. Set it to
`NULL` instead.
This fixes the following warning from clang:

```
programs/pluto/ikev1_spdb_struct.c:1278:18: error: expression which evaluates to zero treated as a null pointer constant of type 'char *' [-Werror,-Wnon-literal-null-conversion]
                                                nbyte[0] = '\0';
                                                           ^~~~
```