### PR TITLE
packaging: add systemd-tmpfiles for directories under /var

### DIFF
--- a/initsystems/systemd/libreswan.conf.in
+++ b/initsystems/systemd/libreswan.conf.in
@@ -1,1 +1,3 @@
 d @@RUNDIR@@ 755 root root -
+d /var/lib/ipsec 0700 root root -
+d /var/lib/ipsec/nss 0700 root root -

--- a/packaging/fedora/libreswan.spec
+++ b/packaging/fedora/libreswan.spec
@@ -194,8 +194,8 @@ certutil -N -d sql:$tmpdir --empty-password
 %attr(0644,root,root) %config(noreplace) %{_sysconfdir}/ipsec.d/policies/*
 %attr(0644,root,root) %config(noreplace) %{_sysctldir}/50-libreswan.conf
 %attr(0755,root,root) %dir %{_rundir}/pluto
-%attr(0700,root,root) %dir %{_sharedstatedir}/ipsec
-%attr(0700,root,root) %dir %{_sharedstatedir}/ipsec/nss
+%ghost %attr(0700,root,root) %verify(not owner group) %{_sharedstatedir}/ipsec
+%ghost %attr(0700,root,root) %verify(not owner group) %{_sharedstatedir}/ipsec/nss
 %attr(0644,root,root) %{_tmpfilesdir}/libreswan.conf
 %attr(0644,root,root) %{_unitdir}/ipsec.service
 %attr(0644,root,root) %config(noreplace) %{_sysconfdir}/pam.d/pluto

--- a/packaging/rhel/9/libreswan.spec
+++ b/packaging/rhel/9/libreswan.spec
@@ -188,6 +188,8 @@ certutil -N -d sql:$tmpdir --empty-password
 %attr(0644,root,root) %config(noreplace) %{_sysconfdir}/ipsec.d/policies/*
 %attr(0644,root,root) %config(noreplace) %{_sysctldir}/50-libreswan.conf
 %attr(0755,root,root) %dir %{_rundir}/pluto
+%ghost %attr(0700,root,root) %verify(not owner group) %{_sharedstatedir}/ipsec
+%ghost %attr(0700,root,root) %verify(not owner group) %{_sharedstatedir}/ipsec/nss
 %attr(0644,root,root) %{_tmpfilesdir}/libreswan.conf
 %attr(0644,root,root) %{_unitdir}/ipsec.service
 %attr(0644,root,root) %config(noreplace) %{_sysconfdir}/pam.d/pluto


### PR DESCRIPTION
This is in service of image-mode systems in the Fedora/RHEL ecosystem.

I am not sure about the change of initsystems/systemd/libreswan.conf.in to add these directories or if I just should introduce a tmpfile to be individually packaged inside the fedora and rhel directories.