### PR TITLE
update github actions with full commit sha

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,15 +13,14 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: ["main"]
   schedule:
-    - cron: '29 17 * * 0'
+    - cron: "29 17 * * 0"
   # Enable manual trigger of the action. Useful for debugging purposes
   workflow_dispatch:
-
 
 jobs:
   analyze:
@@ -35,47 +34,49 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'cpp', 'javascript', 'python' ]
+        language: ["cpp", "javascript", "python"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Use only 'java' to analyze code written in Java, Kotlin or both
         # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    - name: Install build dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -fy --no-install-recommends libnss3-dev libnspr4-dev libpam-dev libcap-ng-dev libcap-ng-utils libselinux-dev libcurl3-nss-dev libldns-dev libunbound-dev libnss3-tools libevent-dev xmlto libsystemd-dev
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -fy --no-install-recommends libnss3-dev libnspr4-dev libpam-dev libcap-ng-dev libcap-ng-utils libselinux-dev libcurl3-nss-dev libldns-dev libunbound-dev libnss3-tools libevent-dev xmlto libsystemd-dev
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        # pinning to full commit hash from tagged version v2.20.4
+        uses: github/codeql-action/init@489225d82a57396c6f426a40e66d461b16b3461d
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+          # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        # pinning to full commit hash from tagged version v2.20.4
+        uses: github/codeql-action/autobuild@489225d82a57396c6f426a40e66d461b16b3461d
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      - run: |
+          echo "Building... "
+          make base
 
-    - run: |
-        echo "Building... "
-        make base
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        # pinning to full commit hash from tagged version v2.20.4
+        uses: github/codeql-action/analyze@489225d82a57396c6f426a40e66d461b16b3461d
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -9,7 +9,7 @@ on:
     branches: ["master", "main"]
   # Schedule the CI job (this method uses cron syntax):
   schedule:
-    - cron: '20 17 * * *' # Sets Semgrep to scan every day at 17:20 UTC.
+    - cron: "20 17 * * *" # Sets Semgrep to scan every day at 17:20 UTC.
     # It is recommended to change the schedule to a random time.
 
   # Enable manual trigger of the action. Useful for debugging purposes
@@ -19,7 +19,7 @@ jobs:
   semgrep:
     # User definable name of this GitHub Actions job.
     name: Scan
-    # If you are self-hosting, change the following `runs-on` value: 
+    # If you are self-hosting, change the following `runs-on` value:
     runs-on: ubuntu-latest
     permissions:
       # required for all workflows
@@ -39,7 +39,8 @@ jobs:
       - run: semgrep ci --sarif --output=semgrep.sarif --config auto --exclude-rule c.lang.security.insecure-use-memset.insecure-use-memset --exclude testing/
 
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
-        uses: github/codeql-action/upload-sarif@v2
+        # pinning to full commit hash from tagged version v2.20.4
+        uses: github/codeql-action/upload-sarif@489225d82a57396c6f426a40e66d461b16b3461d
         with:
           sarif_file: semgrep.sarif
         if: always()


### PR DESCRIPTION
Update the Scanning github actions with full commit sha to remove the annoying warning from semgrep: 
> An action sourced from a third-party repository on GitHub is not pinned to a full length commit SHA. Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload.

References:

- [Semgrep Rule](https://semgrep.dev/r/yaml.github-actions.security.third-party-action-not-pinned-to-commit-sha.third-party-action-not-pinned-to-commit-sha)
- https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components
- https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions