### PR TITLE
pluto: seccomp: allow getres{gid,uid} for bash-5.3

### DIFF
--- a/programs/pluto/pluto_seccomp.c
+++ b/programs/pluto/pluto_seccomp.c
@@ -98,6 +98,8 @@ static void init_seccomp(uint32_t def_action, bool main, struct logger *logger)
 		LSW_SECCOMP_ADD(getpgrp);
 		LSW_SECCOMP_ADD(getppid);
 		LSW_SECCOMP_ADD(getrandom); /* for unbound */
+		LSW_SECCOMP_ADD(getresgid);
+		LSW_SECCOMP_ADD(getresuid);
 		LSW_SECCOMP_ADD(getrlimit);
 		LSW_SECCOMP_ADD(getsockname);
 		LSW_SECCOMP_ADD(getsockopt);


### PR DESCRIPTION
When I upgraded bash-5.2 to bash-5.3 pluto would no longer establish IPSec SAs throwing seccomp errors:
```
2025-07-26T22:10:05.980377+02:00 host pluto: "other": prepare-host command exited with signal 31
2025-07-26T22:10:05.980998+02:00 host pluto: "other": route-host command exited with signal 31
2025-07-26T22:17:18.150536+02:00 host pluto: "other" #2: prepare-host command exited with signal 31
2025-07-26T22:17:18.151134+02:00 host pluto: "other" #2: route-host command exited with signal 31
2025-07-26T22:17:18.151730+02:00 host pluto: "other" #2: down-host command exited with signal 31
```

The culprits are `getres{gid,uid}` syscalls, apparently used in bash-5.3:
```
2025-07-26T22:10:29.258760+02:00 host kernel: audit: type=1326 audit(1753560629.257:6): auid=1000 uid=0 gid=0 ses=4 pid=1234 comm="sh" exe="/bin/bash" sig=31 arch=c000003e syscall=118 compat=0 ip=0x7f2de5afcabb code=0x0
2025-07-26T22:18:12.352731+02:00 host kernel: audit: type=1326 audit(1753561092.351:9): auid=1000 uid=0 gid=0 ses=4 pid=1234 comm="sh" exe="/bin/bash" sig=31 arch=c000003e syscall=120 compat=0 ip=0x7fc3c20fca8b code=0x0
```

Add these syscalls to pluto seccomp filter so it works correctly with the updated bash.