### PR TITLE
pluto: handle partial install_inbound_ipsec_kernel_policy() failures

### DIFF
--- a/programs/pluto/kernel.c
+++ b/programs/pluto/kernel.c
@@ -1714,7 +1714,13 @@ static bool install_inbound_ipsec_kernel_policies(struct child_sa *child)
 		     /* inbound */
 		     str_selector(&spd->remote->client, &sb),
 		     str_selector(&spd->local->client, &db));
-		install_inbound_ipsec_kernel_policy(child, spd, HERE);
+		if (!install_inbound_ipsec_kernel_policy(child, spd, HERE)) {
+		    log_state(RC_LOG_SERIOUS, &child->sa, "Installing IPsec SA failed - check logs or dmesg");
+		    struct spd_owner owner = spd_owner(spd, RT_UNROUTED_FAILURE, logger, HERE);
+		    delete_spd_kernel_policies(spd, &owner, IGNORE_KERNEL_POLICY_MISSING,
+						logger, HERE, "cleanup after failed add_sa");
+			return false;
+		}
 	}
 
 	return true;

--- a/programs/pluto/kernel_policy.c
+++ b/programs/pluto/kernel_policy.c
@@ -576,7 +576,7 @@ static bool pexpect_cat(const struct connection *c, struct logger *logger)
 		PEXPECT(logger, c->local->child.has_cat));
 }
 
-void add_cat_kernel_policy(const struct connection *c,
+bool add_cat_kernel_policy(const struct connection *c,
 			   const struct kernel_policy *kernel_policy,
 			   enum direction direction,
 			   struct logger *logger, where_t where,
@@ -584,7 +584,7 @@ void add_cat_kernel_policy(const struct connection *c,
 {
 	ldbg(logger, "%s", reason);
 	if (!pexpect_cat(c, logger)) {
-		return;
+		return false;
 	}
 
 	ip_selector local_client = selector_from_address(kernel_policy->local.host);
@@ -593,7 +593,9 @@ void add_cat_kernel_policy(const struct connection *c,
 			       kernel_policy, deltatime(0),
 			       logger, where, reason)) {
 		llog(RC_LOG, logger, "%s failed", reason);
+		return false;
 	}
+	return true;
 }
 
 static void delete_cat_kernel_policy(const struct spd_route *spd,
@@ -656,7 +658,7 @@ void delete_cat_kernel_policies(const struct spd_route *spd,
 	}
 }
 
-void install_inbound_ipsec_kernel_policy(struct child_sa *child,
+bool install_inbound_ipsec_kernel_policy(struct child_sa *child,
 					 struct spd_route *spd,
 					 where_t where)
 {
@@ -677,9 +679,11 @@ void install_inbound_ipsec_kernel_policy(struct child_sa *child,
 	const char *add_inbound_cat = NULL;
 #endif
 	if (add_inbound_cat != NULL) {
-		add_cat_kernel_policy(child->sa.st_connection,
+		if(!add_cat_kernel_policy(child->sa.st_connection,
 				      &kernel_policy, DIRECTION_INBOUND,
-				      child->sa.logger, where, add_inbound_cat);
+				      child->sa.logger, where, add_inbound_cat)) {
+			return false;
+		}
 	}
 
 	if (!kernel_ops_policy_add(KERNEL_POLICY_OP_ADD,
@@ -695,7 +699,9 @@ void install_inbound_ipsec_kernel_policy(struct child_sa *child,
 			__func__,
 			str_selector(&kernel_policy.src.client, &sb),
 			str_selector(&kernel_policy.dst.client, &db));
+		return false;
 	}
+	return true;
 }
 
 bool install_outbound_ipsec_kernel_policy(struct child_sa *child,
@@ -719,10 +725,12 @@ bool install_outbound_ipsec_kernel_policy(struct child_sa *child,
 		 * = add outbound client -> client policy for the
 		 *   assigned address.
 		 */
-		add_cat_kernel_policy(child->sa.st_connection,
+		if (!add_cat_kernel_policy(child->sa.st_connection,
 				      &kernel_policy, DIRECTION_OUTBOUND,
 				      child->sa.logger, where,
-				      "CAT: add outbound IPsec policy");
+				      "CAT: add outbound IPsec policy")) {
+			return false;
+		}
 		/*
 		 * Now add the client.
 		 */

--- a/programs/pluto/kernel_policy.h
+++ b/programs/pluto/kernel_policy.h
@@ -222,7 +222,7 @@ void delete_spd_kernel_policies(struct spd_route *spd,
  * maps the local.host -> remote.client.
  */
 
-void add_cat_kernel_policy(const struct connection *c,
+bool add_cat_kernel_policy(const struct connection *c,
 			   const struct kernel_policy *kernel_policy,
 			   enum direction direction,
 			   struct logger *logger, where_t where,
@@ -239,7 +239,7 @@ void delete_cat_kernel_policies(const struct spd_route *spd,
 				struct logger *logger,
 				where_t where);
 
-void install_inbound_ipsec_kernel_policy(struct child_sa *child, struct spd_route *spd,
+bool install_inbound_ipsec_kernel_policy(struct child_sa *child, struct spd_route *spd,
 					 where_t where);
 bool install_outbound_ipsec_kernel_policy(struct child_sa *child, struct spd_route *spd,
 					  enum kernel_policy_op op, where_t where);


### PR DESCRIPTION
This was assumed to never fail, but can fail for various reasons, including trying to use hardware offload that does not support the current properties of the IPsec SA.

eg it could install the "in" policy, then try the "fwd" policy and fail. But it would continue doing the "out" policy and then claim successful IPsec SA.

When a failure happens, try to cleanup partially installed IPsec SA.