### PR TITLE
make ikev1-policy default to "drop"

### DIFF
--- a/configs/d.ipsec.conf/ikev1-policy.xml
+++ b/configs/d.ipsec.conf/ikev1-policy.xml
@@ -3,9 +3,10 @@
   <listitem>
 <para>
 What to do with received IKEv1 packets. Valid options are
-<emphasis remap='B'>accept</emphasis> (default), <emphasis remap='B'>reject</emphasis> which
-will reply with an error, and <emphasis remap='B'>drop</emphasis> which will silently drop
-any received IKEv1 packet. If this option is set to drop or reject, an attempt to load an
+<emphasis remap='B'>drop</emphasis> (default) which will silently drop
+any received IKEv1 packet, <emphasis remap='B'>accept</emphasis>, and
+<emphasis remap='B'>reject</emphasis> which will reply with an error.
+If this option is set to drop or reject, an attempt to load an
 IKEv1 connection will fail, as these connections would never be able to receive a packet
 for processing.
 </para>

--- a/include/ipsecconf/keywords.h
+++ b/include/ipsecconf/keywords.h
@@ -111,7 +111,7 @@ enum keyword_numeric_config_field {
 
 	KBF_LISTEN_TCP,		/* listen on TCP port 4500 - default no */
 	KBF_LISTEN_UDP,		/* listen on UDP port 500/4500 - default yes */
-	KBF_GLOBAL_IKEv1,	/* global ikev1 policy - default accept */
+	KBF_GLOBAL_IKEv1,	/* global ikev1 policy - default drop */
 	KBF_ROOF
 };
 

--- a/lib/libipsecconf/confread.c
+++ b/lib/libipsecconf/confread.c
@@ -95,6 +95,7 @@ static void ipsecconf_default_values(struct starter_config *cfg)
 	/* Don't inflict BSI requirements on everyone */
 	SOPT(KBF_SEEDBITS, 0);
 	SOPT(KBF_DROP_OPPO_NULL, false);
+	SOPT(KBF_GLOBAL_IKEv1, GLOBAL_IKEv1_DROP);
 
 #ifdef HAVE_LABELED_IPSEC
 	SOPT(KBF_SECCTX, SECCTX);

--- a/programs/pluto/server.c
+++ b/programs/pluto/server.c
@@ -188,12 +188,7 @@ bool pluto_listen_tcp = false;
 enum ddos_mode pluto_ddos_mode = DDOS_AUTO; /* default to auto-detect */
 
 enum global_ikev1_policy pluto_ikev1_pol =
-#ifdef USE_IKEv1
-	 GLOBAL_IKEv1_ACCEPT;
-#else
-	/* there is no IKEv1 code compiled in to send a REJECT */
 	GLOBAL_IKEv1_DROP;
-#endif
 
 #ifdef HAVE_SECCOMP
 enum seccomp_mode pluto_seccomp_mode = SECCOMP_DISABLED;


### PR DESCRIPTION
IKEv2 has been available for 16 years (RFC 4306 was published December
2005).  At some point, we should be discouraging IKEv1 adoption.

To the extent that a user needs IKEv1, they can manually add
ikev1-policy=accept to /etc/ipsec.conf.

---

This is just a proposal, happy to hear any feedback on it.

At some point, the long term goal will probably be to change `USE_IKEv1` to be undefined by default, but a reasonable first step is to require admins to explicitly turn it on.  that's what this change does.

This kind of deprecation work is a belt-and-suspenders approach to minimize the potential scale of any implementation vulnerabilities like CVE-2022-23094.