### PR TITLE
ikev2: modify .story of STATE_V2_PARENT_R1 state

### DIFF
--- a/programs/pluto/ikev2_states.c
+++ b/programs/pluto/ikev2_states.c
@@ -85,7 +85,7 @@ struct finite_state v2_states[] = {
 
 	S(STATE_V2_PARENT_I1, "sent IKE_SA_INIT request", CAT_HALF_OPEN_IKE_SA),
 	S(STATE_V2_PARENT_R0, "processing IKE_SA_INIT request", CAT_HALF_OPEN_IKE_SA),
-	S(STATE_V2_PARENT_R1, "sent IKE_SA_INIT reply", CAT_HALF_OPEN_IKE_SA, .v2.secured = true),
+	S(STATE_V2_PARENT_R1, "sent IKE_SA_INIT (or IKE_INTERMEDIATE) response", CAT_HALF_OPEN_IKE_SA, .v2.secured = true),
 	S(STATE_V2_PARENT_R_EAP, "sent EAP request", CAT_OPEN_IKE_SA, .v2.secured = true),
 
 	/*

--- a/testing/pluto/ikev2-crossing-streams-02/description.txt
+++ b/testing/pluto/ikev2-crossing-streams-02/description.txt
@@ -28,7 +28,7 @@ Mar  1 03:44:37.471843: "conn7" #2364: ERROR: asynchronous network error report 
 Mar  1 03:44:45.480036: "conn7" #2364: STATE_PARENT_I1: retransmission; will wait 16 seconds for response
 Mar  1 03:44:45.481185: "conn7" #2364: ERROR: asynchronous network error report on ens192 (172.16.1.2:500), complainant 172.16.2.2: Connection refused [errno 111, origin ICMP type 3 code 3 (not authenticated)]
 Mar  1 03:44:55.365359: "conn7" #2365: proposal 1:IKE=AES_CBC_128-HMAC_MD5-HMAC_MD5_96-MODP2048 chosen from remote proposals 1:IKE:ENCR=AES_CBC_128;PRF=HMAC_MD5;INTEG=HMAC_MD5_96;DH=MODP2048[first-match]
-Mar  1 03:44:55.367416: "conn7" #2365: sent IKE_SA_INIT reply {auth=IKEv2 cipher=AES_CBC_128 integ=HMAC_MD5_96 prf=HMAC_MD5 group=MODP2048}
+Mar  1 03:44:55.367416: "conn7" #2365: sent IKE_SA_INIT (or IKE_INTERMEDIATE) response {auth=IKEv2 cipher=AES_CBC_128 integ=HMAC_MD5_96 prf=HMAC_MD5 group=MODP2048}
 Mar  1 03:44:55.376118: "conn7" #2365: processing decrypted IKE_AUTH request: SK{IDi,AUTH,SA,TSi,TSr}
 Mar  1 03:44:55.376166: "conn7" #2365: IKEv2 mode peer ID is ID_IPV4_ADDR: '172.16.2.2'
 Mar  1 03:44:55.376370: "conn7" #2365: authenticated using authby=secret

--- a/testing/pluto/ikev2-crossing-streams-02/road.console.txt
+++ b/testing/pluto/ikev2-crossing-streams-02/road.console.txt
@@ -104,6 +104,6 @@ road #
  ipsec status |grep STATE_
 000 #1: "static":500 STATE_V2_ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
 000 #2: "static":500 STATE_V2_ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
-000 #3: "static":500 STATE_V2_PARENT_R1 (sent IKE_SA_INIT reply); DISCARD in XXs; idle;
+000 #3: "static":500 STATE_V2_PARENT_R1 (sent IKE_SA_INIT (or IKE_INTERMEDIATE) response); DISCARD in XXs; idle;
 road #
  

--- a/testing/pluto/ikev2-impair-07-send-empty-ike-ke/east.console.txt
+++ b/testing/pluto/ikev2-impair-07-send-empty-ike-ke/east.console.txt
@@ -19,6 +19,6 @@ east #
 "westnet-eastnet-ipv4-psk-ikev2" #1: encountered fatal error in state STATE_V2_PARENT_R0
 "westnet-eastnet-ipv4-psk-ikev2" #1: deleting state (STATE_V2_PARENT_R0) and NOT sending notification
 "westnet-eastnet-ipv4-psk-ikev2" #2: IMPAIR: sending an empty KE value
-"westnet-eastnet-ipv4-psk-ikev2" #2: sent IKE_SA_INIT reply {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=MODP2048}
+"westnet-eastnet-ipv4-psk-ikev2" #2: sent IKE_SA_INIT (or IKE_INTERMEDIATE) response {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=MODP2048}
 east #
  


### PR DESCRIPTION
STATE_V2_PARENT_R1 .story currently does not replicate reality, it can also result in IKE_INTERMEDIATE response (not only IKE_SA_INIT response).

The discrepancy was found during inspecting responder pluto logs of ikev2-intermediate-02-psk/ test.