### PR TITLE
kernel_xfrm: record extended ack from netlink response

### DIFF
--- a/include/netlink_attrib.h
+++ b/include/netlink_attrib.h
@@ -46,4 +46,8 @@ void nl_addattrstrz(struct nlmsghdr *n, int maxlen, int type,
 		const char *str);
 void nl_addattr32(struct nlmsghdr *n, int maxlen, int type, const uint32_t data);
 
+const struct nlattr *nl_getattr(const struct nlmsghdr *n, size_t *offset);
+const char *nl_getattrvalstrz(const struct nlmsghdr *n,
+			      const struct nlattr *attr);
+
 #endif


### PR DESCRIPTION
This enables pluto to log any error message reported through extended ACK attributes[1] in a netlink response, to make diagnostic easier when an error occurs.  Suggested by Sabrina Dubroca.

1. https://docs.kernel.org/userspace-api/netlink/intro.html#ext-ack