### PR TITLE
addconn: improve performance of 'ipsec add' at scale

### DIFF
--- a/include/ipsecconf/confread.h
+++ b/include/ipsecconf/confread.h
@@ -71,7 +71,6 @@ struct starter_end {
 	ip_address addr;
 	ip_address nexthop;
 	ip_cidr vti_ip;
-	ip_protoport protoport;
 
 	keyword_values values;
 };

--- a/include/ipsecconf/confread.h
+++ b/include/ipsecconf/confread.h
@@ -123,6 +123,7 @@ extern void parser_freeany_config_parsed(struct config_parsed **cfg);
 
 extern struct starter_config *confread_load(const char *file,
 					    bool setuponly,
+					    size_t n_allowed, char **allowed,
 					    struct logger *logger);
 
 extern void confread_free(struct starter_config *cfg);

--- a/lib/libipsecconf/confread.c
+++ b/lib/libipsecconf/confread.c
@@ -370,16 +370,6 @@ static bool validate_end(struct starter_conn *conn_st,
 		}
 	}
 
-	/* copy certificate path name */
-
-	if (end->values[KSCF_PROTOPORT].set) {
-		char *value = end->values[KSCF_PROTOPORT].string;
-		err_t ugh = ttoprotoport(value, &end->protoport);
-		if (ugh != NULL)
-			ERR_FOUND("bad %sprotoport=%s [%s]", leftright, value,
-				  ugh);
-	}
-
 	return err;
 #  undef ERR_FOUND
 }

--- a/lib/libipsecconf/confwrite.c
+++ b/lib/libipsecconf/confwrite.c
@@ -313,11 +313,9 @@ static void confwrite_side(FILE *out, struct starter_end *end)
 			str_cidr(&end->vti_ip, &as));
 	}
 
-	if (end->protoport.is_set) {
-		protoport_buf buf;
+	if (end->values[KSCF_PROTOPORT].set)
 		fprintf(out, "\t%sprotoport=%s\n", side,
-			str_protoport(&end->protoport, &buf));
-	}
+			end->values[KSCF_PROTOPORT].string);
 
 	confwrite_int(out, side,
 		      kv_conn | kv_leftright,

--- a/lib/libipsecconf/starterwhack.c
+++ b/lib/libipsecconf/starterwhack.c
@@ -151,7 +151,17 @@ static bool set_whack_end(struct whack_end *w,
 
 	w->subnets = l->values[KSCF_SUBNETS].string;
 	w->host_ikeport = l->values[KNCF_IKEPORT].option;
-	w->protoport = l->protoport;
+
+	if (l->values[KSCF_PROTOPORT].set) {
+		char *value = l->values[KSCF_PROTOPORT].string;
+		err_t ugh = ttoprotoport(value, &w->protoport);
+
+		if (ugh != NULL) {
+			llog_error(logger, 0, "bad %sprotoport=%s [%s]",
+				   lr, value, ugh);
+			return false;
+		}
+	}
 
 	w->cert = l->values[KSCF_CERT].string;
 	w->ckaid = l->values[KSCF_CKAID].string;

--- a/programs/addconn/addconn.c
+++ b/programs/addconn/addconn.c
@@ -350,7 +350,10 @@ int main(int argc, char *argv[])
 		printf("opening file: %s\n", configfile);
 	}
 
-	struct starter_config *cfg = confread_load(configfile, configsetup, logger);
+	struct starter_config *cfg = confread_load(configfile, configsetup,
+						   (!autoall && !dolist)
+						   ? argc - optind : 0,
+						   &argv[optind], logger);
 	if (cfg == NULL) {
 		llog(RC_LOG, logger, "cannot load config file '%s'", configfile);
 		exit(3);

--- a/programs/pluto/plutomain.c
+++ b/programs/pluto/plutomain.c
@@ -333,7 +333,7 @@ static struct starter_config *read_cfg_file(char *configfile, long longindex, st
 {
 	struct starter_config *cfg = NULL;
 
-	cfg = confread_load(configfile, true, logger);
+	cfg = confread_load(configfile, true, 0, NULL, logger);
 	if (cfg == NULL) {
 		/* details already logged */
 		fatal_opt(longindex, logger, "cannot load config file '%s'\n", configfile);

--- a/programs/readwriteconf/readwriteconf.c
+++ b/programs/readwriteconf/readwriteconf.c
@@ -139,7 +139,8 @@ int main(int argc, char *argv[])
 		printf("opening file: %s\n", configfile);
 	}
 
-	struct starter_config *cfg = confread_load(configfile, false, logger);
+	struct starter_config *cfg = confread_load(configfile, false,
+						   0, NULL, logger);
 	if (cfg == NULL) {
 		llog(RC_LOG, logger, "cannot load config file '%s'", configfile);
 		exit(3);


### PR DESCRIPTION
Issue: #2002 

Scenario:
1. We have an `ipsec.conf` with a 1000 connections specified.
2. Connections have `rightprotoport=udp/6081` or `leftprotoport=udp/6081`
3. We add each of these connections with `ipsec add <conn>` one by one, since there are other connections we don't want to disrupt in the process.

Result:
- It takes about 30 minutes to complete the configuration.

Cause:
- Every `ipsec add <conn>` results in full parsing of the large `ipsec.conf`.
- While parsing `*protoopt=udp/6081` of every connection, a very heavy `getservbyname()` function is called (takes 1.8 ms per call).

This PR attempts to solve the problem by:
1. Only loading connections that are specified on the command line (as possible), to avoid unnecessary memory allocations and extra parsing of non-interesting connections.
2. Reordering the `protoport` parsing logic to first check if the value is a number to avoid the costly `getservbyname()` call.

Results:
1. 1000x `ipsec add <conn>`:
```
        protoport      main       Patch #1    Patch #2      Both     SpeedUp
        --------------------------------------------------------------------
        udp/6081      29.6 min    24.5 sec    54.4 sec    22.5 sec     79x
        udp/geneve    22.9 min    23.9 sec    22.9 min    23.9 sec     57x
```
2. `addconn --checkconfig` (only affected by the change in `ttoport`):
```
        protoport      Before     After     SpeedUp
        -------------------------------------------
        udp/6081      1.77 sec   0.04 sec     44x
        udp/geneve    1.37 sec   1.37 sec     --
```

Technically, either one of the changes solves the problem for the main use-case with Open vSwitch (`udp/6081`), but it seemed better to fix the issue for both.

Note: I'm not particularly happy with parsing of aliases and recursive checks for `also`, but I didn't find a better way to filter out connections without breaking the logic for aliases.

Testing done with the following simple script (adjust `N` to get +/-250 connections):
```
# cat pluto-test.sh 
kill $(cat /tmp/pluto-test/pluto.pid 2>/dev/null) 2>/dev/null
sleep 2
ip netns del pluto-ns 2>/dev/null
ip netns add pluto-ns
ip -netns pluto-ns link set dev lo up
ip link del pluto-p1 2>/dev/null
ip link add pluto-p1 type veth peer name pluto-p2
ip link set pluto-p2 netns pluto-ns
ip -netns pluto-ns link set dev pluto-p2 up
ip -netns pluto-ns addr add 30.30.1.1/16 dev pluto-p2
ip -netns pluto-ns route add default via 30.30.100.254

rm -rf /tmp/pluto-test
mkdir -p /tmp/pluto-test/ipsec.d
echo '
config setup
    uniqueids=yes

conn %default
    keyingtries=%forever
    type=transport
    auto=route
    ike=aes_gcm256-sha2_256
    esp=aes_gcm256
    ikev2=insist
' > /tmp/pluto-test/ipsec.conf

touch /tmp/pluto-test/secrets
ipsec initnss --nssdir /tmp/pluto-test/ipsec.d
ip netns exec pluto-ns ipsec pluto --config /tmp/pluto-test/ipsec.conf \
      --ipsecdir /tmp/pluto-test --nssdir /tmp/pluto-test/ipsec.d \
      --logfile /tmp/pluto-test/pluto.log \
      --secretsfile /tmp/pluto-test/secrets \
      --rundir /tmp/pluto-test

sleep 2

set -o errexit

N=5
M=251
for i in $(seq 2 ${N}); do
    for j in $(seq 2 ${M}); do
        echo "
conn tunnel-${i}-${j}
    left=30.30.1.1
    right=30.30.${i}.${j}
    authby=secret
    leftprotoport=udp
    rightprotoport=udp/6081
" >> /tmp/pluto-test/ipsec.conf
        echo "
%any 30.30.${i}.${j} : PSK \"swordfish\"
" >> /tmp/pluto-test/secrets
    done
done

ip netns exec pluto-ns ipsec \
    --ctlsocket /tmp/pluto-test/pluto.ctl \
    --config /tmp/pluto-test/ipsec.conf   \
    rereadsecrets >/dev/null 2>&1

start_time_total=$(date +%s.%3N)
k=1
for i in $(seq 2 ${N}); do
    for j in $(seq 2 ${M}); do
        start_time=$(date +%s.%3N)
        ip netns exec pluto-ns ipsec \
            --ctlsocket /tmp/pluto-test/pluto.ctl \
            --config /tmp/pluto-test/ipsec.conf   \
            add tunnel-${i}-${j} \
            >> /tmp/pluto-test/add.log 2>&1
        end_time=$(date +%s.%3N)
        add_s=$(echo "scale=3; ${end_time} - ${start_time}" | bc)
        printf "%-4d %5.3f\n" ${k} ${add_s}
        let k=$(($k + 1))
    done
done
end_time_total=$(date +%s.%3N)
total_s=$(echo "scale=3; ${end_time_total} - ${start_time_total}" | bc)
printf "Total: %5.3f seconds\n" ${total_s}

kill $(cat /tmp/pluto-test/pluto.pid)
sleep 2
rm -rf /tmp/pluto-test
ip link del pluto-p1
ip netns del pluto-ns
```