### PR TITLE
pluto: fix build warnings against musl c-library

### DIFF
--- a/programs/pluto/demux.c
+++ b/programs/pluto/demux.c
@@ -30,9 +30,9 @@
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>
+#include <poll.h>       /* only used for forensic poll call */
 #include <sys/types.h>
 #include <sys/time.h>   /* only used for belt-and-suspenders select call */
-#include <sys/poll.h>   /* only used for forensic poll call */
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>

--- a/programs/pluto/iface_udp.c
+++ b/programs/pluto/iface_udp.c
@@ -852,7 +852,7 @@ static bool check_msg_errqueue(const struct iface_endpoint *ifp, short interest,
 				llog(RC_LOG, logger,
 				     "unknown cmsg: level %d, type %d, len %zu",
 				     cm->cmsg_level, cm->cmsg_type,
-				     cm->cmsg_len);
+				     (size_t)cm->cmsg_len);
 			}
 		}
 	}

--- a/programs/pluto/kernel_linux.c
+++ b/programs/pluto/kernel_linux.c
@@ -23,9 +23,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <wait.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <sys/wait.h>
 #include <sys/ioctl.h>
 #include <sys/utsname.h>
 


### PR DESCRIPTION
Use POSIX defined locations for poll.h and sys/wait.h.
Cast cmsg_len to size_t as the struct member may be an int.