### PR TITLE
Expect no IKE only for orphan child

### DIFF
--- a/programs/pluto/terminate.c
+++ b/programs/pluto/terminate.c
@@ -158,6 +158,9 @@ static void terminate_v2_states(struct connection *c,
 		connection_teardown_child(child, REASON_DELETED, HERE);
 		return;
 	case CONNECTION_CUCKOO_CHILD:
+		state_attach(&(*child)->sa, c->logger);
+		connection_teardown_child(child, REASON_DELETED, HERE);
+		return;
 	case CONNECTION_ORPHAN_CHILD:
 		state_attach(&(*child)->sa, c->logger);
 		PEXPECT(c->logger, ike == NULL);


### PR DESCRIPTION
When terminating v2 states, CONNECTION_CUCKOO_CHILD SA does have IKE SA and hence we cannot expect it being NULL.

Resolves #2101.