### PR TITLE
testing: update KVM_LINUX_ISO_CKSUM to the latest

### DIFF
--- a/testing/kvm/Makefile
+++ b/testing/kvm/Makefile
@@ -1048,7 +1048,7 @@ KVM_LINUX_OSINFO   ?= $(strip $(shell osinfo-query -f short-id os | grep ' fedor
 KVM_LINUX_URL ?= https://download.fedoraproject.org/pub/fedora/linux/releases/$(KVM_LINUX_RELEASE)/Server/x86_64/iso
 KVM_LINUX_ISO ?= $(KVM_POOLDIR)/Fedora-Server-dvd-x86_64-$(KVM_LINUX_RELEASE)-$(KVM_LINUX_BUILD).iso
 KVM_LINUX_ISO_HASH ?= SHA256
-KVM_LINUX_ISO_CKSUM ?= 32d9ab1798fc8106a0b06e873bdcd83a3efea8412c9401dfe4097347ed0cfc65
+KVM_LINUX_ISO_CKSUM ?= 6037e489103401a6ad4e54a4bcb2df7525693bdc3f2ce4aa895838b65647e551
 KVM_LINUX_ISO_URL ?= $(KVM_LINUX_URL)/$(notdir $(KVM_LINUX_ISO))
 
 KVM_LINUX_KICKSTART_FILE ?= linux/base.ks


### PR DESCRIPTION
Without this, running "kvm install" fails with:
```
  + echo 'SHA256 (/home/ueno/devel/pool/Fedora-Server-dvd-x86_64-41-1.4.iso.tmp) = 32d9ab1798fc8106a0b06e873bdcd83a3efea8412c9401dfe4097347ed0cfc65'
  + cksum -c /home/libreswan/devel/pool/Fedora-Server-dvd-x86_64-41-1.4.iso.tmp: FAILED cksum: WARNING: 1 computed checksum did NOT match
```
The checksum is actually
6037e489103401a6ad4e54a4bcb2df7525693bdc3f2ce4aa895838b65647e551 according to:
https://download.fedoraproject.org/pub/fedora/linux/releases/41/Server/x86_64/iso/Fedora-Server-41-1.4-x86_64-CHECKSUM