### PR TITLE
ecdsasigkey: add "ipsec ecdsasigkey" command

### DIFF
--- a/lib/libswan/Makefile
+++ b/lib/libswan/Makefile
@@ -224,7 +224,7 @@ OBJS += $(abs_builddir)/version.o
 # build version.c using version number from Makefile.ver
 $(abs_builddir)/version.c: $(srcdir)/version.in.c $(top_srcdir)/Makefile.ver
 	rm -f $@.tmp
-	sed -e '/"/s/@IPSECVERSION@/$(IPSECVERSION)/' \
+	sed -e '/"/s/@IPSECVERSION@/$(subst /,\/,$(IPSECVERSION))/' \
 	    -e '/"/s/@IPSECVIDVERSION@/$(IPSECVIDVERSION)/' \
 	    $(srcdir)/version.in.c \
 	    > $@.tmp

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -35,6 +35,7 @@ SUBDIRS += algparse
 SUBDIRS += auto
 SUBDIRS += barf
 SUBDIRS += cavp
+SUBDIRS += ecdsasigkey
 SUBDIRS += ipsec
 SUBDIRS += letsencrypt
 SUBDIRS += look

--- a/programs/ecdsasigkey/Makefile
+++ b/programs/ecdsasigkey/Makefile
@@ -1,0 +1,29 @@
+# Makefile for miscellaneous programs
+# Copyright (C) 2002  Michael Richardson	<mcr@freeswan.org>
+# Copyright (C) 2017 Andrew Cagney <cagney@gnu.org>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.  See <https://www.gnu.org/licenses/gpl2.txt>.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+
+PROGRAM=ecdsasigkey
+OBJS += $(PROGRAM).o
+OBJS += $(LIBRESWANLIB)
+OBJS += $(LSWTOOLLIBS)
+
+USERLAND_LDFLAGS += $(NSS_LDFLAGS)
+USERLAND_LDFLAGS += $(NSPR_LDFLAGS)
+USERLAND_LDFLAGS += $(FIPSCHECK_LDFLAGS)
+
+ifdef top_srcdir
+include $(top_srcdir)/mk/program.mk
+else
+include ../../mk/program.mk
+endif

--- a/programs/ecdsasigkey/ecdsasigkey.8.xml
+++ b/programs/ecdsasigkey/ecdsasigkey.8.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
+                   "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd">
+<!-- lifted from troff+man by doclifter -->
+<refentry>
+<refentryinfo>
+  <author><firstname>Paul</firstname><surname>Wouters</surname><authorblurb><para>placeholder to suppress warning</para> </authorblurb></author>
+</refentryinfo>
+<refmeta>
+<refentrytitle>IPSEC_ECDSASIGKEY</refentrytitle>
+<manvolnum>8</manvolnum>
+<refmiscinfo class='date'>6 Sep 2013</refmiscinfo>
+<refmiscinfo class="source">libreswan</refmiscinfo>
+<refmiscinfo class="manual">Executable programs</refmiscinfo>
+</refmeta>
+<refnamediv id='name'>
+<refname>ipsec ecdsasigkey</refname>
+<refpurpose>generate ECDSA signature key</refpurpose>
+</refnamediv>
+<!-- body begins here -->
+<refsynopsisdiv id='synopsis'>
+<cmdsynopsis>
+  <command>ipsec</command>
+    <arg choice='plain'><replaceable>ecdsasigkey</replaceable></arg>
+    <arg choice='opt'>--verbose </arg>
+    <arg choice='opt'>--seeddev <replaceable>device</replaceable></arg>
+    <arg choice='opt'>--seed <replaceable>numbits</replaceable></arg>
+    <arg choice='opt'>--nssdir <replaceable>nssdir</replaceable></arg>
+    <arg choice='opt'>--password <replaceable>nsspassword</replaceable></arg>
+    <arg choice='opt'>--hostname <replaceable>hostname</replaceable></arg>
+    <arg choice='opt'>curvename</arg>
+</cmdsynopsis>
+</refsynopsisdiv>
+
+
+<refsect1 id='description'><title>DESCRIPTION</title>
+<para><emphasis remap='I'>ecdsasigkey</emphasis>
+generates an ECDSA public/private key pair, suitable for digital signatures, on a named curve specified with
+<emphasis remap='I'>curvename</emphasis>. Currently it only accepts <emphasis remap='I'>secp256r1</emphasis>, <emphasis remap='I'>secp384r1</emphasis>, and <emphasis remap='I'>secp521r1</emphasis>.
+</para>
+
+<para>The public exponent is forced to the value <emphasis remap='B'>3</emphasis>, which has important
+speed advantages for signature checking. Beware that the resulting keys have known weaknesses as encryption keys
+<emphasis remap='B'>and should not be used for that purpose</emphasis>.</para>
+
+<para>The <option>--verbose</option> option makes <emphasis
+remap='I'>ecdsasigkey</emphasis> give a running commentary on standard
+error. By default, it works in silence until it is ready to generate
+output.</para>
+
+<para>The <option>--seeddev</option> option specifies a
+source for random bits used to seed the crypto library's
+RNG. The default is <filename>/dev/random</filename> (see
+<citerefentry><refentrytitle>random</refentrytitle><manvolnum>4</manvolnum></citerefentry>).
+FreeS/WAN and Openswan without NSS support used this option to specify
+the random source used to directly create keys. Libreswan only uses
+it to seed the NSS crypto libraries RNG. Under Linux with hardware random
+support, special devices might show up as <filename>/dev/*rng*</filename>
+devices. However, these should never be accessed directly using this option,
+as hardware failures could lead to extremely non-random values (streams
+of zeroes have been observed in the wild) </para>
+
+<para>The <option>--seedbits</option> option specifies how many seed bits are pulled from
+the random device to seed the NSS PRNG. The default of 480bit comes from FIPS requirements.
+Seed bits are rounded up to a multiple of 8.
+</para>
+
+<para>The use of a different random device or a reduction of seedbits from the default value is
+prevented when the system is running in FIPS mode.</para>
+
+<para>The <option>--nssdir</option> option specifies the directory to use for the nss database.
+This is the directory where the NSS certificate, key and security modules databases reside. The
+default value is <filename>@IPSEC_NSSDIR@</filename>.</para>
+
+<para>The <option>--password</option> option specifies the nss cryptographic module authentication
+password if the NSS module has been configured to require it.  A password is required by hardware
+tokens and also by the internal software token module when configured to run in FIPS mode.
+If the argument is <emphasis remap='I'>@IPSEC_CONFDDIR@</emphasis><filename>/nsspassword</filename>,
+the password comes from that file; otherwise argument is the password.
+</para>
+
+</refsect1>
+
+<refsect1 id='examples'><title>EXAMPLES</title>
+<variablelist remap='TP'>
+ <varlistentry>
+  <term><emphasis remap='B'>ipsec ecdsasigkey --verbose 4096 </emphasis></term>
+  <listitem>
+   <para>generates a 4096-bit signature key  and stores this key in the NSS database.
+    The public key can then be extracted and edited into the <filename>ipsec.conf</filename> (see
+    <citerefentry><refentrytitle>ipsec_showhostkey</refentrytitle><manvolnum>8</manvolnum></citerefentry>).
+   </para>
+  </listitem>
+ </varlistentry>
+</variablelist>
+</refsect1>
+
+<refsect1 id='files'><title>FILES</title>
+<para>/dev/random, /dev/urandom</para>
+</refsect1>
+
+<refsect1 id='see_also'><title>SEE ALSO</title>
+<para>
+<citerefentry><refentrytitle>random</refentrytitle><manvolnum>4</manvolnum></citerefentry>,
+<citerefentry><refentrytitle>rngd</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
+<citerefentry><refentrytitle>ipsec_showhostkey</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
+<emphasis remap='I'>Applied Cryptography, 2nd. ed., by Bruce Schneier, Wiley 1996</emphasis>,
+<emphasis remap='I'>RFCs 2537, 2313</emphasis>,
+<emphasis remap='I'>GNU  MP, the GNU multiple precision arithmetic library, edition 2.0.2, by Torbj Granlund</emphasis>
+</para>
+</refsect1>
+
+<refsect1 id='history'><title>HISTORY</title>
+<para>Originally written for the Linux FreeS/WAN project
+&lt;<ulink url='https://www.freeswan.org'>https://www.freeswan.org</ulink>&gt;
+by Henry Spencer. Updated for the Libreswan Project by Paul Wouters.</para>
+<para>The <emphasis remap='I'>--round</emphasis> and <emphasis remap='I'>--noopt</emphasis>
+options were obsoleted as these were only used with the old non-library crypto code</para>
+<para>The <emphasis remap='I'>--random</emphasis> device is only used for seeding the crypto library,
+not for direct random to generate keys</para>
+</refsect1>
+
+<refsect1 id='bugs'><title>BUGS</title>
+<para><emphasis remap='I'>ecdsasigkey</emphasis>'s run time is difficult
+to predict, since <filename>/dev/random</filename> output can
+be arbitrarily delayed if the system's entropy pool is low on
+randomness, and  the time taken by the search for primes is also somewhat
+unpredictable. Specifically, embedded systems and most virtual machines are low on
+entropy. In such a situation, consider generating the ECDSA key on another machine,
+and copying <filename>ipsec.secrets</filename> and the <filename>@IPSEC_NSSDIR@</filename>
+directory tree to the embedded platform. Note that NSS embeds the full path in the DB files, so
+the path on proxy machine must be identical to the path on the destination machine.
+</para>
+</refsect1>
+</refentry>
+

--- a/programs/ecdsasigkey/ecdsasigkey.c
+++ b/programs/ecdsasigkey/ecdsasigkey.c
@@ -1,0 +1,351 @@
+/*
+ * RSA signature key generation, for libreswan
+ *
+ * Copyright (C) 1999, 2000, 2001  Henry Spencer.
+ * Copyright (C) 2003-2008 Michael C Richardson <mcr@xelerance.com>
+ * Copyright (C) 2003-2009 Paul Wouters <paul@xelerance.com>
+ * Copyright (C) 2009 Avesh Agarwal <avagarwa@redhat.com>
+ * Copyright (C) 2012-2017 Paul Wouters <paul@libreswan.org>
+ * Copyright (C) 2016 Andrew Cagney <cagney@gnu.org>
+ * Copyright (C) 2016 Tuomo Soini <tis@foobar.fi>
+ * Copyright (C) 2019-2020 Paul Wouters <pwouters@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.  See <https://www.gnu.org/licenses/gpl2.txt>.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * NOTE: This should probably be rewritten to use NSS RSA_NewKey()
+ */
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <time.h>
+#include <limits.h>
+#include <errno.h>
+#include <string.h>
+#include <getopt.h>
+#include <libreswan.h>
+#include "lswalloc.h"
+//#include "secrets.h"
+
+#include <prerror.h>
+#include <prinit.h>
+#include <prmem.h>
+#include <plstr.h>
+#include <keyhi.h>
+#include <keythi.h>
+#include <pk11pub.h>
+#include <seccomon.h>
+#include <secerr.h>
+#include <secport.h>
+
+#include <time.h>
+
+#include <arpa/nameser.h> /* for NS_MAXDNAME */
+#include "constants.h"
+#include "lswalloc.h"
+#include "lswlog.h"
+#include "lswtool.h"
+#include "lswconf.h"
+#include "lswnss.h"
+
+#ifndef DEVICE
+# define DEVICE  "/dev/random"
+#endif
+#ifndef MAXBITS
+# define MAXBITS 521
+#endif
+
+#define DEFAULT_SEED_BITS 60 /* 480 bits of random seed */
+
+struct curve {
+	const char *name;
+	SECOidTag tag;
+};
+
+static const struct curve curves[] = {
+	{ "secp256r1", SEC_OID_SECG_EC_SECP256R1 },
+	{ "secp384r1", SEC_OID_SECG_EC_SECP384R1 },
+	{ "secp521r1", SEC_OID_SECG_EC_SECP521R1 }
+};
+
+char usage[] =
+	"ecdsasigkey [--verbose] [ --debug ] [--seeddev <device>] [--nssdir <dir>]\n"
+	"        [--password <password>] [--seedbits bits] [<curve-name>]";
+
+enum opt {
+	OPT_DEBUG = 256,
+};
+
+struct option opts[] = {
+	{ "debug",      0,      NULL,   OPT_DEBUG, },
+	{ "verbose",    0,      NULL,   'v', },
+	{ "seeddev",    1,      NULL,   'S', },
+	{ "help",       0,      NULL,   'h', },
+	{ "version",    0,      NULL,   'V', },
+	{ "nssdir",     1,      NULL,   'd', }, /* nss-tools use -d */
+	{ "password",   1,      NULL,   'P', },
+	{ "seedbits",   1,      NULL,   's', },
+	{ 0,            0,      NULL,   0, }
+};
+char *device = DEVICE;          /* where to get randomness */
+int nrounds = 30;               /* rounds of prime checking; 25 is good */
+
+/* forwards */
+static void ecdsasigkey(SECOidTag curve, int seedbits,
+		 const struct lsw_conf_options *oco, struct logger *logger);
+static void lsw_random(size_t nbytes, unsigned char *buf, struct logger *logger);
+static const char *conv(const unsigned char *bits, size_t nbytes, int format);
+
+/*
+ * UpdateRNG - Updates NSS's PRNG with user generated entropy
+ *
+ * pluto and rsasigkey use the NSS crypto library as its random source.
+ * Some government Three Letter Agencies require that pluto reads additional
+ * bits from /dev/random and feed these into the NSS RNG before drawing random
+ * from the NSS library, despite the NSS library itself already seeding its
+ * internal state. This process can block pluto or rsasigkey for an extended
+ * time during startup, depending on the entropy of the system. Therefore
+ * the default is to not perform this redundant seeding. If specifying a
+ * value, it is recommended to specify at least 460 bits (for FIPS) or 440
+ * bits (for BSI).
+ */
+static void UpdateNSS_RNG(int seedbits, struct logger *logger)
+{
+	SECStatus rv;
+	int seedbytes = BYTES_FOR_BITS(seedbits);
+	unsigned char *buf = alloc_bytes(seedbytes, "TLA seedmix");
+
+	lsw_random(seedbytes, buf, logger);
+	rv = PK11_RandomUpdate(buf, seedbytes);
+	passert(rv == SECSuccess);
+	messupn(buf, seedbytes);
+	pfree(buf);
+}
+
+int main(int argc, char *argv[])
+{
+	log_to_stderr = FALSE;
+	struct logger *logger = tool_init_log("ipsec ecdsasigkey");
+
+	int opt;
+	int seedbits = DEFAULT_SEED_BITS;
+	SECOidTag curve = SEC_OID_UNKNOWN;
+
+	while ((opt = getopt_long(argc, argv, "", opts, NULL)) != EOF)
+		switch (opt) {
+		case 'v':       /* verbose description */
+			log_to_stderr = TRUE;
+			break;
+
+		case OPT_DEBUG:
+			cur_debugging = -1;
+			break;
+
+		case 'S':       /* nonstandard random device for seed */
+			device = optarg;
+			break;
+
+		case 'h':       /* help */
+			printf("Usage:\t%s\n", usage);
+			exit(0);
+			break;
+		case 'V':       /* version */
+			printf("%s %s\n", progname, ipsec_version_code());
+			exit(0);
+			break;
+		case 'd':       /* -d is used for nssdirdir with nss tools */
+			lsw_conf_nssdir(optarg, logger);
+			break;
+		case 'P':       /* token authentication password */
+			lsw_conf_nsspassword(optarg);
+			break;
+		case 's': /* seed bits */
+			seedbits = atoi(optarg);
+			if (PK11_IsFIPS()) {
+				if (seedbits < DEFAULT_SEED_BITS) {
+					fprintf(stderr, "%s: FIPS mode does not allow < %d seed bits\n",
+						progname, DEFAULT_SEED_BITS);
+					exit(1);
+				}
+			}
+			break;
+		case '?':
+		default:
+			printf("Usage:\t%s\n", usage);
+			exit(2);
+		}
+
+	if (argv[optind] == NULL) {
+		curve = SEC_OID_SECG_EC_SECP256R1;
+	} else {
+		for (size_t i = 0; i < elemsof(curves); i++) {
+			if (streq(argv[optind], curves[i].name)) {
+				curve = curves[i].tag;
+				break;
+			}
+		}
+		if (curve == SEC_OID_UNKNOWN) {
+			fprintf(stderr,
+				"%s: curve specification is malformed: %s\n",
+				progname, argv[optind]);
+			exit(1);
+		}
+	}
+
+	/*
+	 * Don't fetch the config options until after they have been
+	 * processed, and really are "constant".
+	 */
+	const struct lsw_conf_options *oco = lsw_init_options();
+
+	ecdsasigkey(curve, seedbits, oco, logger);
+	exit(0);
+}
+
+/*
+ * generate an ECDSA signature key
+ */
+static void ecdsasigkey(SECOidTag curve, int seedbits,
+			const struct lsw_conf_options *oco, struct logger *logger)
+{
+	PK11SlotInfo *slot = NULL;
+	SECKEYPrivateKey *privkey = NULL;
+	SECKEYPublicKey *pubkey = NULL;
+
+	unsigned char buf[65];
+	SECItem ecdsaparams = { siBuffer, buf, sizeof(buf) };
+	SECOidData *oiddata = SECOID_FindOIDByTag(curve);
+
+	passert(oiddata->oid.len <= sizeof(buf) - 2);
+	ecdsaparams.data[0] = SEC_ASN1_OBJECT_ID;
+	ecdsaparams.data[1] = oiddata->oid.len;
+	memcpy(ecdsaparams.data + 2, oiddata->oid.data, oiddata->oid.len);
+	ecdsaparams.len = oiddata->oid.len + 2;
+
+	diag_t d = lsw_nss_setup(oco->nssdir, 0, logger);
+
+	if (d != NULL) {
+		fatal_diag(1, logger, &d, "%s", "");
+	}
+
+	slot = lsw_nss_get_authenticated_slot(logger);
+	if (slot == NULL) {
+		/* already logged */
+		lsw_nss_shutdown();
+		exit(1);
+	}
+
+	/* Do some random-number initialization. */
+	UpdateNSS_RNG(seedbits, logger);
+	privkey = PK11_GenerateKeyPair(slot,
+				       CKM_EC_KEY_PAIR_GEN,
+				       &ecdsaparams, &pubkey,
+				       PR_TRUE,
+				       PK11_IsFIPS() ? PR_TRUE : PR_FALSE,
+				       lsw_nss_get_password_context(logger));
+	/* inTheToken, isSensitive, passwordCallbackFunction */
+	if (privkey == NULL) {
+		fprintf(stderr,
+			"%s: key pair generation failed: \"%d\"\n", progname,
+			PORT_GetError());
+		return;
+	}
+
+	char *hex_ckaid;
+	{
+		SECItem *ckaid = PK11_GetLowLevelKeyIDForPrivateKey(privkey);
+
+		if (ckaid == NULL) {
+			fprintf(stderr, "%s: 'CKAID' calculation failed\n", progname);
+			exit(1);
+		}
+		hex_ckaid = strdup(conv(ckaid->data, ckaid->len, 16));
+		SECITEM_FreeItem(ckaid, PR_TRUE);
+	}
+
+	PORT_Assert(pubkey != NULL);
+	fprintf(stderr, "Generated ECDSA key pair with CKAID %s was stored in the NSS database\n",
+		hex_ckaid);
+	fprintf(stderr, "The public key can be displayed using: ipsec showhostkey --left --ckaid %s\n",
+		hex_ckaid);
+
+	if (hex_ckaid != NULL)
+		free(hex_ckaid);
+	if (privkey != NULL)
+		SECKEY_DestroyPrivateKey(privkey);
+	if (pubkey != NULL)
+		SECKEY_DestroyPublicKey(pubkey);
+
+	lsw_nss_shutdown();
+}
+
+/*
+ * lsw_random - get some random bytes from /dev/random (or wherever)
+ * NOTE: This is only used for additional seeding of the NSS RNG
+ */
+static void lsw_random(size_t nbytes, unsigned char *buf, struct logger *logger)
+{
+	size_t ndone;
+	int dev;
+	ssize_t got;
+
+	dev = open(device, 0);
+	if (dev < 0) {
+		fprintf(stderr, "%s: could not open %s (%s)\n", progname,
+			device, strerror(errno));
+		exit(1);
+	}
+
+	ndone = 0;
+	llog(RC_LOG, logger, "getting %d random seed bytes for NSS from %s...\n",
+		    (int) nbytes * BITS_PER_BYTE, device);
+	while (ndone < nbytes) {
+		got = read(dev, buf + ndone, nbytes - ndone);
+		if (got < 0) {
+			fprintf(stderr, "%s: read error on %s (%s)\n", progname,
+				device, strerror(errno));
+			exit(1);
+		}
+		if (got == 0) {
+			fprintf(stderr, "%s: eof on %s!?!\n", progname, device);
+			exit(1);
+		}
+		ndone += got;
+	}
+
+	close(dev);
+}
+
+/*
+ * conv - convert bits to output in specified datatot format
+ * NOTE: result points into a STATIC buffer
+ */
+static const char *conv(const unsigned char *bits, size_t nbytes, int format)
+{
+	static char convbuf[MAXBITS / 4 + 50];  /* enough for hex */
+	size_t n;
+
+	n = datatot(bits, nbytes, format, convbuf, sizeof(convbuf));
+	if (n == 0) {
+		fprintf(stderr, "%s: can't-happen convert error\n", progname);
+		exit(1);
+	}
+	if (n > sizeof(convbuf)) {
+		fprintf(stderr,
+			"%s: can't-happen convert overflow (need %d)\n",
+			progname, (int) n);
+		exit(1);
+	}
+	return convbuf;
+}

--- a/programs/newhostkey/newhostkey.8.xml
+++ b/programs/newhostkey/newhostkey.8.xml
@@ -29,6 +29,8 @@
     <arg choice='opt'>--nssdir<replaceable>nssdir</replaceable></arg>
     <arg choice='opt'>--password <replaceable>password</replaceable></arg>
     <arg choice='opt'>--bits <replaceable>bits</replaceable></arg>
+    <arg choice='opt'>--curve <replaceable>curve</replaceable></arg>
+    <arg choice='opt'>--keytype <replaceable>rsa|ecdsa</replaceable></arg>
     <arg choice='opt'>--seeddev <replaceable>device</replaceable></arg>
 </cmdsynopsis>
 </refsynopsisdiv>
@@ -84,6 +86,21 @@
 	  number of bits in the RSA key; the current default is a
 	  random (multiple of 16) value between 3072 and 4096. The
 	  minimum allowed is 2192.  </para>
+	</listitem>
+      </varlistentry>
+
+      <varlistentry>
+	<term><option>--curve</option>&nbsp;<replaceable>curve</replaceable></term>
+	<listitem>
+	  <para>The <option>--curve</option> option specifies the
+	  named curve used in the ECDSA key; the current default is secp256r1. See <citerefentry><refentrytitle>ipsec_ecdsasigkey</refentrytitle><manvolnum>8</manvolnum></citerefentry> for the available curve names. </para>
+	</listitem>
+      </varlistentry>
+
+      <varlistentry>
+	<term><option>--keytype</option>&nbsp;<replaceable>rsa|ecdsa</replaceable></term>
+	<listitem>
+	  <para>The <option>--keytype</option> option specifies the type of key, which can either be <emphasis remap='I'>rsa</emphasis> (RSA) or <emphasis remap='I'>ecdsa</emphasis> (ECDSA); if omitted the current default is <emphasis remap='I'>rsa</emphasis>. </para>
 	</listitem>
       </varlistentry>
 

--- a/programs/newhostkey/newhostkey.in
+++ b/programs/newhostkey/newhostkey.in
@@ -19,10 +19,16 @@
 #
 
 me="ipsec newhostkey"
-usage="Usage: $me [--seeddev device] [--bits n] \\
-    [--quiet] [--hostname host] [--nssdir @IPSEC_NSSDIR@] [--password password] "
+usage="Usage:
+	$me [--seeddev device] [--keytype rsa] [--bits n]
+	$me [--seeddev device] --keytype ecdsa [--curve curve]
+
+	other options: [--quiet] [--hostname host] [--nssdir @IPSEC_NSSDIR@] \\
+		[--password password]"
 
 bits=
+curve=
+keytype=rsa
 verbose=
 host=
 seeddev="--seeddev /dev/random"
@@ -32,6 +38,14 @@ while [ $# != 0 ] ; do
     case "$1" in
 	--bits)
 	    bits="${2}"
+	    shift
+	    ;;
+	--curve)
+	    curve="${2}"
+	    shift
+	    ;;
+	--keytype)
+	    keytype="${2}"
 	    shift
 	    ;;
 	--quiet)
@@ -75,6 +89,28 @@ while [ $# != 0 ] ; do
     shift
 done
 
+if [ -n "$bits" ] && [ -n "$curve" ]; then
+    echo "${me}: --bits and --curve are mutually exclusive"
+    exit 2
+fi
+
+case "$keytype" in
+    rsa)
+	if [ -n "$curve" ]; then
+	    echo "${me}: --curve and --keytype rsa are mutually exclusive"
+	fi
+	;;
+    ecdsa)
+	if [ -n "$bits" ]; then
+	    echo "${me}: --bits and --keytype ecdsa are mutually exclusive"
+	fi
+	;;
+    *)
+	echo "${me}: unknown key type \`$keytype'" >&2
+	exit 2
+	;;
+esac
+
 if [ ! -d ${nssdir} ]; then
     echo "No such directory: ${nssdir}"
     exit 255
@@ -88,7 +124,15 @@ if [ ${RETVAL} -eq 255 ]; then
     exit 255
 fi
 
-key=$(ipsec rsasigkey ${verbose} ${seeddev} --nssdir ${nssdir} ${password} ${host} ${bits})
+case "$keytype" in
+    rsa)
+	key=$(ipsec rsasigkey ${verbose} ${seeddev} --nssdir ${nssdir} ${password} ${host} ${bits})
+	;;
+    ecdsa)
+	key=$(ipsec ecdsasigkey ${verbose} ${seeddev} --nssdir ${nssdir} ${password} ${host} ${curve})
+	;;
+esac
+
 RETVAL=$?
 if [ ${RETVAL} -ne 0 ]; then
     exit ${RETVAL}

--- a/programs/showhostkey/showhostkey.c
+++ b/programs/showhostkey/showhostkey.c
@@ -223,7 +223,8 @@ static int pick_by_ckaid(struct secret *secret UNUSED,
 			 void *uservoid)
 {
 	char *start = (char *)uservoid;
-	if (pks->kind == PKK_RSA && ckaid_starts_with(&pks->ckaid, start)) {
+	if ((pks->kind == PKK_RSA || pks->kind == PKK_ECDSA) &&
+	    ckaid_starts_with(&pks->ckaid, start)) {
 		/* stop */
 		return 0;
 	} else {
@@ -294,7 +295,7 @@ static int show_dnskey(struct private_key_stuff *pks,
 static int show_confkey(struct private_key_stuff *pks,
 			char *side)
 {
-	if (pks->kind != PKK_RSA) {
+	if (pks->kind != PKK_RSA && pks->kind != PKK_ECDSA) {
 		char *enumstr = "gcc is crazy";
 		switch (pks->kind) {
 		case PKK_PSK:
@@ -316,11 +317,25 @@ static int show_confkey(struct private_key_stuff *pks,
 		return 5;
 	}
 
-	printf("\t# rsakey %s\n",
-	       pks->keyid.keyid);
-	printf("\t%srsasigkey=%s\n", side,
-	       base64);
-	pfree(base64);
+	switch (pks->kind) {
+	case PKK_RSA:
+		printf("\t# rsakey %s\n",
+		       pks->keyid.keyid);
+		printf("\t%srsasigkey=%s\n", side,
+		       base64);
+		pfree(base64);
+		break;
+	case PKK_ECDSA:
+		printf("\t# ecdsakey %s\n",
+		       pks->keyid.keyid);
+		printf("\t%secdsasigkey=%s\n", side,
+		       base64);
+		pfree(base64);
+		break;
+	default:
+		passert(FALSE);
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
This adds a minimal support for generating raw ECDSA key pair. I guess the remaining tasks to properly support raw ECDSA would be:

- [x] add "ipsec ecdsasigkey" command
- [x] route "ipsec newhostkey" command to "ipsec ecdsasigkey"
- [ ] add configuration support for "(left|right)ecdsasigkey" option
- [ ] actually load and use the key in pluto
- [ ] extend the documentation to cover the configuration using raw ECDSA keys
- [ ] add automated tests