### PR TITLE
seccomp: whitelist statfs64

### DIFF
--- a/programs/pluto/pluto_seccomp.c
+++ b/programs/pluto/pluto_seccomp.c
@@ -158,6 +158,7 @@ static void init_seccomp(uint32_t def_action, bool main, struct logger *logger)
 	LSW_SECCOMP_ADD(sigreturn);
 	LSW_SECCOMP_ADD(stat);
 	LSW_SECCOMP_ADD(statfs);
+	LSW_SECCOMP_ADD(statfs64);
 	LSW_SECCOMP_ADD(waitpid);
 	LSW_SECCOMP_ADD(write);
 


### PR DESCRIPTION
On ppc64le machines the following SECCOMP violation is reported
even though it does not affect connections:

type=SECCOMP msg=audit(...) : auid=unset uid=root gid=root ses=unset
subj=system_u:system_r:ipsec_mgmt_t:s0 pid=19268 comm=sed
exe=/usr/bin/sed sig=SIGSYS arch=ppc64le syscall=statfs64 compat=0
ip=0x7fff7f6978fc code=kill