### PR TITLE
fix trivial orthography on 4.x maintenance branch

### DIFF
--- a/configs/d.ipsec.conf/ipsec-max-bytes.xml
+++ b/configs/d.ipsec.conf/ipsec-max-bytes.xml
@@ -26,7 +26,7 @@
       each of these keys: the hard limit which is the total number of
       bytes that a given key can encrypt, and the soft limit which is
       the number of bytes that can be encrypted before a renegotiation
-      of the IPsec SA is initiated.  Normally the renegotation (via
+      of the IPsec SA is initiated.  Normally the renegotiation (via
       the IKE SA) is completed before the
       <replaceable>ipsec-max-bytes</replaceable> value is reached.
     </para>

--- a/programs/pluto/kernel_xfrm.c
+++ b/programs/pluto/kernel_xfrm.c
@@ -2017,7 +2017,7 @@ static void netlink_kernel_sa_expire(struct nlmsghdr *n, struct logger *logger)
 
 	if ((ue->hard && impair.ignore_hard_expire) ||
 	    (!ue->hard && impair.ignore_soft_expire)) {
-		dbg("IMPAIR is supress a %s EXPIRE event",
+		dbg("IMPAIR is suppress a %s EXPIRE event",
 		    ue->hard ? "hard" : "soft");
 	}
 

--- a/testing/libvirt/freebsd/transmogrify.sh
+++ b/testing/libvirt/freebsd/transmogrify.sh
@@ -30,7 +30,7 @@ mv /tmp/fstab /etc/fstab
 chsh -s /usr/local/bin/bash root
 cp -v /pool/${PREFIX}freebsd.bash_profile /root/.bash_profile
 
-# supress motd
+# suppress motd
 touch /root/.hushlogin
 
 cp -v /pool/${PREFIX}freebsd.rc.conf /etc/rc.conf


### PR DESCRIPTION
This is not as comprehensive as #1646 (which is focused on the main 5.x development branch) , but it clears up a few spelling errors in the 4.x series that are automatically detected by lintian's automated spellchecking of strings and manpages. 