### PR TITLE
documentation: Fix typo

### DIFF
--- a/configs/d.ipsec.conf/nat-keepalive.xml
+++ b/configs/d.ipsec.conf/nat-keepalive.xml
@@ -2,7 +2,7 @@
   <term><emphasis remap='B'>nat-keepalive</emphasis></term>
   <listitem>
 <para>whether to send any NAT-T keep-alives. These one byte packets
-are send to prevent the NAT router from closing its port when there is
+are sent to prevent the NAT router from closing its port when there is
 not enough traffic on the IPsec connection. Acceptable values are:
 <emphasis remap='B'>yes</emphasis> (the default) and
 <emphasis remap='B'>no</emphasis>.

--- a/programs/pluto/ipsec_pluto.8.xml
+++ b/programs/pluto/ipsec_pluto.8.xml
@@ -943,7 +943,7 @@
           <manvolnum>5</manvolnum>
         </citerefentry> for the syntax. The option
       <option>--force-keepalive</option> forces the sending of the <emphasis
-      remap="I">keep-alive packets</emphasis>, which are send to prevent the
+      remap="I">keep-alive packets</emphasis>, which are sent to prevent the
       NAT router from closing its port when there is not enough traffic on the
       IPsec connection. The <option>--keep-alive</option> sets the delay (in
       seconds) of these keep-alive packets. The newer NAT-T standards support


### PR DESCRIPTION
Hi,

i'm pretty sure, albeit not 100%, that "send" should be in the "sent" form here.

best regards,
Max