### PR TITLE
Use close_range to close fds

### DIFF
--- a/mk/config.mk
+++ b/mk/config.mk
@@ -604,6 +604,10 @@ USERLAND_CFLAGS += -DLIBCURL
 CURL_LDFLAGS ?= -lcurl
 endif
 
+ifeq ($(USE_CLOSE_RANGE),true)
+USERLAND_CFLAGS += -DUSE_CLOSE_RANGE
+endif
+
 # Build support for the Linux Audit system
 
 USE_LINUX_AUDIT ?= false

--- a/mk/defaults/linux.mk
+++ b/mk/defaults/linux.mk
@@ -8,6 +8,9 @@ USERLAND_CFLAGS += -Dlinux
 # Expose pipe2() which is always available on BSD, what else?
 USERLAND_CFLAGS += -D_GNU_SOURCE
 
+# close_range
+USE_CLOSE_RANGE := $(shell if echo | gcc -include linux/close_range.h -E - > /dev/null 2>&1; then echo true; else echo false; fi)
+
 PORTDEFINE=-DSCANDIR_HAS_CONST
 
 # Detect linux variants and releases.

--- a/programs/pluto/pluto_seccomp.c
+++ b/programs/pluto/pluto_seccomp.c
@@ -118,6 +118,12 @@ static void init_seccomp(uint32_t def_action, bool main, struct logger *logger)
 		LSW_SECCOMP_ADD(uname);
 		LSW_SECCOMP_ADD(unlink);
 		LSW_SECCOMP_ADD(unlinkat);
+#ifdef USE_CLOSE_RANGE
+#ifndef __SNR_close_range
+#define __SNR_close_range __NR_close_range
+#endif
+		LSW_SECCOMP_ADD(close_range);
+#endif
 	}
 
 	/* common to pluto and helpers */


### PR DESCRIPTION
On some systems, the file descriptor table can be large (524,288
entries on the system I’m writing this on), and the fd-closing loop in
plutomain takes a long time (2-3 *minutes*).

Linux 5.10 introduced the close_range syscall which can close huge
ranges of fds very quickly. This patch enables pluto to use this, when
it’s available.

The Makefile snippet changes detect support for close_range at build
time, using linux/close_range.h as a proxy (if it’s present, the
syscall number will also be present). At runtime, the syscall is
attempted in all cases if pluto was built with it; older kernels will
fail with ENOSYS. In any case, if close_range fails, we fall back to
the existing fd-closing behaviour, which is preserved anyway because
we want to loop over the fds from 0 to ctl_fd (excluded).

Signed-off-by: Stephen Kitt <skitt@redhat.com>