### PR TITLE
crypto: use official ML-KEM PKCS#11 mechanisms with NSS >= 3.118.1

### DIFF
--- a/include/lswnss.h
+++ b/include/lswnss.h
@@ -46,8 +46,9 @@
 
 #include <nss.h>
 
-#if 0 && (( NSS_VMAJOR > 3 ) ||				\
-	  ( NSS_VMAJOR == 3 &&	NSS_VMINOR >= 116 ))
+#if (( NSS_VMAJOR > 3 ) || \
+     ( NSS_VMAJOR == 3 && NSS_VMINOR >= 118 ) || \
+     ( NSS_VMAJOR == 3 && NSS_VMINOR == 118 && NSS_VPATCH == 1))
 #define LSW_CKM_ML_KEM_KEY_PAIR_GEN CKM_ML_KEM_KEY_PAIR_GEN
 #define LSW_CKM_ML_KEM CKM_ML_KEM
 #define LSW_CKP_ML_KEM_768 CKP_ML_KEM_768


### PR DESCRIPTION
That version includes the fix for the issue which previously prevented pluto/ikev2-intermediate-04-addke-ml-kem-768 working.

Fixes: #2488 