### PR TITLE
Fix make git-rpm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ git-rpm:
 	@echo building rpm for libreswan testing
 	mkdir -p $(MAIN_RPMBUILD_SPEC) $(MAIN_RPMBUILD_SOURCES)
 	sed  -e "s/^Version:.*/Version: $(MAIN_RPM_VERSION)/g" \
-	     -e "s/^#global prever.*/%global prever $(MAIN_RPM_PREVER)/" \
+	     -e "s/^.global prever.*/%global prever $(MAIN_RPM_PREVER)/" \
 	     -e "s/^Release:.*/Release: 0.$(MAIN_RPM_PREVER)/" \
 		$(MAIN_RPM_SPECFILE) > $(MAIN_RPMBUILD_SPEC)/libreswan.spec
 	git archive --format=tar --prefix=libreswan-$(MAIN_RPM_VERSION)$(MAIN_RPM_PREVER)/ \


### PR DESCRIPTION
- It was broken by a previous commit that uncommented "global prever" in packaging/rhel/8/libreswan.spec, since the "make git-rpm" script was expecting it to be commented.