### PR TITLE
Bitstomask6 wrong for slash zero

### DIFF
--- a/linux/net/ipsec/goodmask.c
+++ b/linux/net/ipsec/goodmask.c
@@ -156,9 +156,9 @@ int n;
 		result.s6_addr32[3] = htonl(~((1UL << (128 - n)) - 1));
 	} else {
 		result.s6_addr32[0] = 0;
-		result.s6_addr32[0] = 0;
-		result.s6_addr32[0] = 0;
-		result.s6_addr32[0] = 0;
+		result.s6_addr32[1] = 0;
+		result.s6_addr32[2] = 0;
+		result.s6_addr32[3] = 0;
 	}
 
 	return result;


### PR DESCRIPTION
words 1,2,3 might be zero by chance, but no guarantee.
obvious copy and paste typo.  Clearly few people use ::/0 policies.

