### PR TITLE
Fix uplading semgrep erroring when semgrep fails.

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -43,4 +43,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@489225d82a57396c6f426a40e66d461b16b3461d
         with:
           sarif_file: semgrep.sarif
-        if: always()
+        if: ${{ hashFiles('semgrep.sarif') != '' }}


### PR DESCRIPTION
The newest version of Semgrep has a bug, that makes it fail without even outputting the sarif file.
This update only tries to upload the file if it exists.
We _might_ wanna pin the semgrep version to the last known good (`1.45`), or wait for them to push a fix to the `latest` .