### PR TITLE
The XFRM address scope must be global

### DIFF
--- a/programs/pluto/kernel_xfrm_interface.c
+++ b/programs/pluto/kernel_xfrm_interface.c
@@ -71,7 +71,7 @@
 
 #define IPSEC1_XFRM_IF_ID (1U)
 #define IFINFO_REPLY_BUFFER_SIZE (32768 + NL_BUFMARGIN)
-static const int IP_ADDR_GLOBAL_SCOPE = 50;
+static const int IP_ADDR_GLOBAL_SCOPE = 0;
 
 
 static struct pluto_xfrmi *pluto_xfrm_interfaces;

--- a/testing/pluto/ikev2-xfrmi-05-remote-access-client/road.console.txt
+++ b/testing/pluto/ikev2-xfrmi-05-remote-access-client/road.console.txt
@@ -33,7 +33,7 @@ road #
 road #
  ip addr show dev ipsec1
 X: ipsec1@eth0: <NOARP,UP,LOWER_UP> mtu 1500 state UNKNOWN
-    inet 100.64.13.2/32 scope 50 ipsec1
+    inet 100.64.13.2/32 scope global ipsec1
        valid_lft forever preferred_lft forever
 road #
  ../../guestbin/ping-once.sh --up 192.0.2.254

--- a/testing/pluto/ikev2-xfrmi-06/road.console.txt
+++ b/testing/pluto/ikev2-xfrmi-06/road.console.txt
@@ -53,7 +53,7 @@ road #
 road #
  ip addr show dev ipsec1
 X: ipsec1@eth0: <NOARP,UP,LOWER_UP> mtu 1500 state UNKNOWN
-    inet 192.0.2.1/32 scope 50 ipsec1
+    inet 192.0.2.1/32 scope global ipsec1
        valid_lft forever preferred_lft forever
 road #
  ip -s link show ipsec1


### PR DESCRIPTION
- previously it was erroneously being set to 50