### PR TITLE
Clear parent references when deleting Child SA

### DIFF
--- a/programs/pluto/ikev2_create_child_sa.c
+++ b/programs/pluto/ikev2_create_child_sa.c
@@ -1445,6 +1445,20 @@ stf_status process_v2_CREATE_CHILD_SA_child_response(struct ike_sa *ike,
 	pexpect(larval_child->sa.st_sa_kind_when_established == CHILD_SA);
 
 	/*
+	 * If the connection of larval child gets deleted while waiting for the
+	 * CREATE_CHILD_SA response, childs deletetion is deferred and now is the
+	 * time to delete it properly.
+	 */
+	struct connection *c = larval_child->sa.st_connection;
+	if (!c->policy.up && !c->policy.keep) {
+		llog_sa(RC_LOG, larval_child,
+			"connection was deleted while waiting for CREATE_CHILD_SA response, sending DELETE");
+		submit_v2_delete_exchange(ike, larval_child);
+		ike->sa.st_v2_msgid_windows.initiator.wip_sa = NULL;
+		return STF_OK;
+	}
+
+	/*
 	 * Drive the larval Child SA's state machine.
 	 */
 	set_larval_v2_transition(larval_child, &state_v2_ESTABLISHED_CHILD_SA, HERE);
@@ -2173,7 +2187,21 @@ stf_status process_v2_CREATE_CHILD_SA_failure_response(struct ike_sa *ike,
 		return STF_INTERNAL_ERROR;
 	}
 
-        pstat_sa_failed(&(*larval_child)->sa, REASON_TRAFFIC_SELECTORS_FAILED);
+	/*
+	 * If the connection of larval child gets deleted while waiting for the
+	 * CREATE_CHILD_SA response, childs deletetion is deferred and now is the
+	 * time to delete it properly.
+	 */
+	struct connection *c = (*larval_child)->sa.st_connection;
+	if (!c->policy.up && !c->policy.keep) {
+	  llog_sa(RC_LOG, (*larval_child),
+		  "connection was deleted while waiting for CREATE_CHILD_SA response, sending DELETE");
+	  submit_v2_delete_exchange(ike, *larval_child);
+	  ike->sa.st_v2_msgid_windows.initiator.wip_sa = NULL;
+	  return STF_OK;
+	}
+
+	pstat_sa_failed(&(*larval_child)->sa, REASON_TRAFFIC_SELECTORS_FAILED);
 
 	stf_status status = STF_ROOF; /*IKE;place holder*/
 

--- a/programs/pluto/routing.c
+++ b/programs/pluto/routing.c
@@ -1123,6 +1123,31 @@ static bool teardown_child_dispatch_ok(struct connection *c,
 
 static void teardown_child_post_op(const struct routing_annex *e)
 {
+	struct child_sa *child = *e->child;
+	struct state *st = &child->sa;
+
+	/*
+	 * If (cuckoo) larval child has CREATE_CHILD_SA request outstanding, its
+	 * deletion is deferred until the response arrives or until its timeout.
+	 */
+	if (st->st_clonedfrom != SOS_NOBODY && !IS_CHILD_SA_ESTABLISHED(st)) {
+		struct ike_sa *ike = ike_sa_by_serialno(st->st_clonedfrom);
+		if (ike != NULL && ike->sa.st_v2_msgid_windows.initiator.wip_sa == child && ike->sa.st_viable_parent) {
+			llog(RC_LOG, st->logger,
+				"deletion of larval child #%u for connection '%s' deferred (pending CREATE_CHILD_SA response)",
+				st->st_serialno, st->st_connection->name);
+
+			/*
+			 * Since we deferred deletion we also need to restore negotiating_child_sa
+			 * that was cleared by teardown. With that weeding visit won't attempt to
+			 * delete it again.
+			 */
+			st->st_connection->negotiating_child_sa = st->st_serialno;
+			*e->child = NULL;
+			return;
+		}
+	}
+
 	delete_child_sa(e->child);
 }
 

--- a/programs/pluto/terminate.c
+++ b/programs/pluto/terminate.c
@@ -484,6 +484,17 @@ void terminate_and_delete_connections(struct connection *c,
 		 */
 		whack_attach(c, logger);
 		terminate_and_down_and_unroute_connections(c, where);
+
+              /* connection has child sa with deferred deletion */
+              if (c->negotiating_child_sa != SOS_NOBODY) {
+                     ldbg(c->logger, "connection '%s' has children deferring deletion",
+                         c->name);
+                     /* we detach whack even though deletetion is deferred */
+		       whack_detach(c, logger);
+		       terminate_and_down_and_unroute_connections(c, where);
+                     return;
+              }
+
 		/* leave whack attached during death */
 		connection_delref(&c, logger);
 		return;
@@ -562,6 +573,10 @@ static void terminate_v2_child(struct ike_sa **ike, struct child_sa *child,
 	/* redundant */
 	on_delete(&child->sa, skip_send_delete);
 	on_delete(&child->sa, skip_log_message);
+
+       if ((*ike)->sa.st_v2_msgid_windows.initiator.wip_sa == child) {
+         (*ike)->sa.st_v2_msgid_windows.initiator.wip_sa = NULL;
+       }
 	struct connection *cc = child->sa.st_connection;
 
 	if (cc->established_child_sa == child->sa.st_serialno) {

--- a/programs/pluto/timer.c
+++ b/programs/pluto/timer.c
@@ -483,6 +483,18 @@ static void dispatch_event(struct state *st, enum event_type event_type,
 			terminate_ike_family(&ike, REASON_DELETED, HERE);
 		} else {
 			struct child_sa *child = pexpect_child_sa(st);
+
+			/*
+			 * If larval child deletion was deferred, we detach it from its
+			 * initiating IKE so that timeout-initiated child teardown can
+			 * delete it without deferring again.
+			 */
+			if (st->st_clonedfrom != SOS_NOBODY) {
+				struct ike_sa *ike = ike_sa_by_serialno(st->st_clonedfrom);
+				if (ike != NULL && ike->sa.st_v2_msgid_windows.initiator.wip_sa == child) {
+					ike->sa.st_v2_msgid_windows.initiator.wip_sa = NULL;
+				}
+			}
 			connection_teardown_child(&child, REASON_DELETED, HERE);
 		}
 		st = NULL;


### PR DESCRIPTION
If CREATE_CHILD_SA response happens after larval child is gone process_v2_CREATE_CHILD_SA_child_response() accesses already freed child (through parent's wip_sa), found by @igsilya:

```
Thread 1 "pluto" received signal SIGSEGV, Segmentation fault.
0x000055964aec8718 in set_larval_v2_transition (larval=0x55966e031650,
    to=0x55964afea1a0 <state_v2_ESTABLISHED_CHILD_SA>,
    where=where@entry=0x55964afd62a0 <here>) at ikev2_child.c:86
86              const struct v2_transition *transition =
(gdb) #0  0x000055964aec8718 in set_larval_v2_transition (larval=0x55966e031650,
    to=0x55964afea1a0 <state_v2_ESTABLISHED_CHILD_SA>,
    where=where@entry=0x55964afd62a0 <here>) at ikev2_child.c:86
#1  0x000055964ae1244f in process_v2_CREATE_CHILD_SA_child_response (
    ike=0x55966dff5000, larval_child=<optimized out>,
    response_md=0x55966e0463b0) at ikev2_create_child_sa.c:1426
#2  0x000055964aec55ff in v2_dispatch (ike=ike@entry=0x55966dff5000,
    md=md@entry=0x55966e0463b0,
    svm=svm@entry=0x55964affb758 <v2_CREATE_CHILD_SA_response_transition+120>)
    at ikev2.c:1340
```

Crash happens in:

https://github.com/libreswan/libreswan/blob/3d59af8308a5cb2f6d777f6ec9c0ef8b095f7b89/programs/pluto/ikev2_child.c#L82-L93

when accessing `larval->sa.st_state->v2.larval_sa_transition` and we realized that it might happen that larval child gets deleted during CREATE_CHILD_SA exchange. It then points to `&state_undefined` (without `v2`) and crash happens. The proper fix seems to be to clear parent IKE SA reference to the larval child when it is being deleted so that `process_v2_CREATE_CHILD_SA_child_response()` won't get to `set_larval_v2_transition()`.

https://github.com/libreswan/libreswan/blob/3d59af8308a5cb2f6d777f6ec9c0ef8b095f7b89/programs/pluto/ikev2_create_child_sa.c#L1431-L1450

_Update (March 3): Proper solution seems to be to defer child deletion._

