### PR TITLE
ikev2 redirect: make peer redirecting (others) in IKE_AUTH childless

### DIFF
--- a/programs/pluto/ikev2_child.c
+++ b/programs/pluto/ikev2_child.c
@@ -853,6 +853,11 @@ enum child_status process_v2_IKE_AUTH_request_child_sa_payloads(struct ike_sa *i
 		}
 	}
 
+	if (ike->sa.st_sent_redirect) {
+		dbg("sending REDIRECT in IKE_AUTH, no need for CHILD SA (payloads)");
+		return CHILD_SKIPPED;
+	}
+
 	/* try to process them */
 	if (!has_v2_IKE_AUTH_child_sa_payloads(md)) {
 		/*

--- a/testing/pluto/ikev2-redirect-02-auth/east.console.txt
+++ b/testing/pluto/ikev2-redirect-02-auth/east.console.txt
@@ -20,10 +20,6 @@ east #
 east NOW
 XFRM state:
 XFRM policy:
-src 192.0.2.0/24 dst 192.0.1.0/24
-	dir out priority 2084814 ptype main
-	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
 XFRM done
 IPSEC mangle TABLES
 NEW_IPSEC_CONN mangle TABLES
@@ -38,6 +34,6 @@ east #
  # confirm east is in unrouted state again
 east #
  hostname | grep east > /dev/null && ipsec status |grep "eroute owner"
-000 "westnet-eastnet-ipv4-psk-ikev2": 192.0.2.0/24===192.1.2.23<192.1.2.23>[@east]...192.1.2.45<192.1.2.45>[@west]===192.0.1.0/24; prospective erouted; eroute owner: #0
+000 "westnet-eastnet-ipv4-psk-ikev2": 192.0.2.0/24===192.1.2.23<192.1.2.23>[@east]...192.1.2.45<192.1.2.45>[@west]===192.0.1.0/24; unrouted; eroute owner: #0
 east #
  

--- a/testing/pluto/ikev2-redirect-03-auth-loop/east.console.txt
+++ b/testing/pluto/ikev2-redirect-03-auth-loop/east.console.txt
@@ -20,10 +20,6 @@ east #
 east NOW
 XFRM state:
 XFRM policy:
-src 192.0.2.0/24 dst 192.0.1.0/24
-	dir out priority 2084814 ptype main
-	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
 XFRM done
 IPSEC mangle TABLES
 NEW_IPSEC_CONN mangle TABLES
@@ -38,6 +34,6 @@ east #
  # confirm east is in unrouted state again
 east #
  hostname | grep east > /dev/null && ipsec status |grep "eroute owner"
-000 "westnet-eastnet-ipv4-psk-ikev2": 192.0.2.0/24===192.1.2.23<192.1.2.23>[@east]...192.1.2.45<192.1.2.45>[@west]===192.0.1.0/24; prospective erouted; eroute owner: #0
+000 "westnet-eastnet-ipv4-psk-ikev2": 192.0.2.0/24===192.1.2.23<192.1.2.23>[@east]...192.1.2.45<192.1.2.45>[@west]===192.0.1.0/24; unrouted; eroute owner: #0
 east #
  


### PR DESCRIPTION
This solves #453 as well. Also peers that are redirecting others don't have a dead kernel policy anymore, see testing commit.