### PR TITLE
terminate: terminate_and_down_connections() fixes

### DIFF
--- a/programs/pluto/foodgroups.c
+++ b/programs/pluto/foodgroups.c
@@ -111,7 +111,7 @@ static void delete_group_instantiation(co_serial_t serialno, struct logger *logg
 	connection_attach(template, logger);
 	ldbg(template->logger, "removing group template");
 
-	terminate_and_down_connections(&template, logger, HERE);
+	terminate_and_down_connections(template, logger, HERE);
 	/* template lives to fight another day; oops */
 	delete_connection(&template);
 }

--- a/programs/pluto/orient.c
+++ b/programs/pluto/orient.c
@@ -237,7 +237,7 @@ bool orient(struct connection **cp, struct logger *logger)
 
 		if (left && right) {
 			/* too many choices */
-			connection_attach((*cp), logger);
+			connection_addref((*cp), logger);
 			connection_attach((*cp), logger);
 			LLOG_JAMBUF(RC_LOG_SERIOUS, (*cp)->logger, buf) {
 				jam_string(buf, "connection matches both left ");
@@ -245,8 +245,9 @@ bool orient(struct connection **cp, struct logger *logger)
 				jam_string(buf, " and right ");
 				jam_iface(buf, iface);
 			}
-			terminate_and_down_connections(cp, logger, HERE);
+			terminate_and_down_connections((*cp), logger, HERE);
 			connection_detach((*cp), logger);
+			connection_delref(cp, logger);
 			return false;
 		}
 
@@ -270,6 +271,7 @@ bool orient(struct connection **cp, struct logger *logger)
 			 * log line doesn't differentiate.
 			 */
 			pexpect(end != matching_end);
+			connection_addref((*cp), logger);
 			connection_attach((*cp), logger);
 			LLOG_JAMBUF(RC_LOG_SERIOUS, (*cp)->logger, buf) {
 				jam_string(buf, "connection matches both ");
@@ -283,9 +285,9 @@ bool orient(struct connection **cp, struct logger *logger)
 				jam_string(buf, " ");
 				jam_iface(buf, iface);
 			}
-			terminate_and_down_connections(cp, logger, HERE);
+			terminate_and_down_connections((*cp), logger, HERE);
 			connection_detach((*cp), logger);
-
+			connection_delref(cp, logger);
 			return false;
 		}
 

--- a/programs/pluto/terminate.h
+++ b/programs/pluto/terminate.h
@@ -22,7 +22,19 @@ struct connection;
 struct logger;
 
 void terminate_all_connection_states(struct connection *c, where_t where);
-void terminate_and_down_connections(struct connection **cp, struct logger *logger, where_t where);
+
+/*
+ * Traverse the connection tree DOWN-ing all connections (remove +UP
+ * bit), delete states, and eliminate anything on either the pending
+ * or revival queue.
+ *
+ * Caller must take a reference C to stop it being deleted - as will
+ * happen when C is an INSTANCE or LABELED_PARENT.
+ *
+ * If C is a TEMPLATE or LABELED_TEMPLATE this will delete any
+ * INSTANCE, LABELED_PARENT or LABELED_CHILD.
+ */
+void terminate_and_down_connections(struct connection *c, struct logger *logger, where_t where);
 
 void connection_timeout_ike_family(struct ike_sa **ike, where_t where);
 void connection_delete_ike_family(struct ike_sa **ike, where_t where);


### PR DESCRIPTION
- assume/make caller hold a reference

  otherwise terminate_and_down_connections() can delete the caller's CK_INSTANCE, CK_LABELED_PARENT

- don't allow CK_LABELED_CHILD

  can only meaningfully down the parent or template

- for CK_INSTANCE and CK_PERMANENT check pending and revival, and unroute

  can't, for instance, assume an unrouted connection isn't waiting on another connection (pending), or revival