### PR TITLE
pluto: introducing a REDIRECT_FAILED notification type

### DIFF
--- a/include/ietf_constants.h
+++ b/include/ietf_constants.h
@@ -1521,6 +1521,7 @@ typedef enum {
 	v2N_CHILD_SA_NOT_FOUND = 44, /* RFC 7296 */
 	v2N_INVALID_GROUP_ID = 45, /* draft-yeung-g-ikev2 */
 	v2N_AUTHORIZATION_FAILED = 46, /* draft-yeung-g-ikev2 */
+	v2N_REDIRECT_FAILED = 47, /* I don't know if this the right place for this? */
 
 	v2N_ERROR_PSTATS_ROOF, /* used to cap error statistics array */
 

--- a/lib/libswan/constants.c
+++ b/lib/libswan/constants.c
@@ -1821,11 +1821,12 @@ static const char *const ikev2_notify_name[] = {
 	"v2N_CHILD_SA_NOT_FOUND",
 	"v2N_INVALID_GROUP_ID", /* 45 draft-yeung-g-ikev2 */
 	"v2N_AUTHORIZATION_FAILED",
+	"v2N_REDIRECT_FAILED",
 };
 
 enum_names ikev2_notify_names = {
 	v2N_NOTHING_WRONG,
-	v2N_AUTHORIZATION_FAILED,
+	v2N_REDIRECT_FAILED,
 	ARRAY_REF(ikev2_notify_name),
 	"v2N_", /* prefix */
 	&ikev2_notify_names_16384

--- a/programs/pluto/ikev2.c
+++ b/programs/pluto/ikev2.c
@@ -1682,13 +1682,16 @@ void ikev2_process_packet(struct msg_digest *md)
 			 * notification. If redirection is a MUST, try to respond
 			 * with v2N_REDIRECT and don't continue further.
 			 * Otherwise continue as usual.
-			 *
-			 * The function below will do everything (and log the result).
 			 */
-			if (redirect_global(md)) {
+			if (is_redirect_global_enabled()) {
+				/*
+				 * This function will do everything (and log the result)
+				 */
+				if (!redirect_global(md)) {
+					pstat(ikev2_recv_notifies_e, v2N_REDIRECT_FAILED)
+				}
 				return;
 			}
-
 			/*
 			 * Check if we would drop the packet based on
 			 * VID before we create a state. Move this to

--- a/programs/pluto/ikev2_redirect.h
+++ b/programs/pluto/ikev2_redirect.h
@@ -36,12 +36,19 @@ extern void free_global_redirect_dests(void);
 extern void set_global_redirect_dests(const char *gdr_str);
 
 /*
+ * Check if global redirect is enabled or not.
+ *
+ * @return bool TRUE if redirection is a MUST, FALSE otherwise.
+ */
+extern bool is_redirect_global_enabled(void);
+
+/*
  * Check whether we received v2N_REDIRECT_SUPPORTED (in IKE_SA_INIT request),
  * and if we did, send a response with REDIRECT payload (without creating state -
  * just as in COOKIE case).
  *
  * @param md message digest of IKE_SA_INIT request.
- * @return bool TRUE if redirection is a MUST, FALSE otherwise.
+ * @return bool TRUE if a redirection response was sent, FALSE otherwise.
  */
 extern bool redirect_global(struct msg_digest *md);
 


### PR DESCRIPTION
I needed a way to keep track of when a redirect fails for any reasons. I considered changing the debug messages in the redirect_global() function to another type of log message, but thought keeping track of this events in memory would have less of a performance impact especially if there were to be a flood of failures for any reason.

I have tested this by explicitly setting the `global-redirect` option to **yes**, but not setting the `global-redirect-to` to anything.

```bash
config setup
        global-redirect=yes
#        global-redirect-to=1.1.1.1
```
As expected the REDIRECT_FAILED count increased.
```bash
$ sudo ipsec whack --globalstatus | grep -i redirect_failed
total.ikev2.sent.notifies.error.REDIRECT_FAILED=0
total.ikev2.recv.notifies.error.REDIRECT_FAILED=8
```

I'm not 100% sure if these REDIRECT_FAILED errors should be part of the **recv** or the **sent** errors statuses?
