### PR TITLE
addconn: aarch requires faccessat syscall

### DIFF
--- a/programs/addconn/addconn.c
+++ b/programs/addconn/addconn.c
@@ -97,6 +97,7 @@ static void init_seccomp_addconn(uint32_t def_action, struct logger *logger)
 	LSW_SECCOMP_ADD(epoll_wait);
 	LSW_SECCOMP_ADD(epoll_pwait);
 	LSW_SECCOMP_ADD(exit_group);
+	LSW_SECCOMP_ADD(faccessat);
 	LSW_SECCOMP_ADD(fcntl);
 	LSW_SECCOMP_ADD(fstat);
 	LSW_SECCOMP_ADD(futex);


### PR DESCRIPTION
To address the following SECCOMP audit event when seccomp is enabled:

type=SECCOMP msg=audit(03/04/2025 07:39:37.599:201) : auid=unset uid=root gid=root ses=unset subj=system_u:system_r:ipsec_t:s0 pid=6464 comm=addconn exe=/usr/libexec/ipsec/addconn sig=SIGSYS arch=aarch64 syscall=faccessat compat=0 ip=0xffff92e23698 code=kill-thread