### PR TITLE
testing: make check-retval.py work with relative pathnames

### DIFF
--- a/.github/check-retval.py
+++ b/.github/check-retval.py
@@ -53,7 +53,10 @@ for command in cdb.getAllCompileCommands():
             if not arg:
                 break
             continue
-        elif arg == command.filename: # skip the source filename
+        elif arg in [
+                command.filename,
+                os.path.relpath(command.filename, command.directory),
+        ]: # skip the source filename
             continue
         clang_args.append(arg)
     if args.clang_resource_dir:


### PR DESCRIPTION
The check-retval GitHub action had been broken for a while, after the build infrastructure started using relative paths of C source files instead of the absolute paths.