### PR TITLE
WIP: typos found 2023-01-12

### DIFF
--- a/programs/_updown.xfrm/_updown.xfrm.in
+++ b/programs/_updown.xfrm/_updown.xfrm.in
@@ -906,7 +906,7 @@ addvtiiface() {
 			echo "vti interface already exists with identical parameters, OK"
 		    fi
 		else
-		    echo "vti interface \"${VTI_IFACE}\" already exists with conflicting setting (perhaps need vti-sharing=yes ?"
+		    echo "vti interface \"${VTI_IFACE}\" already exists with conflicting setting (perhaps need vti-shared=yes ?"
 		fi
 	    fi
 	fi

--- a/programs/pluto/ipsec_pluto.8.xml
+++ b/programs/pluto/ipsec_pluto.8.xml
@@ -3251,7 +3251,7 @@
           <term><emphasis remap="B">PLUTO_PEER_ID</emphasis></term>
 
           <listitem>
-            <para>Dlists our peer's id.</para>
+            <para>lists our peer's id.</para>
           </listitem>
         </varlistentry>
 

--- a/testing/pluto/ikev2-xfrmi-11-vti-default-route/north.console.txt
+++ b/testing/pluto/ikev2-xfrmi-11-vti-default-route/north.console.txt
@@ -28,7 +28,7 @@ north #
 002 "north-east" #2: up-client output: net.ipv4.conf.vti0.disable_policy = 1
 002 "north-east" #2: up-client output: net.ipv4.conf.vti0.rp_filter = 0
 002 "north-east" #2: up-client output: net.ipv4.conf.vti0.forwarding = 1
-002 "north-east" #2: prepare-client output: vti interface "vti0" already exists with conflicting setting (perhaps need vti-sharing=yes ?
+002 "north-east" #2: prepare-client output: vti interface "vti0" already exists with conflicting setting (perhaps need vti-shared=yes ?
 004 "north-east" #2: initiator established Child SA using #1; IPsec tunnel [0.0.0.0-255.255.255.255:0-65535 0] -> [0.0.0.0-255.255.255.255:0-65535 0] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256-NONE DPD=passive}
 north #
  ping -n -q -w 4 -c 4 192.0.2.254

--- a/testing/pluto/netkey-vti-01/west.console.txt
+++ b/testing/pluto/netkey-vti-01/west.console.txt
@@ -50,7 +50,7 @@ west #
 002 "westnet-eastnet-vti" #2: up-client output: net.ipv4.conf.vti0.disable_policy = 1
 002 "westnet-eastnet-vti" #2: up-client output: net.ipv4.conf.vti0.rp_filter = 0
 002 "westnet-eastnet-vti" #2: up-client output: net.ipv4.conf.vti0.forwarding = 1
-002 "westnet-eastnet-vti" #2: prepare-client output: vti interface "vti0" already exists with conflicting setting (perhaps need vti-sharing=yes ?
+002 "westnet-eastnet-vti" #2: prepare-client output: vti interface "vti0" already exists with conflicting setting (perhaps need vti-shared=yes ?
 004 "westnet-eastnet-vti" #2: IPsec SA established tunnel mode {ESP=>0xESPESP <0xESPESP xfrm=AES_CBC_128-HMAC_SHA1_96 DPD=passive}
 west #
  # since we have vti-routing=no, no marking, so unencrypted packets are dropped

--- a/testing/pluto/netkey-vti-05/west.console.txt
+++ b/testing/pluto/netkey-vti-05/west.console.txt
@@ -46,7 +46,7 @@ west #
 002 "westnet-eastnet-vti" #2: up-client output: net.ipv4.conf.vti0.disable_policy = 1
 002 "westnet-eastnet-vti" #2: up-client output: net.ipv4.conf.vti0.rp_filter = 0
 002 "westnet-eastnet-vti" #2: up-client output: net.ipv4.conf.vti0.forwarding = 1
-002 "westnet-eastnet-vti" #2: prepare-client output: vti interface "vti0" already exists with conflicting setting (perhaps need vti-sharing=yes ?
+002 "westnet-eastnet-vti" #2: prepare-client output: vti interface "vti0" already exists with conflicting setting (perhaps need vti-shared=yes ?
 004 "westnet-eastnet-vti" #2: IPsec SA established tunnel mode {ESP=>0xESPESP <0xESPESP xfrm=AES_CBC_128-HMAC_SHA1_96 DPD=passive}
 west #
  # Without the sleep, XfrmInNoPols shows first packet sometimes goes out before policy is in place?

--- a/testing/pluto/netkey-vti-06/road.console.txt
+++ b/testing/pluto/netkey-vti-06/road.console.txt
@@ -26,7 +26,7 @@ road #
 002 "road-east-vti" #2: up-client output: net.ipv4.conf.vti0.disable_policy = 1
 002 "road-east-vti" #2: up-client output: net.ipv4.conf.vti0.rp_filter = 0
 002 "road-east-vti" #2: up-client output: net.ipv4.conf.vti0.forwarding = 1
-002 "road-east-vti" #2: prepare-client output: vti interface "vti0" already exists with conflicting setting (perhaps need vti-sharing=yes ?
+002 "road-east-vti" #2: prepare-client output: vti interface "vti0" already exists with conflicting setting (perhaps need vti-shared=yes ?
 004 "road-east-vti" #2: IPsec SA established tunnel mode {ESP=>0xESPESP <0xESPESP xfrm=AES_CBC_128-HMAC_SHA1_96 DPD=passive}
 road #
  # since we have vti-routing=no, no marking, so unencrypted packets are dropped


### PR DESCRIPTION
Hi there,

This pull requests includes two typos found, each in their respective commit.

1) One small typo in the pluto manpage is fixed.

2) I notices a warning message in my log like so:
``prepare-client output: vti interface "vti42" already exists with conflicting setting (perhaps need vti-sharing=yes ?``
However, the setting "vti-sharing" does not exist according to the ipsec.conf(5) manpage and a libreswan wiki search. I would say this is a typo, and actually the setting is actually called "vti-shared".

This pull-request is work-in-progress, as i am unsure to what steps to follow to fully test this change (As this does not only affect documentation files).

best regards,
Max


PS: The text in https://libreswan.org/man/ipsec_pluto.8.html points to itself. Is there a publicly available repo to submit a fix?