### PR TITLE
Fix compilation error on Fedora 44

### DIFF
--- a/programs/pluto/ikev2_proposals.c
+++ b/programs/pluto/ikev2_proposals.c
@@ -450,7 +450,7 @@ static int process_transforms(struct pbs_in *prop_pbs, struct jambuf *remote_jam
 	 */
 	{
 		int local_propnum;
-		const struct ikev2_proposal *local_proposal;
+		const struct ikev2_proposal *local_proposal UNUSED;
 		FOR_EACH_V2_PROPOSAL_IN_RANGE(local_propnum, local_proposal, local_proposals,
 					      local_propnum_base, local_propnum_bound) {
 			struct ikev2_proposal_match *matching_local_proposal = &matching_local_proposals[local_propnum];
@@ -770,7 +770,7 @@ static int process_transforms(struct pbs_in *prop_pbs, struct jambuf *remote_jam
 	}
 
 	int local_propnum;
-	struct ikev2_proposal *local_proposal;
+	struct ikev2_proposal *local_proposal UNUSED;
 	FOR_EACH_V2_PROPOSAL_IN_RANGE(local_propnum, local_proposal, local_proposals,
 				      local_propnum_base, local_propnum_bound) {
 		struct ikev2_proposal_match *matching_local_proposal = &matching_local_proposals[local_propnum];


### PR DESCRIPTION
On Fedora 44, where -Wunused-but-set-variable is enabled with GCC 16, the build fails with:
```
  ikev2_proposals.c: In function ‘process_transforms’:
  ikev2_proposals.c:453:46: error: variable ‘local_proposal’ set but not used [-Werror=unused-but-set-variable=]
    453 |                 const struct ikev2_proposal *local_proposal;
        |                                              ^~~~~~~~~~~~~~
  ikev2_proposals.c:773:32: error: variable ‘local_proposal’ set but not used [-Werror=unused-but-set-variable=]
    773 |         struct ikev2_proposal *local_proposal;
        |                                ^~~~~~~~~~~~~~
  cc1: all warnings being treated as errors
```
This fixes it by adding the UNUSED attribute to the local variable.