### PR TITLE
Fix referenced before assignment in nsrun script

### DIFF
--- a/testing/utils/nsrun
+++ b/testing/utils/nsrun
@@ -607,6 +607,9 @@ class TestList:
             if line[0] == '#':
                 logger.debug("skip comment: %s", line)
                 continue
+            testdir = ''
+            testtype = ''
+            testexpect = ''
             try:
                 tokens = []
                 tokens = line.split()


### PR DESCRIPTION
- The TestList __next__() function had 3 variables that were referenced before they were assigned.
- This was encountered on a Fedora 36 cloud-based VM, running the testsuite with Namespaces in the VM. The version of Python on the VM is 3.10.9.

Signed-off-by: Brady Johnson <bradyallenjohnson@gmail.com>