### PR TITLE
add DUSE_SHA1 ifdef it in Makefile.inc.local to compile options

### DIFF
--- a/lib/libswan/Makefile
+++ b/lib/libswan/Makefile
@@ -188,6 +188,7 @@ OBJS += ike_alg_none.o
 
 ifeq ($(USE_SHA1),true)
 OBJS += ike_alg_sha1.o
+USERLAND_CFLAGS += -DUSE_SHA1
 endif
 
 ifeq ($(USE_SHA2),true)


### PR DESCRIPTION
If we add USE_SHA1=yes to Makefile.inc.local
it won't pass to compile options for lib/libswan
so we have error:
make[1]: Entering directory 'lib/libswan'
cc -DTimeZoneOffset=timezone -Dlinux -D_GNU_SOURCE -pthread -std=gnu99 -g -Werror -Wall -Wextra -Wformat -Wformat-nonliteral -Wformat-security -Wundef -Wmissing-declarations -Wredundant-decls -Wnested-externs -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -fstack-protector-all -fno-strict-aliasing -fPIE -DPIE -DNSS_IPSEC_PROFILE -DXFRM_LIFETIME_DEFAULT=30 -DUSE_IKEv1 -DXFRM_SUPPORT -DUSE_XFRM_INTERFACE -DUSE_DNSSEC -DDEFAULT_DNSSEC_ROOTKEY_FILE=\"/usr/share/dns/root.key\" -DLIBCURL -DHAVE_NM -DAUTH_HAVE_PAM -DUSE_3DES -DUSE_AES -DUSE_CAMELLIA -DUSE_CHACHA -DUSE_DH31 -DUSE_MD5 -DUSE_SHA2 -DUSE_PRF_AES_XCBC -DDEFAULT_RUNDIR=\"/run/pluto\" -DIPSEC_CONF=\"/etc/ipsec.conf\" -DIPSEC_CONFDDIR=\"/etc/ipsec.d\" -DIPSEC_NSSDIR=\"/var/lib/ipsec/nss\" -DIPSEC_CONFDIR=\"/etc\" -DIPSEC_EXECDIR=\"/usr/local/libexec/ipsec\" -DIPSEC_SBINDIR=\"/usr/local/sbin\" -DIPSEC_VARDIR=\"/var\" -DPOLICYGROUPSDIR=\"/etc/ipsec.d/policies\" -DIPSEC_SECRETS_FILE=\"/etc/ipsec.secrets\" -DFORCE_PR_ASSERT -DUSE_FORK=1 -DUSE_VFORK=0 -DUSE_DAEMON=0 -DUSE_PTHREAD_SETSCHEDPRIO=1 -DGCC_LINT -DHAVE_LIBCAP_NG \
	-I. -I../../OBJ.linux.x86_64/lib/libswan -I../../include -I/usr/include/nss -I/usr/include/nspr \
	-DHERE_BASENAME=\"secrets.c\"  \
	-MF ../../OBJ.linux.x86_64/lib/libswan/secrets.d \
	-MP -MMD -MT secrets.o \
	-o ../../OBJ.linux.x86_64/lib/libswan/secrets.o \
	-c lib/libswan/secrets.c
lib/libswan/secrets.c: In function ‘RSA_sign_hash’:
lib/libswan/secrets.c:301:20: error: ‘ike_alg_hash_sha1’ undeclared (first use in this function); did you mean ‘ike_alg_hash_md5’?
      hash_algo == &ike_alg_hash_sha1 /* old style rsa with SHA1*/) {
                    ^~~~~~~~~~~~~~~~~
                    ike_alg_hash_md5
lib/libswan/secrets.c:301:20: note: each undeclared identifier is reported only once for each function it appears in
make[2]: *** [../../mk/rules.mk:57: secrets.o] Error 1
make[1]: *** [../../mk/targets.mk:82: all] Error 2
make[1]: Leaving directory 'lib/libswan'
make: *** [../mk/targets.mk:82: recursive-all] Error 2

So could you accept this patch or write something to better?