### PR TITLE
libswan: move libevent event_base to libswan

### DIFF
--- a/include/global_event_base.h
+++ b/include/global_event_base.h
@@ -1,0 +1,25 @@
+/* global event_base declaration, for libreswan
+ *
+ * Copyright (C) 2025 Eshaan Gupta
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.  See <https://www.gnu.org/licenses/gpl2.txt>.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ */
+
+#ifndef GLOBAL_EVENT_BASE_H
+#define GLOBAL_EVENT_BASE_H
+
+struct event_base;
+
+extern struct event_base *get_global_event_base(void);
+extern void set_global_event_base(struct event_base *eb);
+
+#endif

--- a/lib/libswan/Makefile
+++ b/lib/libswan/Makefile
@@ -202,6 +202,7 @@ OBJS += bad_sparse_where.o
 OBJS += lswglob.o
 
 OBJS += global_logger.o
+OBJS += global_event_base.o
 OBJS += jambuf.o
 OBJS += jam_humber.o
 OBJS += jam_bytes.o

--- a/lib/libswan/global_event_base.c
+++ b/lib/libswan/global_event_base.c
@@ -1,0 +1,29 @@
+/* global event_base storage, for libreswan
+ *
+ * Copyright (C) 2025 Eshaan Gupta
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.  See <https://www.gnu.org/licenses/gpl2.txt>.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ */
+
+#include "global_event_base.h"
+
+static struct event_base *global_eb = NULL;
+
+struct event_base *get_global_event_base(void)
+{
+	return global_eb;
+}
+
+void set_global_event_base(struct event_base *eb)
+{
+	global_eb = eb;
+}

--- a/programs/pluto/server.c
+++ b/programs/pluto/server.c
@@ -88,6 +88,7 @@
 #include "hash_table.h"
 #include "ip_address.h"
 #include "ip_info.h"
+#include "global_event_base.h"
 
 /*
  *  Server main loop and socket initialization routines.
@@ -519,6 +520,7 @@ void free_server(struct logger *logger)
 	free_signal_handlers(logger);
 
 	ldbg(logger, "releasing event base");
+	set_global_event_base(NULL);
 	event_base_free(pluto_eb);
 	pluto_eb = NULL;
 #if LIBEVENT_VERSION_NUMBER >= 0x02010100
@@ -1103,6 +1105,7 @@ void init_server(struct logger *logger)
 
 	int s = evthread_make_base_notifiable(pluto_eb);
 	passert(s >= 0);
+	set_global_event_base(pluto_eb);
 	ldbg(logger, "libevent initialized");
 }
 
@@ -1179,7 +1182,7 @@ void stop_server(server_stopped_cb *cb NEVER_RETURNS)
 
 struct event_base *get_pluto_event_base(void)
 {
-	return pluto_eb;
+	return get_global_event_base();
 }
 
 unsigned nr_processors_online(void)


### PR DESCRIPTION
Closes #2616

Adds a global_event_base get/set interface in lib/libswan/, following the existing global_logger pattern. Pluto's init_server() publishes the event_base after creation and free_server() clears it before freeing. get_pluto_event_base() now delegates to get_global_event_base().

The header uses only a forward declaration (struct event_base;) with no libevent headers, so non-pluto programs linking libswan.a are unaffected.

This makes the libevent event loop accessible from lib/libswan/ (e.g., fd.c) for future non-blocking/buffered I/O work (#2617, #1859).

New files:
-include/global_event_base.h — header declaring get_global_event_base() / set_global_event_base()
-lib/libswan/global_event_base.c — stores the global event_base pointer

Modified files:
-lib/libswan/Makefile — added global_event_base.o to OBJS
-programs/pluto/server.c — calls setter in init_server() / free_server(), delegates getter