### PR TITLE
whack: global-redirect and global-redirect-to options

### DIFF
--- a/configs/d.ipsec.conf/global-redirect.xml
+++ b/configs/d.ipsec.conf/global-redirect.xml
@@ -4,7 +4,7 @@
 <para>Whether to send requests for the remote peer to redirect IKE/IPsec SA's during IKE_SA_INIT. Valid options are
 	<emphasis remap='B'>no</emphasis> (the default), <emphasis remap='B'>yes</emphasis> and <emphasis remap='B'>auto</emphasis>, where auto means
 	that the requests will be sent if DDoS mode is active (see <emphasis remap='B'>ddos-mode</emphasis>). If set, the option <emphasis remap='B'>global-redirect-to=</emphasis> must 	also be set to indicate where to redirect peers to. For specific connection redirection after IKE SA authentication, see the <emphasis remap='B'>send-redirect=</emphasis> and
-	<emphasis remap='B'>redirect-to=</emphasis> options. Runtime redirects can be triggered via the <emphasis remap='I'>ipsec whack --redirect</emphasis> command.
+	<emphasis remap='B'>redirect-to=</emphasis> options. This configuration can be changed at runtime via the <emphasis remap='I'>ipsec whack --global-redirect</emphasis> command.
 </para>
   </listitem>
   </varlistentry>
@@ -13,7 +13,7 @@
   <listitem>
 <para>Where to send remote peers to via the <emphasis remap='B'>global-redirect</emphasis> option. This can be a list, or a single entry, of IP addresses or hostnames (FQDNs).
 	If there is a list of entries, they must be separated with comma's. One specified entry means all peers will be redirected
-	to it, while multiple specified entries means peers will be evenly distributed across the specified servers.
+	to it, while multiple specified entries means peers will be evenly distributed across the specified servers. This configuration can be changed at runtime via the <emphasis remap='I'>ipsec whack --global-redirect-to</emphasis> command.
 </para>
   </listitem>
   </varlistentry>

--- a/include/whack.h
+++ b/include/whack.h
@@ -66,7 +66,7 @@
  */
 
 #define WHACK_BASIC_MAGIC (((((('w' << 8) + 'h') << 8) + 'k') << 8) + 25)
-#define WHACK_MAGIC (((((('o' << 8) + 'h') << 8) + 'k') << 8) + 48)
+#define WHACK_MAGIC (((((('o' << 8) + 'h') << 8) + 'k') << 8) + 49)
 
 /* struct whack_end is a lot like connection.h's struct end
  * It differs because it is going to be shipped down a socket
@@ -355,6 +355,8 @@ struct whack_message {
 	bool vti_shared; /* use remote %any and skip cleanup on down? */
 
 	/* for RFC 5685 - IKEv2 Redirect mechanism */
+	enum allow_global_redirect global_redirect;
+	char *global_redirect_to;
 	char *redirect_to;
 	char *accept_redirect_to;
 

--- a/lib/libwhack/whacklib.c
+++ b/lib/libwhack/whacklib.c
@@ -256,6 +256,7 @@ static bool pickle_whack_message(struct whackpacker *wp, struct pickler *pickle)
 		PICKLE_STRING(&wp->msg->conn_mark_out) &&
 		PICKLE_STRING(&wp->msg->vti_iface) &&
 		PICKLE_STRING(&wp->msg->remote_host) &&
+		PICKLE_STRING(&wp->msg->global_redirect_to) &&
 		PICKLE_STRING(&wp->msg->redirect_to) &&
 		PICKLE_STRING(&wp->msg->accept_redirect_to) &&
 		PICKLE_STRING(&wp->msg->active_redirect_dests) &&

--- a/programs/pluto/ipsec_pluto.8.xml
+++ b/programs/pluto/ipsec_pluto.8.xml
@@ -440,6 +440,24 @@
 
       <arg choice="plain"><replaceable>whack</replaceable></arg>
 
+      <arg choice="plain">--global-redirect
+      <replaceable>yes|no|auto</replaceable></arg>
+    </cmdsynopsis>
+
+    <cmdsynopsis>
+      <command>ipsec</command>
+
+      <arg choice="plain"><replaceable>whack</replaceable></arg>
+
+      <arg choice="plain">--global-redirect-to
+      <replaceable>ip-address(es)</replaceable></arg>
+    </cmdsynopsis>
+
+    <cmdsynopsis>
+      <command>ipsec</command>
+
+      <arg choice="plain"><replaceable>whack</replaceable></arg>
+
       <arg choice="opt">
 	--name
 	<replaceable>connection-name</replaceable>
@@ -449,7 +467,7 @@
       <replaceable>ip-address(es)</replaceable></arg>
 
     </cmdsynopsis>
-    
+
     <cmdsynopsis>
       <command>ipsec</command>
 
@@ -2281,30 +2299,47 @@
         </varlistentry>
       </variablelist>
 
-      <para>Redirecting active clients can be done using IKEv2 redirect
-      mechanism.</para>
+      <para>Redirecting clients can be done using IKEv2 redirect mechanism.</para>
 
       <variablelist remap="TP">
         <varlistentry>
-          <term><option>--name</option>&nbsp;<emphasis
-          remap="i">connection_name</emphasis></term>
+          <term><option>--global-redirect</option>&nbsp;<emphasis
+          remap="i">yes|no|auto</emphasis></term>
 
-	  <listitem>
-	    <para>Specifying this is optional. If not specified
-	    the mechanism will redirect all currently active peers.
-	    If specified, only the peers from connection <emphasis
-	    remap="i">connection_name</emphasis> will be redirected.
-            </para>
+          <listitem>
+            <para>The --global-redirect option controls whether <emphasis
+            remap="b">pluto</emphasis> will instruct remote peers to redirect
+            IKE/IPsec SA's during IKE_SA_INIT. Valid options are <emphasis
+            remap="b">no</emphasis>, <emphasis remap="b">yes</emphasis> and
+            <emphasis remap="b">auto</emphasis>, where auto means remote peers
+            will be redirected if DDoS mode is active.</para>
           </listitem>
         </varlistentry>
 
         <varlistentry>
+          <term><option>--global-redirect-to</option>&nbsp;<emphasis
+          remap="i">ip-address(es)</emphasis></term>
+
+          <listitem>
+            <para>The destination, or a list of destinations, where the peers will
+            be redirected.</para>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
+          <term><option>--name</option>&nbsp;<emphasis
+          remap="i">connection_name</emphasis></term>
+
           <term><option>--redirect-to</option>&nbsp;<emphasis
           remap="i">ip-address(es)</emphasis></term>
 
-	  <listitem>
-	    <para>A destination, or a list of destination, where
-	    the peers will be redirected.
+          <listitem>
+            <para>The destination, or a list of destinations, where the peers will
+            be redirected.
+            Specifying the connection name is optional. If not specified
+            the mechanism will redirect all currently active peers.
+            If specified, only the peers from connection <emphasis
+            remap="i">connection_name</emphasis> will be redirected.
             </para>
           </listitem>
         </varlistentry>

--- a/programs/pluto/rcv_whack.c
+++ b/programs/pluto/rcv_whack.c
@@ -580,6 +580,21 @@ static void whack_process(const struct whack_message *const m, struct show *s)
 		find_states_and_redirect(m->name, m->active_redirect_dests, whackfd);
 	}
 
+	if (m->global_redirect) {
+		dbg("whack: global_redirect %d", m->global_redirect);
+		global_redirect = m->global_redirect;
+		llog(RC_LOG, logger,
+			"set global redirect to %s",
+			enum_name(&allow_global_redirect_names, global_redirect));
+	}
+
+	if (m->global_redirect_to) {
+		dbg("whack: global_redirect_to %s", m->global_redirect_to);
+		set_global_redirect_dests(m->global_redirect_to);
+		llog(RC_LOG, logger,
+			"set global redirect target to %s", global_redirect_to());
+	}
+
 	/* update any socket buffer size before calling listen */
 	if (m->ike_buf_size != 0) {
 		dbg("whack: ike_buf_size %lu", m->ike_buf_size);

--- a/programs/whack/whack.c
+++ b/programs/whack/whack.c
@@ -201,6 +201,8 @@ static void help(void)
 		"	[--showstates] | [--addresspoolstatus] [--processstatus]\n"
 		"\n"
 		"refresh dns: whack --ddns\n"
+		"global redirect: whack --global-redirect yes|no|auto\n"
+		"	--global-redirect-to <ip-address, dns-domain, ..> \n"
 		"\n"
 #ifdef HAVE_SECCOMP
 		"testing: whack --seccomp-crashtest (CAREFUL!)\n"
@@ -308,6 +310,8 @@ enum option_enums {
 	OPT_REKEY_IPSEC,
 
 	OPT_ACTIVE_REDIRECT,
+	OPT_GLOBAL_REDIRECT,
+	OPT_GLOBAL_REDIRECT_TO,
 
 	OPT_DDOS_BUSY,
 	OPT_DDOS_UNLIMITED,
@@ -578,6 +582,8 @@ static const struct option long_opts[] = {
 	{ "ike-socket-errqueue-toggle", no_argument, NULL, OPT_IKE_MSGERR + OO },
 
 	{ "redirect-to", required_argument, NULL, OPT_ACTIVE_REDIRECT + OO },
+	{ "global-redirect", required_argument, NULL, OPT_GLOBAL_REDIRECT + OO },
+	{ "global-redirect-to", required_argument, NULL, OPT_GLOBAL_REDIRECT_TO + OO },
 
 	{ "ddos-busy", no_argument, NULL, OPT_DDOS_BUSY + OO },
 	{ "ddos-unlimited", no_argument, NULL, OPT_DDOS_UNLIMITED + OO },
@@ -1367,6 +1373,22 @@ int main(int argc, char **argv)
 
 		case OPT_ACTIVE_REDIRECT:	/* --redirect-to */
 			msg.active_redirect_dests = strdup(optarg);
+			continue;
+
+		case OPT_GLOBAL_REDIRECT:	/* --global-redirect */
+			if (streq(optarg, "yes")) {
+				msg.global_redirect = GLOBAL_REDIRECT_YES;
+			} else if (streq(optarg, "no")) {
+				msg.global_redirect = GLOBAL_REDIRECT_NO;
+			} else if (streq(optarg, "auto")) {
+				msg.global_redirect = GLOBAL_REDIRECT_AUTO;
+			} else {
+				diag("invalid option argument for --global-redirect (allowed arguments: yes, no, auto)");
+			}
+			continue;
+
+		case OPT_GLOBAL_REDIRECT_TO:	/* --global-redirect-to */
+			msg.global_redirect_to = strdup(optarg);
 			continue;
 
 		case OPT_DDOS_BUSY:	/* --ddos-busy */
@@ -2580,6 +2602,7 @@ int main(int argc, char **argv)
 	if (!(msg.whack_connection || msg.whack_key ||
 	      msg.whack_delete ||msg.whack_deleteid || msg.whack_deletestate ||
 	      msg.whack_deleteuser || msg.active_redirect_dests != NULL ||
+	      msg.global_redirect || msg.global_redirect_to != NULL ||
 	      msg.whack_initiate || msg.whack_oppo_initiate ||
 	      msg.whack_terminate ||
 	      msg.whack_route || msg.whack_unroute || msg.whack_listen ||


### PR DESCRIPTION
We have IPsec gateways running Libreswan on cloud infrastructure. We have successfully used the config options `global-redirect` and `global-redirect-to` so Libreswan acts as a Load Balancer. Due to the changing nature of the cloud we have an external process that checks the status and IP address of our servers. We'd like to be able to change the redirect targets on the fly without having to restart pluto.

This patch adds the following argumenbts to `ipsec whack`:
- `--global-redirect` with valid options yes, no and auto
- `--global-redirect-to` comma separated list or global redirect targets