### PR TITLE
building openbsd: don't try to use SADB_X_SPDFLUSH

### DIFF
--- a/external/include/pfkeyv2/openbsd.h
+++ b/external/include/pfkeyv2/openbsd.h
@@ -1,4 +1,4 @@
-/* $OpenBSD: pfkeyv2.h,v 1.92 2022/03/02 09:27:34 claudio Exp $ */
+/* $OpenBSD: pfkeyv2.h,v 1.94 2023/08/07 03:35:06 dlg Exp $ */
 /*
  *	@(#)COPYRIGHT	1.1 (NRL) January 1998
  *
@@ -252,6 +252,14 @@ struct sadb_x_mtu {
 	uint32_t  sadb_x_mtu_mtu;
 };
 
+struct sadb_x_iface {
+	uint16_t  sadb_x_iface_len;
+	uint16_t  sadb_x_iface_exttype;
+	uint32_t  sadb_x_iface_unit;
+	uint8_t   sadb_x_iface_direction;
+	uint8_t   sadb_x_iface_reserved[7];
+};
+
 #ifdef _KERNEL
 #define SADB_X_GETSPROTO(x) \
 	( (x) == SADB_SATYPE_AH ? IPPROTO_AH :\
@@ -300,7 +308,8 @@ struct sadb_x_mtu {
 #define SADB_X_EXT_RDOMAIN            37
 #define SADB_X_EXT_MTU                38
 #define SADB_X_EXT_REPLAY             39
-#define SADB_EXT_MAX                  39
+#define SADB_X_EXT_IFACE              40
+#define SADB_EXT_MAX                  40
 
 /* Fix pfkeyv2.c struct pfkeyv2_socket if SATYPE_MAX > 31 */
 #define SADB_SATYPE_UNSPEC		 0
@@ -412,7 +421,7 @@ int pfkeyv2_acquire(struct ipsec_policy *, union sockaddr_union *,
 
 int pfkeyv2_get(struct tdb *, void **, void **, int *, int *);
 int pfkeyv2_policy(struct ipsec_acquire *, void **, void **, int *);
-int pfkeyv2_send(struct socket *, void *, int);
+int pfkeyv2_dosend(struct socket *, void *, int);
 int pfkeyv2_sendmessage(void **, int, struct socket *, u_int8_t, int, u_int);
 int pfkeyv2_dump_policy(struct ipsec_policy *, void **, void **, int *);
 int pfkeyv2_dump_walker(struct tdb *, void *, int);
@@ -438,6 +447,7 @@ void export_mtu(void **, struct tdb *);
 void export_tap(void **, struct tdb *);
 void export_satype(void **, struct tdb *);
 void export_counter(void **, struct tdb *);
+void export_iface(void **, struct tdb *);
 
 void import_address(struct sockaddr *, struct sadb_address *);
 void import_identities(struct ipsec_ids **, int, struct sadb_ident *,
@@ -452,6 +462,7 @@ void import_udpencap(struct tdb *, struct sadb_x_udpencap *);
 void import_tag(struct tdb *, struct sadb_x_tag *);
 void import_rdomain(struct tdb *, struct sadb_x_rdomain *);
 void import_tap(struct tdb *, struct sadb_x_tap *);
+void import_iface(struct tdb *, struct sadb_x_iface *);
 
 extern const uint64_t sadb_exts_allowed_out[SADB_MAX+1];
 extern const uint64_t sadb_exts_required_out[SADB_MAX+1];

--- a/programs/pluto/kernel_pfkeyv2.c
+++ b/programs/pluto/kernel_pfkeyv2.c
@@ -609,7 +609,11 @@ static void kernel_pfkeyv2_init(bool flush, struct logger *logger)
 	if (flush) {
 		struct inbuf resp;
 		sadb_base_sendrecv(&resp, SADB_FLUSH, SADB_SATYPE_UNSPEC, logger);
+#ifdef SADB_X_SPDFLUSH /* FreeBSD NetBSD */
 		sadb_base_sendrecv(&resp, SADB_X_SPDFLUSH, SADB_SATYPE_UNSPEC, logger);
+#else /* OpenBSD */
+		ldbg(logger, "OpenBSD SADB_FLUSH does everything; SADB_X_SPDFLUSH not needed");
+#endif
 	}
 }
 

--- a/programs/pluto/kernel_sadb.h
+++ b/programs/pluto/kernel_sadb.h
@@ -86,9 +86,11 @@ enum sadb_type {
 #define SADB_FLUSH sadb_flush
 #endif
 
+#ifdef SADB_X_SPDFLUSH
 	sadb_x_spdflush = SADB_X_SPDFLUSH,
 #undef SADB_X_SPDFLUSH
 #define SADB_X_SPDFLUSH sadb_x_spdflush
+#endif
 
 	sadb_register = SADB_REGISTER,
 #undef SADB_REGISTER


### PR DESCRIPTION
On OpenBSD, SADB_FLUSH flushes everything.