### PR TITLE
building: fix typo in ok[] initializer

### DIFF
--- a/programs/pluto/connections.c
+++ b/programs/pluto/connections.c
@@ -1889,7 +1889,7 @@ static enum connection_kind extract_connection_end_kind(const struct whack_messa
 static bool shunt_ok(enum shunt_kind shunt_kind, enum shunt_policy shunt_policy)
 {
 	static const bool ok[SHUNT_KIND_ROOF][SHUNT_POLICY_ROOF] = {
-		[SHUNT_KIND_NONE] {
+		[SHUNT_KIND_NONE] = {
 			[SHUNT_UNSET] = true,
 		},
 		[SHUNT_KIND_NEVER_NEGOTIATE] = {


### PR DESCRIPTION
bizarely only OpenBSD saw this as a problem!