### PR TITLE
pluto: allow nic-offload=packet to configure lifetime limits

### DIFF
--- a/programs/pluto/kernel_xfrm.c
+++ b/programs/pluto/kernel_xfrm.c
@@ -1586,19 +1586,10 @@ static bool netlink_add_sa(const struct kernel_state *sa, bool replace,
 	req.p.reqid = sa->reqid;
 	ldbg(logger, "%s() adding IPsec SA with reqid %d", __func__, sa->reqid);
 
-	if (sa->nic_offload.dev == NULL /* i.e., no offload */ ||
-	    sa->nic_offload.type != KERNEL_OFFLOAD_PACKET) {
-		req.p.lft.soft_byte_limit = sa->sa_max_soft_bytes;
-		req.p.lft.hard_byte_limit = sa->sa_ipsec_max_bytes;
-		req.p.lft.hard_packet_limit = sa->sa_ipsec_max_packets;
-		req.p.lft.soft_packet_limit = sa->sa_max_soft_packets;
-	} else {
-		/* This has further FIPS implications :/ */
-		req.p.lft.soft_byte_limit = XFRM_INF;
-		req.p.lft.hard_byte_limit = XFRM_INF;
-		req.p.lft.hard_packet_limit = XFRM_INF;
-		req.p.lft.soft_packet_limit = XFRM_INF;
-	}
+	req.p.lft.soft_byte_limit = sa->sa_max_soft_bytes;
+	req.p.lft.hard_byte_limit = sa->sa_ipsec_max_bytes;
+	req.p.lft.hard_packet_limit = sa->sa_ipsec_max_packets;
+	req.p.lft.soft_packet_limit = sa->sa_max_soft_packets;
 
 	req.n.nlmsg_len = NLMSG_ALIGN(NLMSG_LENGTH(sizeof(req.p)));
 


### PR DESCRIPTION
Previously nic-offload=packet wasn't allowed to configure lifetime byte/packet limits for SA.

Simply since there was no driver/HW that supports that. That is no longer the case since Linux kernel 6.7+ which added support for lifetime limit configuration. Specifically from the following commit onwards
https://patchwork.kernel.org/project/netdevbpf/patch/20231012192750.124945-16-saeed@kernel.org/#25551683