### PR TITLE
fix debian packaging missing systemd unit ipsec.service

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -27,6 +27,7 @@ override_dh_auto_build:
 		LIBEXECDIR=/usr/libexec/ipsec \
 		MANDIR=/usr/share/man \
 		USE_LDAP=true \
+		INITSYSTEM=systemd \
 		$(ENABLE_LIBCAP_NG) \
 		$(ENABLE_SELINUX)
 
@@ -39,6 +40,7 @@ override_dh_auto_install-arch:
 		LIBEXECDIR=/usr/libexec/ipsec \
 		MANDIR=/usr/share/man \
 		USE_LDAP=true \
+		INITSYSTEM=systemd \
 		$(ENABLE_LIBCAP_NG) \
 		$(ENABLE_SELINUX) \
 		DESTDIR=$(CURDIR)/debian/libreswan


### PR DESCRIPTION
when "make deb", the resulting package does not have the unit file for systemd, this commit solves the issue.

dpkg -c libreswan_4.9-1_amd64.deb  | grep service
-rw-r--r-- root/root      1531 2022-10-13 01:00 ./lib/systemd/system/ipsec.service

