### PR TITLE
libswan: add self-tests that exercise IKEv2 key derivation

### DIFF
--- a/include/ike_alg_test_prf.h
+++ b/include/ike_alg_test_prf.h
@@ -27,3 +27,26 @@ extern const struct prf_test_vector hmac_md5_prf_tests[];
 bool test_prf_vectors(const struct prf_desc *desc,
 		      const struct prf_test_vector *tests,
 		      struct logger *logger);
+
+struct kdf_test_vector {
+	const char *description;
+	const char *ni;
+	unsigned ni_size;
+	const char *nr;
+	unsigned nr_size;
+	const char *gir;
+	const char *gir_new;
+	unsigned gir_size;
+	const char *spii;
+	const char *spir;
+	const char *skeyseed;
+	const char *skeyseed_rekey;
+	const char *dkm;
+	unsigned dkm_size;
+};
+
+extern const struct kdf_test_vector hmac_sha1_kdf_tests[];
+
+bool test_kdf_vectors(const struct prf_desc *desc,
+		      const struct kdf_test_vector *tests,
+		      struct logger *logger);

--- a/lib/libswan/ike_alg_prf_test_vectors.c
+++ b/lib/libswan/ike_alg_prf_test_vectors.c
@@ -166,6 +166,7 @@ static bool test_prf_vector(const struct prf_desc *prf,
 		? decode_to_chunk(__func__, test->message)
 		: alloc_chunk(test->message_size, __func__);
 	chunk_t prf_output = decode_to_chunk(__func__, test->prf_output);
+	bool ok = true;
 
 
 	/* chunk interface */
@@ -177,7 +178,9 @@ static bool test_prf_vector(const struct prf_desc *prf,
 	if (DBGP(DBG_CRYPT)) {
 		DBG_dump_hunk("chunk output", chunk_output);
 	}
-	bool ok = verify_hunk(test->description, prf_output, chunk_output);
+	if (!verify_hunk(test->description, prf_output, chunk_output)) {
+		ok = false;
+	}
 
 	/* symkey interface */
 	PK11SymKey *symkey_key = symkey_from_hunk("key symkey", chunk_key, logger);
@@ -191,9 +194,10 @@ static bool test_prf_vector(const struct prf_desc *prf,
 	if (DBGP(DBG_CRYPT)) {
 		DBG_symkey(logger, "output", "symkey", symkey_output);
 	}
-	ok = verify_symkey(test->description, prf_output, symkey_output, logger);
+	if (!verify_symkey(test->description, prf_output, symkey_output, logger)) {
+		ok = false;
+	}
 	DBGF(DBG_CRYPT, "%s: %s %s", __func__, test->description, ok ? "passed" : "failed");
-	release_symkey(__func__, "symkey", &symkey_output);
 
 	free_chunk_content(&chunk_message);
 	free_chunk_content(&chunk_key);

--- a/lib/libswan/ike_alg_test.c
+++ b/lib/libswan/ike_alg_test.c
@@ -50,4 +50,7 @@ void test_ike_alg(struct logger *logger)
 #ifdef USE_MD5
 	TEST(test_prf_vectors, ike_alg_prf_hmac_md5,       hmac_md5_prf_tests);
 #endif
+#ifdef USE_SHA1
+	TEST(test_kdf_vectors, ike_alg_prf_sha1,           hmac_sha1_kdf_tests);
+#endif
 }


### PR DESCRIPTION
This adds a self-test that exercise key derivation through the
CKM_NSS_IKE_PRF_DERIVE and CKM_NSS_IKE_PRF_PLUS_DERIVE mechanisms
provided by NSS.  As such, while the test vector is taken from CAVP,
it only covers minimal scenarios.
