### PR TITLE
Introduce ppk-ids connection option as a prep work for draft-smyslov-ipsecme-ikev2-qr-alt-07 (PPKs during INTERMEDIATE exchange)

### DIFF
--- a/configs/Makefile
+++ b/configs/Makefile
@@ -153,6 +153,7 @@ XMLSOURCES += d.ipsec.conf/ms-dh-downgrade.xml
 XMLSOURCES += d.ipsec.conf/dns-match-id.xml
 XMLSOURCES += d.ipsec.conf/require-id-on-certificate.xml
 XMLSOURCES += d.ipsec.conf/ppk.xml
+XMLSOURCES += d.ipsec.conf/ppk-ids.xml
 XMLSOURCES += d.ipsec.conf/nat-ikev1-method.xml
 XMLSOURCES += d.ipsec.conf/esp.xml
 XMLSOURCES += d.ipsec.conf/ah.xml

--- a/configs/d.ipsec.conf/ppk-ids.xml
+++ b/configs/d.ipsec.conf/ppk-ids.xml
@@ -1,0 +1,13 @@
+  <varlistentry>
+  <term><emphasis remap='B'>ppk-ids</emphasis></term>
+  <listitem>
+<para>EXPERIMENTAL: Specify which PPK_ID's to look for in .secrets file.
+The value must be a string (enclosed in quotes) containing a comma-separated 
+list with PPK_ID's. Whitespaces can be a part of PPK_ID and will not be
+stripped. If some PPK_ID's are specified and PPK feature is enabled
+(<emphasis remap='B'>ppk=</emphasis>), one of the PPK secrets must have an ID
+matching one of the specified PPK_ID's. If this option is not set and the PPK
+feature is enabled, any matching PPK secret will be used.
+</para>
+  </listitem>
+  </varlistentry>

--- a/configs/d.ipsec.conf/ppk-ids.xml
+++ b/configs/d.ipsec.conf/ppk-ids.xml
@@ -3,11 +3,11 @@
   <listitem>
 <para>EXPERIMENTAL: Specify which PPK_ID's to look for in .secrets file.
 The value must be a string (enclosed in quotes) containing a comma-separated 
-list with PPK_ID's. Whitespaces can be a part of PPK_ID and will not be
-stripped. If some PPK_ID's are specified and PPK feature is enabled
-(<emphasis remap='B'>ppk=</emphasis>), one of the PPK secrets must have an ID
-matching one of the specified PPK_ID's. If this option is not set and the PPK
-feature is enabled, any matching PPK secret will be used.
+list with PPK_ID's. Whitespaces cannot be a part of PPK_ID, i.e., they will be
+seen as a delimiter. If some PPK_ID's are specified and PPK feature
+is enabled (<emphasis remap='B'>ppk=</emphasis>), one of the PPK secrets must
+have an ID matching one of the specified PPK_ID's. If this option is not set and
+the PPK feature is enabled, any matching PPK secret will be used.
 </para>
   </listitem>
   </varlistentry>

--- a/configs/d.ipsec.conf/ppk.xml
+++ b/configs/d.ipsec.conf/ppk.xml
@@ -10,7 +10,7 @@ only if PPK is used for key derivation;
 signifying that PPK should not be used for key derivation.
 PPKs can be used in connections that allow only IKEv2. In libreswan that would
 mean that ikev2 option must have value <emphasis remap='B'>insist</emphasis>.
- (currently based on draft-fluhrer-qr-ikev2, not raft-ietf-ipsecme-qr-ikev2-00)
+ This feature is based on RFC 8784.
 </para>
   </listitem>
   </varlistentry>

--- a/include/ietf_constants.h
+++ b/include/ietf_constants.h
@@ -1639,9 +1639,9 @@ typedef enum {
 	v2N_CLONE_IKE_SA_SUPPORTED = 16432, /* RFC-7791 */
 	v2N_CLONE_IKE_SA = 16433, /* RFC-7791 */
 	v2N_PUZZLE = 16434, /* RFC-8019 */
-	v2N_USE_PPK = 16435, /* draft-ietf-ipsecme-qr-ikev2 */
-	v2N_PPK_IDENTITY = 16436, /* draft-ietf-ipsecme-qr-ikev2 */
-	v2N_NO_PPK_AUTH = 16437, /* draft-ietf-ipsecme-qr-ikev2 */
+	v2N_USE_PPK = 16435, /* RFC 8784 */
+	v2N_PPK_IDENTITY = 16436, /* RFC 8784 */
+	v2N_NO_PPK_AUTH = 16437, /* RFC 8784 */
 	v2N_INTERMEDIATE_EXCHANGE_SUPPORTED = 16438, /* draft-ietf-ipsecme-ikev2-intermediate-04 */
 	v2N_IP4_ALLOWED = 16439,
 	v2N_IP6_ALLOWED = 16440,
@@ -1658,7 +1658,7 @@ typedef enum {
 
 } v2_notification_t;
 
-/* draft-ietf-ipsecme-qr-ikev2-01 created registry */
+/* RFC 8784 created registry */
 enum ikev2_ppk_id_type {
 	PPK_ID_OPAQUE = 1,
 	PPK_ID_FIXED = 2,

--- a/include/ipsecconf/confread.h
+++ b/include/ipsecconf/confread.h
@@ -142,6 +142,7 @@ struct starter_conn {
 	char *conn_mark_in;
 	char *conn_mark_out;
 	char *vti_iface;
+	char *ppk_ids;
 	char *redirect_to;
 	char *accept_redirect_to;
 	bool vti_routing;

--- a/include/ipsecconf/keywords.h
+++ b/include/ipsecconf/keywords.h
@@ -151,6 +151,7 @@ enum keyword_string_conn_field {
 	KSCF_last_leftright = KSCF_SUBNETS,
 
 	KSCF_AUTHBY,
+	KSCF_PPKIDS,
 	KSCF_MODECFGDNS,
 	KSCF_MODECFGDOMAINS,
 	KSCF_IKE,

--- a/include/whack.h
+++ b/include/whack.h
@@ -368,6 +368,9 @@ struct whack_message {
 	bool vti_routing; /* perform routing into vti device or not */
 	bool vti_shared; /* use remote %any and skip cleanup on down? */
 
+	/* RFC 8784 and draft-smyslov-ipsecme-ikev2-qr-alt-07 */
+	char *ppk_ids;
+
 	/* for RFC 5685 - IKEv2 Redirect mechanism */
 	enum allow_global_redirect global_redirect;
 	char *global_redirect_to;

--- a/lib/libipsecconf/confread.c
+++ b/lib/libipsecconf/confread.c
@@ -1244,6 +1244,7 @@ static bool load_conn(struct starter_conn *conn,
 	str_to_conn(conn_mark_out, KSCF_CONN_MARK_OUT);
 	str_to_conn(vti_iface, KSCF_VTI_IFACE);
 
+	str_to_conn(ppk_ids, KSCF_PPKIDS);
 	str_to_conn(redirect_to, KSCF_REDIRECT_TO);
 	str_to_conn(accept_redirect_to, KSCF_ACCEPT_REDIRECT_TO);
 
@@ -1580,6 +1581,7 @@ static void copy_conn_default(struct starter_conn *conn,
 	STR_FIELD(conn_mark_in);
 	STR_FIELD(conn_mark_out);
 	STR_FIELD(vti_iface);
+	STR_FIELD(ppk_ids);
 	STR_FIELD(redirect_to);
 	STR_FIELD(accept_redirect_to);
 	STR_FIELD(dpd_delay);
@@ -1747,6 +1749,7 @@ static void confread_free_conn(struct starter_conn *conn)
 	STR_FIELD(conn_mark_in);
 	STR_FIELD(conn_mark_out);
 	STR_FIELD(vti_iface);
+	STR_FIELD(ppk_ids);
 	STR_FIELD(redirect_to);
 	STR_FIELD(accept_redirect_to);
 

--- a/lib/libipsecconf/keywords.c
+++ b/lib/libipsecconf/keywords.c
@@ -483,6 +483,7 @@ const struct keyword_def ipsec_conf_keywords[] = {
   { "keyexchange",  kv_conn,  kt_enum,  KNCF_KEYEXCHANGE,  kw_keyexchange_list, NULL, },
   { "ikev2",  kv_conn | kv_processed,  kt_enum,  KNCF_IKEv2,  kw_fourvalued_list, NULL, },
   { "ppk", kv_conn | kv_processed, kt_enum, KNCF_PPK, kw_fourvalued_list, NULL, },
+  { "ppk-ids", kv_conn | kv_processed, kt_string, KSCF_PPKIDS, NULL, NULL, },
   { "intermediate",  kv_conn | kv_processed, kt_bool, KNCF_INTERMEDIATE, NULL, NULL, },
   { "esn",  kv_conn | kv_processed,  kt_enum,  KNCF_ESN,  kw_esn_list, NULL, },
   { "decap-dscp",  kv_conn | kv_processed,  kt_bool,  KNCF_DECAP_DSCP,  NULL, NULL, },

--- a/lib/libipsecconf/starterwhack.c
+++ b/lib/libipsecconf/starterwhack.c
@@ -654,6 +654,9 @@ static int starter_whack_basic_add_conn(struct starter_config *cfg,
 	if (conn->options_set[KNCF_VTI_SHARED])
 		msg.vti_shared = conn->options[KNCF_VTI_SHARED];
 
+	msg.ppk_ids = conn->ppk_ids;
+	conn_log_val(conn, "ppk-ids", msg.ppk_ids);
+
 	msg.redirect_to = conn->redirect_to;
 	conn_log_val(conn, "redirect-to", msg.redirect_to);
 	msg.accept_redirect_to = conn->accept_redirect_to;

--- a/lib/libswan/constants.c
+++ b/lib/libswan/constants.c
@@ -2143,7 +2143,7 @@ enum_names secret_kind_names = {
 };
 
 /*
- * IKEv2 PPK ID types - draft-ietf-ipsecme-qr-ikev2-01
+ * IKEv2 PPK ID types - RFC 8784
  */
 static const char *const ikev2_ppk_id_type_name[] = {
 	/* 0 - Reserved */

--- a/lib/libwhack/whacklib.c
+++ b/lib/libwhack/whacklib.c
@@ -362,6 +362,7 @@ static bool pickle_whack_message(struct whackpacker *wp,
 		PICKLE_STRING(&wp->msg->conn_mark_out) &&
 		PICKLE_STRING(&wp->msg->vti_iface) &&
 		PICKLE_STRING(&wp->msg->remote_host) &&
+		PICKLE_STRING(&wp->msg->ppk_ids) &&
 		PICKLE_STRING(&wp->msg->global_redirect_to) &&
 		PICKLE_STRING(&wp->msg->redirect_to) &&
 		PICKLE_STRING(&wp->msg->accept_redirect_to) &&

--- a/programs/pluto/connections.c
+++ b/programs/pluto/connections.c
@@ -349,6 +349,7 @@ static void discard_connection(struct connection **cp, bool connection_valid)
 		pfreeany(config->modecfg.dns.list);
 		pfreeany(config->modecfg.domains);
 		pfreeany(config->modecfg.banner);
+		pfreeany(config->ppk_ids);
 		pfreeany(config->redirect.to);
 		pfreeany(config->redirect.accept);
 		FOR_EACH_ELEMENT(end, config->end) {
@@ -2469,6 +2470,8 @@ static diag_t extract_connection(const struct whack_message *wm,
 
 		config->modecfg.banner = clone_str(wm->modecfg_banner, "connection modecfg_banner");
 
+		/* RFC 8784 and draft-smyslov-ipsecme-ikev2-qr-alt-07 */
+		config->ppk_ids = clone_str(wm->ppk_ids, "connection ppk_ids");
 
 		/* RFC 5685 - IKEv2 Redirect mechanism */
 		config->redirect.to = clone_str(wm->redirect_to, "connection redirect_to");

--- a/programs/pluto/connections.c
+++ b/programs/pluto/connections.c
@@ -350,6 +350,9 @@ static void discard_connection(struct connection **cp, bool connection_valid)
 		pfreeany(config->modecfg.domains);
 		pfreeany(config->modecfg.banner);
 		pfreeany(config->ppk_ids);
+		if (config->ppk_ids_shunks != NULL) {
+			pfree(config->ppk_ids_shunks);
+		}
 		pfreeany(config->redirect.to);
 		pfreeany(config->redirect.accept);
 		FOR_EACH_ELEMENT(end, config->end) {
@@ -2472,6 +2475,12 @@ static diag_t extract_connection(const struct whack_message *wm,
 
 		/* RFC 8784 and draft-smyslov-ipsecme-ikev2-qr-alt-07 */
 		config->ppk_ids = clone_str(wm->ppk_ids, "connection ppk_ids");
+		if (config->ppk_ids != NULL) {
+			config->ppk_ids_shunks = shunks(shunk1(config->ppk_ids),
+							", ",
+							EAT_EMPTY_SHUNKS,
+							HERE); /* process into shunks once */
+		}
 
 		/* RFC 5685 - IKEv2 Redirect mechanism */
 		config->redirect.to = clone_str(wm->redirect_to, "connection redirect_to");

--- a/programs/pluto/connections.h
+++ b/programs/pluto/connections.h
@@ -196,6 +196,7 @@ struct config {
 
 	/* RFC 8784 and draft-smyslov-ipsecme-ikev2-qr-alt-07 */
 	char *ppk_ids;
+	struct shunks *ppk_ids_shunks;
 
 	struct {
 		char *to;        /* RFC 5685 */

--- a/programs/pluto/connections.h
+++ b/programs/pluto/connections.h
@@ -194,6 +194,9 @@ struct config {
 
 	reqid_t sa_reqid;
 
+	/* RFC 8784 and draft-smyslov-ipsecme-ikev2-qr-alt-07 */
+	char *ppk_ids;
+
 	struct {
 		char *to;        /* RFC 5685 */
 		char *accept;

--- a/programs/pluto/ikev2_ike_auth.c
+++ b/programs/pluto/ikev2_ike_auth.c
@@ -119,7 +119,7 @@ stf_status initiate_v2_IKE_AUTH_request(struct ike_sa *ike, struct msg_digest *m
 	 */
 	if (LIN(POLICY_PPK_ALLOW, pc->policy) && ike->sa.st_seen_ppk) {
 		chunk_t *ppk_id;
-		chunk_t *ppk = get_connection_ppk(ike->sa.st_connection, &ppk_id);
+		const chunk_t *ppk = get_connection_ppk_initiator(ike->sa.st_connection, &ppk_id);
 
 		if (ppk != NULL) {
 			dbg("found PPK and PPK_ID for our connection");
@@ -470,7 +470,7 @@ stf_status initiate_v2_IKE_AUTH_request_signature_continue(struct ike_sa *ike,
 	 */
 	if (ike->sa.st_seen_ppk) {
 		chunk_t *ppk_id;
-		get_connection_ppk(ike->sa.st_connection, &ppk_id);
+		get_connection_ppk_initiator(ike->sa.st_connection, &ppk_id);
 		struct ppk_id_payload ppk_id_p = { .type = 0, };
 		create_ppk_id_payload(ppk_id, &ppk_id_p);
 		if (DBGP(DBG_BASE)) {
@@ -662,7 +662,8 @@ stf_status process_v2_IKE_AUTH_request_standard_payloads(struct ike_sa *ike, str
 			return STF_FATAL;
 		}
 
-		const chunk_t *ppk = get_ppk_by_id(&payl.ppk_id);
+		const chunk_t *ppk = get_connection_ppk_responder(ike->sa.st_connection,
+								  &payl.ppk_id);
 		free_chunk_content(&payl.ppk_id);
 		if (ppk != NULL) {
 			found_ppk = true;

--- a/programs/pluto/keys.c
+++ b/programs/pluto/keys.c
@@ -550,7 +550,7 @@ const chunk_t *get_connection_ppk_initiator(const struct connection *c, chunk_t 
 		 * try to find any matching PPK, if found, save the corresponding
 		 * PPK_ID in ppk_id
 		 */
-		DBG_log("ppk-ids conn option not specified, look for first matching secret");
+		ldbg(c->logger, "ppk-ids conn option not specified, look for first matching secret");
 		struct secret *s = lsw_get_secret(c, SECRET_PPK, false);
 
 		if (s == NULL) {
@@ -567,7 +567,7 @@ const chunk_t *get_connection_ppk_initiator(const struct connection *c, chunk_t 
 		}
 		return &pks->ppk;
 	} else {
-		DBG_log("ppk-ids conn option specified, iterate through list: %s", ppk_ids);
+		ldbg(c->logger, "ppk-ids conn option specified, iterate through list: %s", ppk_ids);
 		/*
 		 * iterate through PPK_ID (ppk-ids:) list and try to at
 		 * least one secrets entry that matches a PPK_ID from the
@@ -580,7 +580,8 @@ const chunk_t *get_connection_ppk_initiator(const struct connection *c, chunk_t 
 			size_t len = strcspn(ppk_ids, ",");
 			chunk_t ppk_ids_elem = chunk2(ppk_ids, len);
 
-			DBG_dump_hunk("try to find PPK with PPK_ID:", ppk_ids_elem);
+			ldbg(c->logger, "try to find PPK with PPK_ID:");
+			ldbg_hunk(c->logger, ppk_ids_elem);
 
 			const chunk_t *ppk = get_ppk_by_id(&ppk_ids_elem);
 
@@ -605,11 +606,11 @@ const chunk_t *get_connection_ppk_responder(const struct connection *c, chunk_t 
 
 	if (ppk_ids == NULL) {
 		/* try to find PPK with PPK_ID ppk_id */
-		DBG_dump_hunk("ppk-ids conn option not specified, look for PPK with ID:",
-				*ppk_id);
+		ldbg(c->logger, "ppk-ids conn option not specified, look for PPK with ID:");
+		ldbg_hunk(c->logger, *ppk_id);
 		return get_ppk_by_id(ppk_id);
 	} else {
-		DBG_log("ppk-ids conn option specified, iterate through list: %s", ppk_ids);
+		ldbg(c->logger, "ppk-ids conn option specified, iterate through list: %s", ppk_ids);
 		/*
 		 * iterate through PPK_ID (ppk-ids:) list and try to at
 		 * least one secrets entry that matches a PPK_ID from the
@@ -622,10 +623,11 @@ const chunk_t *get_connection_ppk_responder(const struct connection *c, chunk_t 
 			size_t len = strcspn(ppk_ids, ",");
 			chunk_t ppk_ids_elem = chunk2(ppk_ids, len);
 
-			DBG_dump_hunk("checking if received PPK_ID is equal to: ", ppk_ids_elem);
+			ldbg(c->logger, "checking if received PPK_ID is equal to:");
+			ldbg_hunk(c->logger, ppk_ids_elem);
 
 			if (hunk_eq(*ppk_id, ppk_ids_elem)) {
-				DBG_dump_hunk("match! try to find PPK with PPK_ID:", ppk_ids_elem);
+				ldbg(c->logger, "match! try to find PPK with that PPK_ID");
 				/* ppk_id in the conf option list, try to find it */
 				return get_ppk_by_id(ppk_id);
 			} else {

--- a/programs/pluto/keys.h
+++ b/programs/pluto/keys.h
@@ -55,8 +55,8 @@ enum keys_to_show { SHOW_ALL_KEYS = 1, SHOW_EXPIRED_KEYS, };
 extern void show_pubkeys(struct show *s, bool utc, enum keys_to_show keys_to_show);
 
 extern const chunk_t *get_connection_psk(const struct connection *c);
-extern chunk_t *get_connection_ppk(const struct connection *c, chunk_t **ppk_id);
-extern const chunk_t *get_ppk_by_id(const chunk_t *ppk_id);
+extern const chunk_t *get_connection_ppk_initiator(const struct connection *c, chunk_t **ppk_id);
+extern const chunk_t *get_connection_ppk_responder(const struct connection *c, chunk_t *ppk_id);
 
 extern void load_preshared_secrets(struct logger *logger);
 extern void free_preshared_secrets(struct logger *logger);

--- a/programs/pluto/packet.c
+++ b/programs/pluto/packet.c
@@ -1089,7 +1089,7 @@ struct_desc ikev2_id_r_desc = {
 };
 
 /*
- * IKEv2 - draft-ietf-ipsecme-qr-ikev2-01 (no ascii art provided in RFC)
+ * IKEv2 - RFC 8784 (no ascii art provided in RFC)
  * PPK_ID types
  *                         1                   2                   3
  *     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1

--- a/programs/pluto/packet.h
+++ b/programs/pluto/packet.h
@@ -964,7 +964,7 @@ struct ikev2_prop {
 
 extern struct_desc ikev2_prop_desc;
 
-/* draft-ietf-ipsecme-qr-ikev2-01 */
+/* RFC 8784 */
 struct ikev2_ppk_id {
 	uint8_t isappkid_type;
 };


### PR DESCRIPTION
ppk-ids option allows for specifying a list of PPK_IDs to look for in .secrets file

I'm open to suggestions if something needs to be improved in the patch.