### PR TITLE
ipsec barf: fix shell test expression

### DIFF
--- a/programs/barf/barf.in
+++ b/programs/barf/barf.in
@@ -53,8 +53,8 @@ findlog() {	# findlog string fallbackstring possiblefile ...
     for f
     do
 	if [ -s ${LOGS}/${f} -a \
-	    -f ${LOGS}/${f} -a \
-	    grep -E -q "${s}" ${LOGS}/${f} 2>/dev/null ]
+	    -f ${LOGS}/${f} ] && \
+	    grep -E -q "${s}" ${LOGS}/${f} 2>/dev/null
 	then
 	    # aha, this one has it
 	    findlog_file=${LOGS}/${f}
@@ -66,8 +66,8 @@ findlog() {	# findlog string fallbackstring possiblefile ...
     for f
     do
 	if [ -s ${LOGS}/${f} -a \
-	    -f ${LOGS}/${f} -a \
-	    grep -E -q "${t}" ${LOGS}/${f} 2>/dev/null ]
+	    -f ${LOGS}/${f} ] && \
+	    grep -E -q "${t}" ${LOGS}/${f} 2>/dev/null
 	then
 	    # aha, this one has it
 	    findlog_file=${LOGS}/${f}
@@ -80,8 +80,8 @@ findlog() {	# findlog string fallbackstring possiblefile ...
     for f in $(ls -t ${LOGS} | grep -E -v 'lastlog|tmp|^mail|\.(gz|Z)$')
 	do
 	if [ -f ${LOGS}/${f} -a \
-	    ! -d ${LOGS}/${f} -a \
-	    grep -E -q "${s}" ${LOGS}/${f} 2>/dev/null ]
+	    ! -d ${LOGS}/${f} ] && \
+	    grep -E -q "${s}" ${LOGS}/${f} 2>/dev/null
 	then
 	    # found it
 	    findlog_file=${LOGS}/${f}
@@ -93,8 +93,8 @@ findlog() {	# findlog string fallbackstring possiblefile ...
     for f in $(ls -t ${LOGS} | grep -E -v 'lastlog|tmp|^mail|\.(gz|Z)$')
     do
 	if [ -s ${LOGS}/${f} -a \
-	    -f ${LOGS}/${f} -a \
-	    grep -E -q "${t}" ${LOGS}/${f} 2>/dev/null ]
+	    -f ${LOGS}/${f} ] && \
+	    grep -E -q "${t}" ${LOGS}/${f} 2>/dev/null
 	then
 	    # found it
 	    findlog_file=${LOGS}/${f}


### PR DESCRIPTION
Spotted by shellcheck:
```
  /usr/libexec/ipsec/barf:55:5: error[SC1073]: Couldn't parse this test expression. Fix to allow more checks.
  #   53|       for f
  #   54|       do
  #   55|-> 	if [ -s ${LOGS}/${f} -a \
  #   56|   	    -f ${LOGS}/${f} -a \
  #   57|   	    grep -E -q "${s}" ${LOGS}/${f} 2>/dev/null ]
```
Signed-off-by: Daiki Ueno <dueno@redhat.com>