### PR TITLE
Fix the handling of metrics in routes on VTI interfaces.

### DIFF
--- a/programs/_updown.xfrm/_updown.xfrm.in
+++ b/programs/_updown.xfrm/_updown.xfrm.in
@@ -987,7 +987,7 @@ addvti() {
 		# Tuomo should improve this with using ${PLUTO_MY_CLIENT_NET}
 		# echo "setting up vti routing"
 		r=add
-		ip route list | grep -q "${PLUTO_PEER_CLIENT%/*}" && r=change
+		ip route list dev "${VTI_IFACE}" | grep -q "${PLUTO_PEER_CLIENT%/*}" && r=change
 		if [ "${r}" = change ]; then
 		    # resolve LAN conflict by forcing host route for default gw
 		    gw="$(ip ro li | grep ^default | awk '{ print $3;}')"
@@ -995,12 +995,8 @@ addvti() {
 		    # echo "ip route add ${gw} dev ${gwdev}"
 		    ip route add ${gw} dev ${gwdev} >/dev/null ||:
 		fi
-		srcip=""
-		if [ -n "${PLUTO_MY_SOURCEIP}" ]; then
-		    srcip=" src ${PLUTO_MY_SOURCEIP}"
-		fi
-		# echo "ip route ${r} ${PLUTO_PEER_CLIENT} dev ${VTI_IFACE} ${srcip}"
-		ip route ${r} ${PLUTO_PEER_CLIENT} dev ${VTI_IFACE} ${srcip}
+		# echo "ip route ${r} ${PLUTO_PEER_CLIENT} dev ${VTI_IFACE}${PLUTO_MY_SOURCEIP:+ src ${PLUTO_MY_SOURCEIP}}${PLUTO_METRIC:+ metric ${PLUTO_METRIC}}"
+		ip route ${r} ${PLUTO_PEER_CLIENT} dev ${VTI_IFACE}${PLUTO_MY_SOURCEIP:+ src ${PLUTO_MY_SOURCEIP}}${PLUTO_METRIC:+ metric ${PLUTO_METRIC}}
 		echo "done ip route"
 	    fi
 	fi
@@ -1010,8 +1006,8 @@ addvti() {
 delvti() {
     if [ -n "${VTI_IFACE}" -a -d /proc/sys/net/ipv4/conf/${VTI_IFACE} ]; then
 	if [ "${VTI_ROUTING}" = yes ]; then
-	    ip route del ${PLUTO_PEER_CLIENT} dev ${VTI_IFACE} \
-		src ${PLUTO_MY_SOURCEIP} ||:
+		# echo "ip route del ${PLUTO_PEER_CLIENT} dev ${VTI_IFACE}${PLUTO_MY_SOURCEIP:+ src ${PLUTO_MY_SOURCEIP}}${PLUTO_METRIC:+ metric ${PLUTO_METRIC}}"
+		ip route del ${PLUTO_PEER_CLIENT} dev ${VTI_IFACE}${PLUTO_MY_SOURCEIP:+ src ${PLUTO_MY_SOURCEIP}}${PLUTO_METRIC:+ metric ${PLUTO_METRIC}} ||:
 	fi
 	# TODO: we can't delete vti interface because we don't have proper reference
 	# counting.


### PR DESCRIPTION
The `metric` parameter is not being added when using a VTI interface (`vti-interface=vtiX` and `vti-routing=yes`).

The parameter has been added to the script, and when checking if a route already exists, it should verify the correct VTI interface, as the same route may exist for different interfaces in environments with access redundancy.