### PR TITLE
xfrmi: fix xfrm interface ip refcount problem

### DIFF
--- a/programs/pluto/ikev1_quick.c
+++ b/programs/pluto/ikev1_quick.c
@@ -1591,13 +1591,6 @@ static stf_status quick_inI1_outR1_continue12_tail(struct state *st, struct msg_
 	 * We do this before any state updating so that
 	 * failure won't look like success.
 	 */
-#ifdef USE_XFRM_INTERFACE
-	struct connection *c = st->st_connection;
-	if (c->xfrmi != NULL && c->xfrmi->if_id != 0)
-		if (!add_xfrm_interface(c, st->logger))
-			return STF_FATAL;
-#endif
-
 	struct child_sa *child = pexpect_child_sa(st);
 
 	terminate_conflicts(child);
@@ -1767,12 +1760,6 @@ stf_status quick_inR1_outI2_tail(struct state *st, struct msg_digest *md)
 	 * We do this before any state updating so that
 	 * failure won't look like success.
 	 */
-#ifdef USE_XFRM_INTERFACE
-	if (c->xfrmi != NULL && c->xfrmi->if_id != 0)
-		if (!add_xfrm_interface(c, st->logger))
-			return STF_FATAL;
-#endif
-
 	/*
 	 * IKE must still exist as how else could the quick message
 	 * have been decrypted?
@@ -1810,12 +1797,6 @@ stf_status quick_inI2(struct state *st, struct msg_digest *md UNUSED)
 	 * We do this before any state updating so that
 	 * failure won't look like success.
 	 */
-#ifdef USE_XFRM_INTERFACE
-	struct connection *c = st->st_connection;
-	if (c->xfrmi != NULL && c->xfrmi->if_id != 0)
-		if (!add_xfrm_interface(c, st->logger))
-			return STF_FATAL;
-#endif
 	/*
 	 * IKE must still exist as how else could the quick message
 	 * have been decrypted?

--- a/programs/pluto/ikev2_child.c
+++ b/programs/pluto/ikev2_child.c
@@ -433,13 +433,6 @@ v2_notification_t process_v2_child_request_payloads(struct ike_sa *ike,
 	 * ipsec_sa, but that will give us a "eroute in use"
 	 * error.
 	 */
-#ifdef USE_XFRM_INTERFACE
-	if (cc->xfrmi != NULL && cc->xfrmi->if_id != 0) {
-		if (!add_xfrm_interface(cc, larval_child->sa.logger)) {
-			return v2N_TEMPORARY_FAILURE; /* fatal */
-		}
-	}
-#endif
 
 	/* re-check IKE, child about to be updated */
 	pexpect(ike->sa.st_connection->established_ike_sa == ike->sa.st_serialno);
@@ -852,18 +845,6 @@ v2_notification_t process_v2_child_response_payloads(struct ike_sa *ike, struct 
 	}
 
 	ikev2_derive_child_keys(ike, child);
-
-#ifdef USE_XFRM_INTERFACE
-	/* before calling do_command() */
-	if (child->sa.st_state->kind != STATE_V2_REKEY_CHILD_I1) {
-		if (c->xfrmi != NULL &&
-		    c->xfrmi->if_id != 0) {
-			if (!add_xfrm_interface(c, child->sa.logger)) {
-				return v2N_TEMPORARY_FAILURE; /* delete child */
-			}
-		}
-	}
-#endif
 
 	/* now install child SAs */
 	if (!connection_establish_child(ike, child, HERE)) {

--- a/programs/pluto/ipsec_interface.h
+++ b/programs/pluto/ipsec_interface.h
@@ -54,7 +54,8 @@ struct pluto_xfrmi {
 /* Both add_xfrm_interface() return true on success, false otherwise */
 
 extern diag_t setup_xfrm_interface(struct connection *c, const char *ipsec_interface);
-extern bool add_xfrm_interface(struct connection *c, struct logger *logger);
+extern bool add_xfrm_interface(const struct connection *c, struct logger *logger);
+extern void remove_xfrm_interface(const struct connection *c, struct logger *logger);
 extern void stale_xfrmi_interfaces(struct logger *logger);
 extern err_t xfrm_iface_supported(struct logger *logger);
 extern void free_xfrmi_ipsec1(struct logger *logger);

--- a/programs/pluto/kernel_xfrm_interface.c
+++ b/programs/pluto/kernel_xfrm_interface.c
@@ -1204,13 +1204,6 @@ diag_t setup_xfrm_interface(struct connection *c, const char *ipsec_interface)
 		return NULL;
 	}
 
-	/* something other than ipsec-interface=no, check support */
-	err_t err = xfrm_iface_supported(c->logger);
-	if (err != NULL) {
-		return diag("ipsec-interface=%s not supported: %s",
-			    ipsec_interface, err);
-	}
-
 	uint32_t xfrm_if_id;
 	if (yn != NULL) {
 		PEXPECT(c->logger, yn->value == YN_YES);
@@ -1234,6 +1227,17 @@ diag_t setup_xfrm_interface(struct connection *c, const char *ipsec_interface)
 			xfrm_if_id = kernel_ops->ipsec_interface->map_if_id_zero;
 		} else {
 			xfrm_if_id = value;
+		}
+	}
+
+	/* check if interface is already used by pluto */
+	if(!find_pluto_xfrmi_interface(xfrm_if_id))
+	{
+		/* something other than ipsec-interface=no, check support */
+		err_t err = xfrm_iface_supported(c->logger);
+		if (err != NULL) {
+			return diag("ipsec-interface=%s not supported: %s",
+				    ipsec_interface, err);
 		}
 	}
 

--- a/programs/pluto/routing.c
+++ b/programs/pluto/routing.c
@@ -31,6 +31,7 @@
 #include "updown.h"
 #include "instantiate.h"
 #include "connection_event.h"
+#include "ipsec_interface.h"
 
 enum routing_event {
 	/* fiddle with the ROUTE bit */
@@ -2441,9 +2442,35 @@ static bool dispatch(enum routing_event event,
 	{
 		struct old_routing old = ldbg_routing_start(event, c, logger, e);
 		{
+#ifdef USE_XFRM_INTERFACE
+			if(c->xfrmi != NULL && c->xfrmi->if_id != 0) {
+				PEXPECT(logger, ok);
+				/*
+				 *  add xfrm interface early for route on demand RT_UNROUTED->RT_ROUTE_ONDEMAND
+				 *  or when established from unrouted tunnel RT_UNROUTED_INBOUND->RT_TUNNEL
+				 */
+				if ((c->routing.state == RT_UNROUTED && event == CONNECTION_ROUTE) ||
+				     c->routing.state == RT_UNROUTED_INBOUND) {
+					ldbg_routing(logger, "adding ipsec-interface %"PRIu32,
+						     c->xfrmi->if_id);
+					ok = add_xfrm_interface(c, logger);
+				}
+			}
+#endif
 			if (e->dispatch_ok == NULL ||
 			    e->dispatch_ok(c, logger, e)) {
 				ok = dispatch_1(event, c, logger, e);
+#ifdef USE_XFRM_INTERFACE
+				if (old.routing != c->routing.state &&
+				    c->xfrmi != NULL && c->xfrmi->if_id != 0) {
+					PEXPECT(logger, ok);
+					if (c->routing.state == RT_UNROUTED) {
+						ldbg_routing(logger, "removing ipsec-interface %"PRIu32,
+							     c->xfrmi->if_id);
+						remove_xfrm_interface(c, logger);
+					}
+				}
+#endif
 			}
 			if (ok && e->post_op != NULL) {
 				e->post_op(e);

--- a/programs/pluto/updown.c
+++ b/programs/pluto/updown.c
@@ -509,6 +509,16 @@ bool do_updown(enum updown updown_verb,
 		bad_case(updown_verb);
 	}
 
+#ifdef USE_XFRM_INTERFACE
+	if (c->xfrmi != NULL && c->xfrmi->if_id != 0) {
+		if(updown_verb == UPDOWN_ROUTE) {
+			if(!add_xfrm_interface(c, logger))
+				return false;
+		} else if(updown_verb == UPDOWN_UNROUTE) {
+			remove_xfrm_interface(c, logger);
+		}
+	}
+#endif
 	/*
 	 * Support for skipping updown, eg leftupdown="".  Useful on
 	 * busy servers that do not need to use updown for anything.

--- a/programs/pluto/updown.c
+++ b/programs/pluto/updown.c
@@ -509,16 +509,6 @@ bool do_updown(enum updown updown_verb,
 		bad_case(updown_verb);
 	}
 
-#ifdef USE_XFRM_INTERFACE
-	if (c->xfrmi != NULL && c->xfrmi->if_id != 0) {
-		if(updown_verb == UPDOWN_ROUTE) {
-			if(!add_xfrm_interface(c, logger))
-				return false;
-		} else if(updown_verb == UPDOWN_UNROUTE) {
-			remove_xfrm_interface(c, logger);
-		}
-	}
-#endif
 	/*
 	 * Support for skipping updown, eg leftupdown="".  Useful on
 	 * busy servers that do not need to use updown for anything.

--- a/programs/pluto/whack_route.c
+++ b/programs/pluto/whack_route.c
@@ -37,11 +37,6 @@ static unsigned maybe_route_connection(struct connection *c)
 	}
 
 	if (c->routing.state == RT_UNROUTED) {
-#ifdef USE_XFRM_INTERFACE
-		if (c->xfrmi != NULL && c->xfrmi->if_id != 0)
-			if (!add_xfrm_interface(c, c->logger))
-				return 0;
-#endif
 		/* both install policy and route connection */
 		connection_route(c, HERE);
 		return 1; /* counted */

--- a/testing/pluto/ipsec-interface-06-ipv4-ikev1-xfrmi/west.console.txt
+++ b/testing/pluto/ipsec-interface-06-ipv4-ikev1-xfrmi/west.console.txt
@@ -107,11 +107,11 @@ west #
  ipsec auto --down westnet-eastnet
 "westnet-eastnet": terminating SAs using this connection
 "westnet-eastnet" #2: deleting IPsec SA (QUICK_I2) and sending notification using ISAKMP SA #1
+"westnet-eastnet" #2: delete ipsec-interface=ipsec1 if_id=1 IP [192.0.1.251/32] added by pluto
 "westnet-eastnet" #2: ESP traffic information: in=252B out=252B
 "westnet-eastnet" #1: deleting ISAKMP SA (MAIN_I4) and sending notification
 west #
  ipsec auto --delete westnet-eastnet
-"westnet-eastnet": delete ipsec-interface=ipsec1 if_id=1 IP [192.0.1.251/32] added by pluto
 "westnet-eastnet": delete ipsec-interface=ipsec1 if_id=1 added by pluto
 west #
  

--- a/testing/pluto/ipsec-interface-06-ipv4-ikev2-xfrmi/west.console.txt
+++ b/testing/pluto/ipsec-interface-06-ipv4-ikev2-xfrmi/west.console.txt
@@ -102,11 +102,11 @@ west #
  ipsec auto --down westnet-eastnet
 "westnet-eastnet": terminating SAs using this connection
 "westnet-eastnet" #1: sent INFORMATIONAL request to delete IKE SA
+"westnet-eastnet" #2: delete ipsec-interface=ipsec1 if_id=1 IP [192.0.1.251/24] added by pluto
 "westnet-eastnet" #2: ESP traffic information: in=252B out=252B
 "westnet-eastnet" #1: deleting IKE SA (established IKE SA)
 west #
  ipsec auto --delete westnet-eastnet
-"westnet-eastnet": delete ipsec-interface=ipsec1 if_id=1 IP [192.0.1.251/24] added by pluto
 "westnet-eastnet": delete ipsec-interface=ipsec1 if_id=1 added by pluto
 west #
  

--- a/testing/pluto/ipsec-interface-06-ipv6-ikev1-xfrmi/west.console.txt
+++ b/testing/pluto/ipsec-interface-06-ipv6-ikev1-xfrmi/west.console.txt
@@ -118,11 +118,11 @@ west #
  ipsec auto --down westnet-eastnet
 "westnet-eastnet": terminating SAs using this connection
 "westnet-eastnet" #2: deleting IPsec SA (QUICK_I2) and sending notification using ISAKMP SA #1
+"westnet-eastnet" #2: delete ipsec-interface=ipsec1 if_id=1 IP [2001:db8:0:1::251/64] added by pluto
 "westnet-eastnet" #2: ESP traffic information: in=312B out=312B
 "westnet-eastnet" #1: deleting ISAKMP SA (MAIN_I4) and sending notification
 west #
  ipsec auto --delete westnet-eastnet
-"westnet-eastnet": delete ipsec-interface=ipsec1 if_id=1 IP [2001:db8:0:1::251/64] added by pluto
 "westnet-eastnet": delete ipsec-interface=ipsec1 if_id=1 added by pluto
 west #
  

--- a/testing/pluto/ipsec-interface-06-ipv6-ikev2-xfrmi/west.console.txt
+++ b/testing/pluto/ipsec-interface-06-ipv6-ikev2-xfrmi/west.console.txt
@@ -113,11 +113,11 @@ west #
  ipsec auto --down westnet-eastnet
 "westnet-eastnet": terminating SAs using this connection
 "westnet-eastnet" #1: sent INFORMATIONAL request to delete IKE SA
+"westnet-eastnet" #2: delete ipsec-interface=ipsec1 if_id=1 IP [2001:db8:0:1::251/64] added by pluto
 "westnet-eastnet" #2: ESP traffic information: in=312B out=312B
 "westnet-eastnet" #1: deleting IKE SA (established IKE SA)
 west #
  ipsec auto --delete westnet-eastnet
-"westnet-eastnet": delete ipsec-interface=ipsec1 if_id=1 IP [2001:db8:0:1::251/64] added by pluto
 "westnet-eastnet": delete ipsec-interface=ipsec1 if_id=1 added by pluto
 west #
  

--- a/testing/pluto/ipsec-interface-15-blocked-ikev2-xfrmi/west.console.txt
+++ b/testing/pluto/ipsec-interface-15-blocked-ikev2-xfrmi/west.console.txt
@@ -45,14 +45,14 @@ west #
  ipsec delete westnet4-eastnet4
 "westnet4-eastnet4": terminating SAs using this connection
 "westnet4-eastnet4" #1: deleting IKE SA (ESTABLISHED_IKE_SA) and sending notification
+"westnet4-eastnet4" #2: cannot delete ipsec-interface=ipsec1 if_id=1 IP [192.0.1.251/24], not created by pluto
 "westnet4-eastnet4" #2: ESP traffic information: in=0B out=0B
-"westnet4-eastnet4": cannot delete ipsec-interface=ipsec1 if_id=1 IP [192.0.1.251/24], not created by pluto
 west #
  ipsec delete westnet6-eastnet6
 "westnet6-eastnet6": terminating SAs using this connection
 "westnet6-eastnet6" #3: deleting IKE SA (ESTABLISHED_IKE_SA) and sending notification
+"westnet6-eastnet6" #4: cannot delete ipsec-interface=ipsec1 if_id=1 IP [2001:db8:0:1::251/64], not created by pluto
 "westnet6-eastnet6" #4: ESP traffic information: in=0B out=0B
-"westnet6-eastnet6": cannot delete ipsec-interface=ipsec1 if_id=1 IP [2001:db8:0:1::251/64], not created by pluto
 west #
  ip --color=never link show ipsec1
 X: ipsec1@eth1: <NOARP,UP,LOWER_UP> mtu 1500 state UNKNOWN
@@ -62,11 +62,15 @@ west #
  ip --color=never link show ipsec1
 Device "ipsec1" does not exist.
 west #
+ 
+west #
  #
 west #
  # invalid device; <<ipsec add>> is before <<ip link>>
 west #
  #
+west #
+ 
 west #
  ipsec add westnet4-eastnet4
 "westnet4-eastnet4": added IKEv2 connection
@@ -92,7 +96,8 @@ ERROR: "westnet4-eastnet4" #6: device ipsec1 exists but do not match expected ty
 "westnet4-eastnet4" #5: IKE SA established but initiator rejected Child SA response
 "westnet4-eastnet4" #6: sent INFORMATIONAL request to delete larval Child SA using IKE SA #5
 "westnet4-eastnet4" #6: connection is supposed to remain up; revival attempt 1 scheduled in 0 seconds
-ERROR: "westnet4-eastnet4" #6: netlink response for Del SA esp.ESPSPIi@192.1.2.23: No such process (errno 3)
+ERROR: "westnet4-eastnet4" #6: kernel: xfrm XFRM_MSG_DELPOLICY delete response for flow (in): No such file or directory (errno 2)
+"westnet4-eastnet4" #6: kernel: replace_ipsec_with_bare_kernel_policy() inbound delete failed
 west #
  ipsec up westnet6-eastnet6
 "westnet6-eastnet6" #8: initiating IKEv2 connection to 2001:db8:1:2::23 using UDP
@@ -106,17 +111,20 @@ ERROR: "westnet6-eastnet6" #9: device ipsec1 exists but do not match expected ty
 "westnet6-eastnet6" #8: IKE SA established but initiator rejected Child SA response
 "westnet6-eastnet6" #9: sent INFORMATIONAL request to delete larval Child SA using IKE SA #8
 "westnet6-eastnet6" #9: connection is supposed to remain up; revival attempt 1 scheduled in 0 seconds
-ERROR: "westnet6-eastnet6" #9: netlink response for Del SA esp:ESPSPIi@2001:db8:1:2::23: No such process (errno 3)
+ERROR: "westnet6-eastnet6" #9: kernel: xfrm XFRM_MSG_DELPOLICY delete response for flow (in): No such file or directory (errno 2)
+"westnet6-eastnet6" #9: kernel: replace_ipsec_with_bare_kernel_policy() inbound delete failed
 west #
  ipsec delete westnet4-eastnet4
 "westnet4-eastnet4": terminating SAs using this connection
 "westnet4-eastnet4" #5: deleting IKE SA (ESTABLISHED_IKE_SA) and sending notification
-ERROR: "westnet4-eastnet4": unreference_xfrmi_ip() Unable to unreference IP on xfrmi device [ipsec1] id [1]
+ERROR: "westnet4-eastnet4" #7: unreference_xfrmi_ip() Unable to unreference IP on xfrmi device [ipsec1] id [1]
+"westnet4-eastnet4" #7: ESP traffic information: in=0B out=0B
 west #
  ipsec delete westnet6-eastnet6
 "westnet6-eastnet6": terminating SAs using this connection
 "westnet6-eastnet6" #8: deleting IKE SA (ESTABLISHED_IKE_SA) and sending notification
-ERROR: "westnet6-eastnet6": unreference_xfrmi_ip() Unable to unreference IP on xfrmi device [ipsec1] id [1]
+ERROR: "westnet6-eastnet6" #10: unreference_xfrmi_ip() Unable to unreference IP on xfrmi device [ipsec1] id [1]
+"westnet6-eastnet6" #10: ESP traffic information: in=0B out=0B
 west #
  ip --color=never link show ipsec1
 X: ipsec1@NONE: <NOARP> mtu 1500 qdisc state DOWN qlen 1000


### PR DESCRIPTION
As mentioned in https://github.com/libreswan/libreswan/issues/1778#issuecomment-2285548428 there is actual an issue with referencing xfrm interfacip.

Actual add_xfrm_interface is called in several places when the connection is going up and add_xfrm_interface_ip which create/reference the interface ip is also called from there.
But unreference_xfrmi_ip is only called from unreference_xfrmi when the connection is deleted (discard_connection).

Previous in e727e23 double ip references were removed and in 6b66fc5 a new double reference added.

This leads to the following problems:

* if a connection is deleted that had never been up, it regardless unreferencing an ip. Which leads either to an error "Unable to unreference IP on xfrmi device" or it deletes the ip from another connection as described in #1778
* for every up/down an new reference is created, but the ip will never been deleted

So moving the referencing/unreferencing to updown depending on UPDOWN_ROUTE/UPDOWN_UNROUTE makes sure the ip is correctly referenced for routed-ondemand and routed-tunnel.

I added also an fix for the initial xfrm interface check.