### PR TITLE
testing: fix CodeQL build failure

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,12 +42,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -fy --no-install-recommends libnss3-dev libnspr4-dev libpam-dev libcap-ng-dev libcap-ng-utils libselinux-dev libcurl3-nss-dev libldns-dev libunbound-dev libnss3-tools libevent-dev xmlto libsystemd-dev
+          sudo apt-get install -fy --no-install-recommends libnss3-dev libnspr4-dev libpam-dev libcap-ng-dev libcap-ng-utils libselinux-dev libcurl4-openssl-dev libldns-dev libunbound-dev libnss3-tools libevent-dev xmlto libsystemd-dev
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL


### PR DESCRIPTION
libcurl3-nss-dev is no longer provided in Ubuntu 24.04: https://packages.ubuntu.com/source/noble/curl