### PR TITLE
Fix versioning when using topic branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ include $(top_srcdir)/mk/config.mk
 MAIN_RPMBUILD_SOURCES  = $(shell rpm --eval %{_sourcedir})
 MAIN_RPMBUILD_SPEC  = $(shell rpm --eval %{_specdir})
 MAIN_RPM_VERSION = $(shell make showversion | sed "s/-.*//")
-MAIN_RPM_PREVER = $(shell make showversion | sed -e  "s/^.[^-]*-\([^-]*\)-\(.*\)/rc\1_\2/" -e "s/-/_/g")
+MAIN_RPM_PREVER = $(shell make showversion | sed -e  "s/^.[^-]*-\([^-]*\)-\(.*\)/rc\1_\2/" -e "s/-/_/g" -e "s/\//_/g")
 MAIN_RPM_PREFIX  = libreswan-$(MAIN_RPM_VERSION)$(MAIN_RPM_PREVER)
 MAIN_RPM_RHEL_PKG = $(shell rpm -qf /etc/redhat-release)
 MAIN_RPM_RHEL_VERSION = $(shell echo $(MAIN_RPM_RHEL_PKG) | sed "s/.*-release-\(.\).*/\1/")

--- a/lib/libswan/Makefile
+++ b/lib/libswan/Makefile
@@ -282,8 +282,8 @@ OBJS += $(abs_builddir)/version.o
 # build version.c using version number from mk/version.mk
 $(abs_builddir)/version.c: $(srcdir)/version.in.c $(top_srcdir)/mk/version.mk
 	rm -f $@.tmp
-	sed -e '/"/s/@IPSECVERSION@/$(subst /,\/,$(IPSECVERSION))/' \
-	    -e '/"/s/@IPSECVIDVERSION@/$(IPSECVIDVERSION)/' \
+	sed -e '/"/s/@IPSECVERSION@/$(subst /,_,$(IPSECVERSION))/' \
+	    -e '/"/s/@IPSECVIDVERSION@/$(subst /,_,$(IPSECVIDVERSION))/' \
 	    $(srcdir)/version.in.c \
 	    > $@.tmp
 	mv $@.tmp $@

--- a/packaging/utils/setlibreswanversion
+++ b/packaging/utils/setlibreswanversion
@@ -25,7 +25,7 @@ cd "${2:-.}" || usage
 # -f .git check is needed for "git worktree"
 if [ -d .git -o -f .git ]; then
     if git version >/dev/null 2>&1; then
-	CUR=$(git describe --tags ${ADD_GIT_DIRTY})
+	CUR=$(git describe --tags --always ${ADD_GIT_DIRTY})
 	BRANCH=$(git rev-parse --abbrev-ref HEAD)
 	echo "${CUR}-${BRANCH}"
 	exit 0


### PR DESCRIPTION
- The command "git describe --tags" used in setlibreswanversion returns error: "fatal: No names found, cannot describe anything." that is fixed adding the "--always" as a fallback.
- When the branch name is something like "topic/some_name" the sed scripts in the Makefiles need some slight tweaking.