### PR TITLE
logging: fix str_nss_oid

### DIFF
--- a/lib/libswan/jam_nss_oid.c
+++ b/lib/libswan/jam_nss_oid.c
@@ -30,7 +30,7 @@ const char *str_nss_oid(SECOidTag oidtag, name_buf *b)
 			 "SEC_OID_%d", oidtag);
 		b->buf = b->tmp;
 	}
-	return b->tmp;
+	return b->buf;
 }
 
 size_t jam_nss_oid(struct jambuf *buf, SECOidTag oidtag)


### PR DESCRIPTION
If the OID is known, str_nss_oid previously returned an uninitialized buffer, instead of the actual description.

I stumbled upon this when testing with `update-crypto-policies --set DEFAULT:TEST-PQ`, where SHA-1 is disabled by policy; the log contained `SGN_Digest(...gibberish...) failed`.