### PR TITLE
pluto: do not include NSS headers in ikev2_ipseckey_dnsr.c

### DIFF
--- a/programs/pluto/ikev2_ipseckey.h
+++ b/programs/pluto/ikev2_ipseckey.h
@@ -1,4 +1,5 @@
 #include "state.h"
+#include "ikev2_ipseckey_dnsr.h" /* for dns_status */
 
 #ifndef _IKEV2_IPSECKEY_H
 #define _IKEV2_IPSECKEY_H
@@ -10,12 +11,6 @@
 #endif
 
 #define IS_LIBUNBOUND LSW_LIBUNBOUND_ENABLED
-
-typedef enum {
-	DNS_OK = STF_OK,
-	DNS_FATAL = STF_FATAL,
-	DNS_SUSPEND = STF_SUSPEND,
-} dns_status;
 
 dns_status responder_fetch_idi_ipseckey(struct ike_sa *ike,
 					stf_status (*callback)(struct ike_sa *ike,

--- a/programs/pluto/ikev2_ipseckey_dnsr.c
+++ b/programs/pluto/ikev2_ipseckey_dnsr.c
@@ -19,6 +19,12 @@
  * for more details.
  */
 
+/* This file has been split from ikev2_ipseckey.c to avoid macro
+ * conflicts between NSS headers and OpenSSL 3.0 headers (included
+ * through <ldns/ldns.h>. Therefore, this file should not include
+ * internal headers that depends on NSS headers.
+ */
+
 #ifndef USE_DNSSEC
 # error this file should only be compiled when DNSSEC is defined
 #endif
@@ -30,7 +36,6 @@
 #include <unbound.h>
 #include "unbound-event.h"
 #include "dnssec.h"    /* includes unbound.h */
-#include "ikev2_ipseckey.h" /* for dns_status */
 #include "ikev2_ipseckey_dnsr.h"
 #include "secrets.h"
 

--- a/programs/pluto/ikev2_ipseckey_dnsr.h
+++ b/programs/pluto/ikev2_ipseckey_dnsr.h
@@ -3,6 +3,12 @@
 #ifndef _IKEV2_IPSECKEY_DNSR_H
 #define _IKEV2_IPSECKEY_DNSR_H
 
+typedef enum {
+	DNS_OK = STF_OK,
+	DNS_FATAL = STF_FATAL,
+	DNS_SUSPEND = STF_SUSPEND,
+} dns_status;
+
 struct p_dns_req;
 
 typedef void dnsr_cb_fn(struct p_dns_req *);
@@ -22,6 +28,8 @@ typedef void dnsr_pubkeys_cb_fn(struct p_dns_req *dnsr,
 
 typedef void dnsr_validate_address_cb_fn(struct p_dns_req *dnsr,
 					 unsigned char *addr);
+
+struct ike_sa;
 
 struct p_dns_req {
 	dns_status dns_status;


### PR DESCRIPTION
This file has an inherent dependency on OpenSSL 3.0 headers through
<ldns/ldns.h>, which causes macro conflicts with NSS.

Related to #474.

Signed-off-by: Daiki Ueno <dueno@redhat.com>