### PR TITLE
building linux: turn on USE_XFRM_HEADER_COPY for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,6 @@ For Debian / Ubuntu / Mint
       libpam0g-dev libcap-ng-dev libldns-dev xmlto \
       libcurl4-openssl-dev
 
-apt-get install build-essential pkg-config \
-      bison fles
-
 For Fedora/CentOS-Stream/RHEL/AlmaLinux/RockyLinux etc.
 
     dnf install audit-libs-devel bison curl-devel flex \

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ source:
 For Debian / Ubuntu / Mint
 
     apt-get install build-essential pkg-config \
-      bison flex libnss3-dev libevent-dev libunbound-dev \
-      libpam0g-dev libcap-ng-dev libldns-dev xmlto \
-      libcurl4-openssl-dev
+      bison flex libnss3-dev libnss3-tools libevent-dev \
+      libunbound-dev libpam0g-dev libcap-ng-dev \
+      libldns-dev xmlto libcurl4-openssl-dev
 
 For Fedora/CentOS-Stream/RHEL/AlmaLinux/RockyLinux etc.
 

--- a/mk/defaults/linux.mk
+++ b/mk/defaults/linux.mk
@@ -50,6 +50,19 @@ ifneq ($(filter debian ubuntu,$(LINUX_VARIANT)),)
   ifeq ($(LINUX_VERSION_CODENAME),trixie) # Debian 13; until June 30 2030
     USE_XFRM_HEADER_COPY ?= true
   endif
+  # https://releases.ubuntu.com/
+  ifeq ($(LINUX_VERSION_CODENAME),focal) # Ubuntu 20.04.6 LTS
+    USE_ML_KEM_768 ?= false
+    USE_XFRM_HEADER_COPY ?= true
+  endif
+  ifeq ($(LINUX_VERSION_CODENAME),jammy) # Ubuntu 22.04.5 LTS
+    USE_ML_KEM_768 ?= false
+    USE_XFRM_HEADER_COPY ?= true
+  endif
+  ifeq ($(LINUX_VERSION_CODENAME),noble) # Ubuntu 24.04.3 LTS
+    USE_ML_KEM_768 ?= false
+    USE_XFRM_HEADER_COPY ?= true
+  endif
 endif
 
 #


### PR DESCRIPTION
Additionally, set USE_ML_KEM_768 to false. nss3 on Ubuntu seems not to have new NSS version (>= 3.105 ?) that support USE_ML_KEM_768 (manually tested on Ubuntu 22.04 and Ubuntu 24.04, the build doesn't work)