### PR TITLE
Fix CVE-2022-23094 patch for 4.3 and 4.2

### DIFF
--- a/security/CVE-2022-23094.txt
+++ b/security/CVE-2022-23094.txt
@@ -101,7 +101,7 @@ index 4f644fd4f8..e0f3652aa9 100644
  								 &pd->payload, sizeof(pd->payload), &pd->pbs);
  					if (d != NULL) {
 - -						log_diag(RC_LOG, st->st_logger, &d, "%s", "");
-+						llog_diag(RC_LOG,
++						log_diag(RC_LOG,
 +							st != NULL ? st->st_logger : md->md_logger,
 +							&d, "%s", "");
  						LOG_PACKET(RC_LOG_SERIOUS,
@@ -112,7 +112,7 @@ index 4f644fd4f8..e0f3652aa9 100644
  						 &pd->pbs);
  			if (d != NULL) {
 - -				log_diag(RC_LOG, st->st_logger, &d, "%s", "");
-+				llog_diag(RC_LOG,
++				log_diag(RC_LOG,
 +					st != NULL ? st->st_logger : md->md_logger,
 +					&d, "%s", "");
  				LOG_PACKET(RC_LOG_SERIOUS,


### PR DESCRIPTION
libreswan 4.2 and 4.3 only have log_diag, not llog_diag.

Note that this change breaks the OpenPGP signature over the CVE
announcement, so it probably needs to be re-signed.