### PR TITLE
Fix nsspassword location in tests

### DIFF
--- a/testing/guestbin/swan-prep
+++ b/testing/guestbin/swan-prep
@@ -503,7 +503,7 @@ if userland in ("libreswan", "openswan"):
         with open("/run/pluto/nsspw", "w") as f:
             f.write(dbpassword)
             f.write("\n")
-        with open(nssdir + "/nsspassword", "w") as f:
+        with open(ipsecdir + "/nsspassword", "w") as f:
             if args.nsspw:
                 f.write("NSS Certificate DB:" + dbpassword + "\n")
             if args.fips:


### PR DESCRIPTION
NSS password needs to be located in ipsecdir instead
of nssdir. For the testuite it does not matter but
if a testsuite is used with a nssdir that differs from
ipsecdir it causes issues.