### PR TITLE
whack: support structured logging in JSON

### DIFF
--- a/include/whack.h
+++ b/include/whack.h
@@ -489,6 +489,8 @@ struct whack_message {
 	/* what metric to put on ipsec routes */
 	int metric;
 
+	bool whack_json;
+
 	/* space for strings (hope there is enough room) */
 	size_t str_size;
 	unsigned char string[4096];

--- a/programs/ipsec/ipsec.in
+++ b/programs/ipsec/ipsec.in
@@ -493,6 +493,10 @@ ipsec_whack() {
 		utc="${1}"
 		shift
 		;;
+	    --json)
+		json="${1}"
+		shift
+		;;
 	    --verbose)
 		verbose="${1}"
 		shift
@@ -509,7 +513,7 @@ ipsec_whack() {
 		;;
 	esac
     done
-    ${dry_run} "${IPSEC_EXECDIR}/whack" --ctlsocket "${CTLSOCKET}" ${asynchronous} ${conn_name} ${utc} ${cmd} ${remote_host}
+    ${dry_run} "${IPSEC_EXECDIR}/whack" --ctlsocket "${CTLSOCKET}" ${asynchronous} ${conn_name} ${utc} ${cmd} ${remote_host} ${json}
     exit $?
 }
 

--- a/programs/pluto/Makefile
+++ b/programs/pluto/Makefile
@@ -87,6 +87,8 @@ OBJS += ikev2_eap.o
 
 OBJS += state_db.o
 OBJS += show.o
+OBJS += show_text.o
+OBJS += show_json.o
 OBJS += binlog.o
 OBJS += retransmit.o
 OBJS += quirks.o

--- a/programs/pluto/ikev2_liveness.c
+++ b/programs/pluto/ikev2_liveness.c
@@ -140,7 +140,7 @@ static bool recent_last_contact(struct child_sa *child,
  * that half the channel is working.  All the incoming packets could
  * be retransmits.
  *
- * note: this mutates *st by calling get_sa_bundle_info
+ * note: this mutates *st by calling get_ipsec_traffic
  */
 
 void event_v2_liveness(struct state *st)

--- a/programs/pluto/kernel.c
+++ b/programs/pluto/kernel.c
@@ -1944,11 +1944,11 @@ void teardown_ipsec_kernel_states(struct child_sa *child)
  * for errors, as they could mean that the SA is broken and needs to
  * be replace anyway.
  *
- * note: this mutates *st by calling get_sa_bundle_info
+ * note: this mutates *st by calling get_ipsec_traffic
  *
  * XXX:
  *
- * The use of get_sa_bundle_info() here is likely bogus.  The function
+ * The use of get_ipsec_traffic() here is likely bogus.  The function
  * returns the SA's add time (PF_KEY v2 documents it as such, xfrm
  * returns the .add_time field so presumably ...) when it is assumed
  * to be returning the idle time.

--- a/programs/pluto/nat_traversal.c
+++ b/programs/pluto/nat_traversal.c
@@ -288,7 +288,7 @@ void event_v1_nat_keepalive(struct state *st)
 	 * keepalives, we don't need to check IPsec SA's being idle.
 	 * If we were to check IPsec SA, we could then also update the
 	 * ISAKMP SA, but we think this is too expensive (call
-	 * get_sa_bundle_info() to kernel _and_ find ISAKMP SA.
+	 * get_ipsec_traffic() to kernel _and_ find ISAKMP SA.
 	 */
 	if (!IS_IPSEC_SA_ESTABLISHED(st)) {
 		ldbg(st->logger, "NAT-keep-alive: IPsec SA is not established");

--- a/programs/pluto/pluto_stats.c
+++ b/programs/pluto/pluto_stats.c
@@ -403,7 +403,7 @@ void whack_showstats(const struct whack_message *wm UNUSED, struct show *s)
 	show(s, "total.ipsec.type.non_encap=%lu", pstats_ipsec_encap_no);
 	/*
 	 * Total counts only total of traffic by terminated IPsec
-	 * SA's.  Should we call get_sa_bundle_info() for bytes of
+	 * SA's.  Should we call get_ipsec_traffic() for bytes of
 	 * active IPsec SA's?
 	 */
 	show_bytes(s, "total.ipsec.traffic", &pstats_ipsec_bytes);

--- a/programs/pluto/rcv_whack.c
+++ b/programs/pluto/rcv_whack.c
@@ -691,14 +691,14 @@ static void whack_handle(struct fd *whackfd, struct logger *whack_logger)
 	}
 
 	if (msg.basic.whack_status) {
-		struct show *s = alloc_show(whack_logger);
+		struct show *s = alloc_show(whack_logger, &show_text_ops);
 		whack_status(s, mononow());
 		free_show(&s);
 		/* bail early, but without complaint */
 		return; /* don't shutdown */
 	}
 
-	struct show *s = alloc_show(whack_logger);
+	struct show *s = alloc_show(whack_logger, &show_text_ops);
 	whack_process(&msg, s);
 	free_show(&s);
 }

--- a/programs/pluto/rcv_whack.c
+++ b/programs/pluto/rcv_whack.c
@@ -691,14 +691,14 @@ static void whack_handle(struct fd *whackfd, struct logger *whack_logger)
 	}
 
 	if (msg.basic.whack_status) {
-		struct show *s = alloc_show(whack_logger, &show_text_ops);
+		struct show *s = alloc_show(whack_logger, msg.whack_json ? &show_json_ops : &show_text_ops);
 		whack_status(s, mononow());
 		free_show(&s);
 		/* bail early, but without complaint */
 		return; /* don't shutdown */
 	}
 
-	struct show *s = alloc_show(whack_logger, &show_text_ops);
+	struct show *s = alloc_show(whack_logger, msg.whack_json ? &show_json_ops : &show_text_ops);
 	whack_process(&msg, s);
 	free_show(&s);
 }

--- a/programs/pluto/show.h
+++ b/programs/pluto/show.h
@@ -21,6 +21,7 @@
 struct show;
 enum rc_type;
 struct logger;
+struct show_ops;
 
 /*
  * Try to deal with the separator (i.e., don't output duplicate blank
@@ -28,7 +29,10 @@ struct logger;
  * in show (whack-only) output.
  */
 
-struct show *alloc_show(struct logger *logger);
+extern const struct show_ops show_text_ops;
+extern const struct show_ops show_json_ops;
+
+struct show *alloc_show(struct logger *logger, const struct show_ops *ops);
 void free_show(struct show **s);
 /* underlying global logger formed by alloc_show() */
 struct logger *show_logger(struct show *s);
@@ -80,13 +84,46 @@ void show_separator(struct show *s);
 void show_blank(struct show *s);
 
 /*
- * If necessary show the separator (aka blank line), and then show the
- * message.  Suppress further separation.
- *
- * "comment" comes from RC_LOG, better name?
+ * Line based output functions. If necessary show the separator (aka
+ * blank line), and then show the message.  Suppress further
+ * separation.
  */
 
 void show(struct show *s, const char *message, ...) PRINTF_LIKE(2);
 void show_rc(enum rc_type rc, struct show *s, const char *message, ...) PRINTF_LIKE(3);
+
+/*
+ * Structured output functions.
+ */
+void show_structured_start(struct show *s);
+void show_structured_end(struct show *s);
+
+#define SHOW_STRUCTURED(S, F)				\
+	for (bool F = (show_structured_start(S), true); \
+	     F; show_structured_end(S), F = false)
+
+void show_raw(struct show *s, const char *message, ...) PRINTF_LIKE(2);
+void show_string(struct show *s, const char *message, ...) PRINTF_LIKE(2);
+
+void show_member_start(struct show *s, const char *name);
+void show_member_end(struct show *s);
+
+#define SHOW_MEMBER(S, F, FMT, ...)					\
+	for (bool F = (show_member_start(S, FMT, ##__VA_ARGS__), true); \
+	     F;	show_member_end(S), F = false)
+
+void show_array_start(struct show *s);
+void show_array_end(struct show *s);
+
+#define SHOW_ARRAY(S, F)				\
+	for (bool F = (show_array_start(S), true);	\
+	     F;	show_array_end(S), F = false)
+
+void show_object_start(struct show *s);
+void show_object_end(struct show *s);
+
+#define SHOW_OBJECT(S, F)				\
+	for (bool F = (show_object_start(S), true);	\
+	     F; show_object_end(S), F = false)
 
 #endif

--- a/programs/pluto/show_json.c
+++ b/programs/pluto/show_json.c
@@ -1,0 +1,112 @@
+/* show functions in JSON format, for libreswan
+ *
+ * Copyright (C) 2025 Daiki Ueno <dueno@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.  See <https://www.gnu.org/licenses/gpl2.txt>.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ */
+
+#include "log.h"
+#include "show.h"
+#include "show_ops.h"
+
+static size_t jam_json_quoted_bytes(struct jambuf *buf, const void *ptr, size_t size)
+{
+	size_t n = 0;
+	const char *chars = ptr;
+	for (unsigned i = 0; i < size; i++) {
+		char c = chars[i];
+		switch (c) {
+		case '"':
+		case '\\':
+			n += jam_char(buf, '\\');
+			/* FALLTHROUGH */
+		default:
+			n += jam_char(buf, chars[i]);
+		}
+	}
+	return n;
+}
+
+#define jam_json_quoted_hunk(BUF, HUNK)				\
+	({								\
+		typeof(HUNK) hunk_ = (HUNK); /* evaluate once */	\
+		jam_json_quoted_bytes(BUF, hunk_.ptr, hunk_.len);	\
+	})
+
+VPRINTF_LIKE(2)
+static void json_raw_va_list(struct jambuf *buf, const char *message, va_list ap)
+{
+	jam_va_list(buf, message, ap);
+}
+
+VPRINTF_LIKE(2)
+static void json_string_va_list(struct jambuf *buf, const char *message, va_list ap)
+{
+	JAMBUF(buf2) {
+		jam_char(buf, '"');
+		jam_va_list(buf2, message, ap);
+		jam_json_quoted_hunk(buf, jambuf_as_shunk(buf2));
+		jam_char(buf, '"');
+	}
+}
+
+VPRINTF_LIKE(2)
+static void json_member_start(struct jambuf *buf, const char *name)
+{
+	JAMBUF(buf2) {
+		jam_char(buf, '"');
+		jam_string(buf2, name);
+		jam_json_quoted_hunk(buf, jambuf_as_shunk(buf2));
+		jam_string(buf, "\": ");
+	}
+}
+
+static void json_member_end(struct jambuf *buf UNUSED)
+{
+}
+
+static void json_array_start(struct jambuf *buf)
+{
+	jam_string(buf, "[");
+}
+
+static void json_array_end(struct jambuf *buf)
+{
+	jam_string(buf, "]");
+}
+
+static void json_object_start(struct jambuf *buf)
+{
+	jam_string(buf, "{");
+}
+
+static void json_object_end(struct jambuf *buf)
+{
+	jam_string(buf, "}");
+}
+
+static void json_separator(struct jambuf *buf)
+{
+	jam_string(buf, ", ");
+}
+
+const struct show_ops show_json_ops = {
+	.raw_va_list = json_raw_va_list,
+	.string_va_list = json_string_va_list,
+	.member_start = json_member_start,
+	.member_end = json_member_end,
+	.array_start = json_array_start,
+	.array_end = json_array_end,
+	.object_start = json_object_start,
+	.object_end = json_object_end,
+	.separator = json_separator,
+};

--- a/programs/pluto/show_ops.h
+++ b/programs/pluto/show_ops.h
@@ -1,0 +1,37 @@
+/* show backend functions, for libreswan
+ *
+ * Copyright (C) 2025 Daiki Ueno <dueno@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.  See <https://www.gnu.org/licenses/gpl2.txt>.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ */
+
+#ifndef SHOW_OPS_H
+#define SHOW_OPS_H
+
+#include <stdarg.h>
+#include <stdbool.h>
+
+struct jambuf;
+
+struct show_ops {
+	void (*raw_va_list)(struct jambuf *buf, const char *message, va_list ap);
+	void (*string_va_list)(struct jambuf *buf, const char *message, va_list ap);
+	void (*member_start)(struct jambuf *buf, const char *name);
+	void (*member_end)(struct jambuf *buf);
+	void (*array_start)(struct jambuf *buf);
+	void (*array_end)(struct jambuf *buf);
+	void (*object_start)(struct jambuf *buf);
+	void (*object_end)(struct jambuf *buf);
+	void (*separator)(struct jambuf *buf);
+};
+
+#endif

--- a/programs/pluto/show_text.c
+++ b/programs/pluto/show_text.c
@@ -1,0 +1,53 @@
+/* show functions in text format, for libreswan
+ *
+ * Copyright (C) 2025 Daiki Ueno <dueno@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.  See <https://www.gnu.org/licenses/gpl2.txt>.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ */
+
+#include "log.h"
+#include "show_ops.h"
+#include "show.h"
+
+VPRINTF_LIKE(2)
+static void raw_va_list(struct jambuf *buf, const char *message, va_list ap)
+{
+	jam_va_list(buf, message, ap);
+}
+
+static void discard(struct jambuf *buf UNUSED)
+{
+}
+
+VPRINTF_LIKE(2)
+static void member_start(struct jambuf *buf, const char *name)
+{
+	jam_string(buf, name);
+	jam_string(buf, "=");
+}
+
+static void separator(struct jambuf *buf)
+{
+	jam_string(buf, ", ");
+}
+
+const struct show_ops show_text_ops = {
+	.raw_va_list = raw_va_list,
+	.string_va_list = raw_va_list,
+	.member_start = member_start,
+	.member_end = discard,
+	.array_start = discard,
+	.array_end = discard,
+	.object_start = discard,
+	.object_end = discard,
+	.separator = separator,
+};

--- a/programs/pluto/state.c
+++ b/programs/pluto/state.c
@@ -1639,6 +1639,13 @@ void jam_humber_uintmax(struct jambuf *buf,
 	jam_string(buf, suffix);
 }
 
+const char *str_humber_uintmax(const char *prefix, uintmax_t val, const char *suffix, humber_buf *buf)
+{
+	struct jambuf jb = ARRAY_AS_JAMBUF(buf->buf);
+	jam_humber_uintmax(&jb, prefix, val, suffix);
+	return buf->buf;
+}
+
 void whack_briefstatus(const struct whack_message *wm UNUSED, struct show *s)
 {
 	show_separator(s);

--- a/programs/pluto/state.h
+++ b/programs/pluto/state.h
@@ -948,6 +948,9 @@ extern void set_sa_expire_next_event(enum sa_expire_kind expire, struct child_sa
 void jam_humber_uintmax(struct jambuf *buf,
 			const char *prefix, uintmax_t val, const char *suffix);
 
+const char *str_humber_uintmax(const char *prefix, uintmax_t val,
+			       const char *suffix, humber_buf *buf);
+
 /* IKE SA | ISAKMP SA || Child SA | IPsec SA */
 const char *state_sa_name(const struct state *st);
 /* IKE | ISAKMP || Child | IPsec */

--- a/programs/pluto/updown.c
+++ b/programs/pluto/updown.c
@@ -74,7 +74,7 @@ static void jam_clean_xauth_username(struct jambuf *buf,
 /*
  * fmt_common_shell_out: form the command string
  *
- * note: this mutates *st by calling get_sa_bundle_info().
+ * note: this mutates *st by calling get_ipsec_traffic().
  */
 
 static bool fmt_common_shell_out(char *buf, size_t blen,
@@ -245,9 +245,9 @@ static bool fmt_common_shell_out(char *buf, size_t blen,
 
 	if (first_ipsec_proto != NULL) {
 		/*
-		 * note: this mutates *st by calling get_sa_bundle_info
+		 * note: this mutates *st by calling get_ipsec_traffic
 		 *
-		 * XXX: does the get_sa_bundle_info() call order matter? Should this
+		 * XXX: does the get_ipsec_traffic() call order matter? Should this
 		 * be a single "atomic" call?
 		 */
 		if (get_ipsec_traffic(child, first_ipsec_proto, DIRECTION_INBOUND)) {

--- a/programs/pluto/whack_briefconnectionstatus.c
+++ b/programs/pluto/whack_briefconnectionstatus.c
@@ -71,7 +71,7 @@ static uint64_t get_child_bytes(const struct connection *c, enum direction direc
 		}
 
 		/* note: this mutates *st by calling
-		 * get_sa_bundle_info */
+		 * get_ipsec_traffic */
 		struct child_sa *child = pexpect_child_sa(st);
 		struct ipsec_proto_info *first_ipsec_proto =
 		    (child->sa.st_esp.protocol == &ip_protocol_esp ? &child->sa.st_esp:

--- a/programs/pluto/whack_showstates.c
+++ b/programs/pluto/whack_showstates.c
@@ -169,7 +169,7 @@ static size_t jam_readable_humber(struct jambuf *buf, uint64_t num, bool kilos)
 }
 
 /*
- * Note: st cannot be const because we call get_sa_bundle_info on it
+ * Note: st cannot be const because we call get_ipsec_traffic on it
  */
 
 static void show_state(struct show *s, struct state *st, const monotime_t now)

--- a/programs/pluto/whack_trafficstatus.c
+++ b/programs/pluto/whack_trafficstatus.c
@@ -43,7 +43,7 @@
 #include "whack_trafficstatus.h"
 #include "iface.h"
 
-/* note: this mutates *st by calling get_sa_bundle_info */
+/* note: this mutates *st by calling get_ipsec_traffic */
 static void jam_child_sa_traffic(struct jambuf *buf, struct child_sa *child)
 {
 	if (!pexpect(child != NULL)) {
@@ -171,7 +171,7 @@ static unsigned whack_trafficstatus_connection(const struct whack_message *m UNU
 		nr++;
 		SHOW_JAMBUF(s, buf) {
 			/* note: this mutates *st by calling
-			 * get_sa_bundle_info */
+			 * get_ipsec_traffic */
 			jam_child_sa_traffic(buf, pexpect_child_sa(st));
 		}
 	}

--- a/programs/pluto/whack_trafficstatus.c
+++ b/programs/pluto/whack_trafficstatus.c
@@ -43,40 +43,50 @@
 #include "whack_trafficstatus.h"
 #include "iface.h"
 
-/* note: this mutates *st by calling get_ipsec_traffic */
-static void jam_child_sa_traffic(struct jambuf *buf, struct child_sa *child)
+/* note: this mutates *child by calling get_ipsec_traffic */
+static void show_child_sa_traffic_object(struct show *s, struct child_sa *child)
 {
-	if (!pexpect(child != NULL)) {
-		return;
+	const struct connection *c = child->sa.st_connection;
+
+	SHOW_MEMBER(s, serialno, "serial") {
+		show_string(s, PRI_SO, pri_so(child->sa.st_serialno));
 	}
 
-	jam_so(buf, child->sa.st_serialno);
-	jam_string(buf, ": ");
-
-	const struct connection *c = child->sa.st_connection;
-	jam_connection(buf, c);
+	SHOW_MEMBER(s, connection, "connection") {
+		connection_buf cb;
+		show_string(s, "%s%s", c->name, str_connection_suffix(c, &cb));
+	}
 
 	if (child->sa.st_xauth_username[0] != '\0') {
-		jam(buf, ", username=%s", child->sa.st_xauth_username);
-	}
-
-	/* traffic */
-	jam(buf, ", type=%s",
-	    (child->sa.st_esp.protocol == &ip_protocol_esp ? "ESP" :
-	     child->sa.st_ah.protocol == &ip_protocol_ah ? "AH" :
-	     child->sa.st_ipcomp.protocol == &ip_protocol_ipcomp ? "IPCOMP" :
-	     "UNKNOWN"));
-
-	if (c->iface->nic_offload) {
-		switch (c->config->nic_offload) {
-		case NIC_OFFLOAD_PACKET: jam(buf, "(nic-offload=packet)"); break;
-		case NIC_OFFLOAD_CRYPTO: jam(buf, "(nic-offload=crypto)"); break;
-		case NIC_OFFLOAD_NO: break;
-		case NIC_OFFLOAD_UNSET: jam(buf, "(nic-offload=UNSET)"); break;
+		SHOW_MEMBER(s, username, "username") {
+			show_string(s, "%s", child->sa.st_xauth_username);
 		}
 	}
 
-	jam(buf, ", add_time=%"PRIu64, child->sa.st_esp.add_time);
+	/* traffic */
+	SHOW_MEMBER(s, type_, "type") {
+		show_string(s, "%s",
+		     (child->sa.st_esp.protocol == &ip_protocol_esp ? "ESP" :
+		      child->sa.st_ah.protocol == &ip_protocol_ah ? "AH" :
+		      child->sa.st_ipcomp.protocol == &ip_protocol_ipcomp ? "IPCOMP" :
+		      "UNKNOWN"));
+	}
+
+	if (c->iface->nic_offload && c->config->nic_offload != NIC_OFFLOAD_NO) {
+		SHOW_MEMBER(s, nic_offload, "nic-offload") {
+			switch (c->config->nic_offload) {
+			case NIC_OFFLOAD_PACKET: show_string(s, "%s", "packet"); break;
+			case NIC_OFFLOAD_CRYPTO: show_string(s, "%s", "crypto"); break;
+			case NIC_OFFLOAD_UNSET: show_string(s, "%s", "UNSET"); break;
+			default:
+				break;
+			}
+		}
+	}
+
+	SHOW_MEMBER(s, add_time, "add_time") {
+		show_raw(s, "%"PRIu64, child->sa.st_esp.add_time);
+	}
 
 	struct ipsec_proto_info *first_ipsec_proto =
 		(child->sa.st_esp.protocol == &ip_protocol_esp ? &child->sa.st_esp:
@@ -86,20 +96,28 @@ static void jam_child_sa_traffic(struct jambuf *buf, struct child_sa *child)
 	passert(first_ipsec_proto != NULL);
 
 	if (get_ipsec_traffic(child, first_ipsec_proto, DIRECTION_INBOUND)) {
-		jam(buf, ", inBytes=%ju", first_ipsec_proto->inbound.bytes);
+		SHOW_MEMBER(s, in_bytes, "inBytes"){
+			show_raw(s, "%ju", first_ipsec_proto->inbound.bytes);
+		}
 	}
 
 	if (get_ipsec_traffic(child, first_ipsec_proto, DIRECTION_OUTBOUND)) {
-		jam(buf, ", outBytes=%ju", first_ipsec_proto->outbound.bytes);
+		SHOW_MEMBER(s, out_bytes, "outBytes") {
+			show_raw(s, "%ju", first_ipsec_proto->outbound.bytes);
+		}
 		if (c->config->sa_ipsec_max_bytes != 0) {
-			jam_humber_uintmax(buf, ", maxBytes=", c->config->sa_ipsec_max_bytes, "B");
+			SHOW_MEMBER(s, max_bytes, "maxBytes") {
+				humber_buf hb;
+				show_string(s, "%s", str_humber_uintmax("", c->config->sa_ipsec_max_bytes, "B", &hb));
+			}
 		}
 	}
 
 	if (child->sa.st_xauth_username[0] == '\0') {
-		jam(buf, ", id='");
-		jam_id_bytes(buf, &c->remote->host.id, jam_sanitized_bytes);
-		jam(buf, "'");
+		SHOW_MEMBER(s, id, "id") {
+			id_buf ib;
+			show_string(s, "%s", str_id_bytes(&c->remote->host.id, jam_sanitized_bytes, &ib));
+		}
 	}
 
 	/*
@@ -114,16 +132,32 @@ static void jam_child_sa_traffic(struct jambuf *buf, struct child_sa *child)
 			* pool. */
 		       &c->local) {
 		if (nr_child_leases(*end) > 0) {
-			jam(buf, ", lease=");
-			const char *sep = "";
-			FOR_EACH_ELEMENT(lease, (*end)->child.lease) {
-				if (lease->ip.is_set) {
-					jam_string(buf, sep); sep = ",";
-					/* XXX: lease should be CIDR */
-					ip_subnet s = subnet_from_address(*lease);
-					jam_subnet(buf, &s);
+			SHOW_MEMBER(s, lease_, "lease") {
+				SHOW_ARRAY(s, leases) {
+					FOR_EACH_ELEMENT(lease, (*end)->child.lease) {
+						if (lease->ip.is_set) {
+							/* XXX: lease should be CIDR */
+							ip_subnet sn = subnet_from_address(*lease);
+							subnet_buf sb;
+							show_string(s, "%s", str_subnet(&sn, &sb));
+						}
+					}
 				}
 			}
+		}
+	}
+}
+
+/* note: this mutates *child by calling get_ipsec_traffic */
+static void show_child_sa_traffic(struct show *s, struct child_sa *child)
+{
+	if (!pexpect(child != NULL)) {
+		return;
+	}
+
+	SHOW_STRUCTURED(s, child_sa_traffic) {
+		SHOW_OBJECT(s, child_sa_traffic_connection) {
+			show_child_sa_traffic_object(s, child);
 		}
 	}
 }
@@ -169,11 +203,9 @@ static unsigned whack_trafficstatus_connection(const struct whack_message *m UNU
 
 		/* whack-log-global - no prefix */
 		nr++;
-		SHOW_JAMBUF(s, buf) {
-			/* note: this mutates *st by calling
-			 * get_ipsec_traffic */
-			jam_child_sa_traffic(buf, pexpect_child_sa(st));
-		}
+		/* note: this mutates *st by calling
+		 * get_ipsec_traffic */
+		show_child_sa_traffic(s, pexpect_child_sa(st));
 	}
 
 	return nr; /* return count */

--- a/programs/whack/whack.c
+++ b/programs/whack/whack.c
@@ -443,6 +443,8 @@ enum opt {
 	OPT_OPPO_DPORT,
 	OPT_OPPO_LABEL,
 
+	OPT_JSON,
+
 	/* List options */
 
 	LST_UTC,
@@ -734,6 +736,7 @@ const struct option optarg_options[] = {
 	{ "processstatus\0", no_argument, NULL, OPT_PROCESSSTATUS },
 	{ "statestatus\0", no_argument, NULL, OPT_SHOW_STATES }, /* alias to catch typos */
 	{ "showstates\0", no_argument, NULL, OPT_SHOW_STATES },
+	{ "json\0", no_argument, NULL, OPT_JSON },
 
 #ifdef USE_SECCOMP
 	{ "seccomp-crashtest\0", no_argument, NULL, OPT_SECCOMP_CRASHTEST },
@@ -1444,6 +1447,10 @@ int main(int argc, char **argv)
 
 		case OPT_ASYNC:	/* --asynchronous */
 			msg.whack_async = true;
+			continue;
+
+		case OPT_JSON:	/* --json */
+			msg.whack_json = true;
 			continue;
 
 		/* List options */


### PR DESCRIPTION
This adds a `--json` option to "ipsec trafficstatus" to control whether the output is formatted in JSON.  Internally, this extends the jambuf interface to be called in a structural way, so the same code paths can be used for both plaintext and JSON formatted output, for example:
```c
  jam_array_start(buf);
    jam_object_start(buf);
      jam_field_start(buf, "field");
        jam_value_string(buf, "%s", "value");
      jam_field_end(buf");
    jam_object_end(buf);
  jam_array_end(buf);
```