### PR TITLE
fix typos and minor errors in docs

### DIFF
--- a/docs/CHANGES.openswan
+++ b/docs/CHANGES.openswan
@@ -1,6 +1,6 @@
 
 Note that listings are in chronological order of release times, not in order
-of version numbers, so you will find 2.5.x and 2.6.x releases intersperced.
+of version numbers, so you will find 2.5.x and 2.6.x releases interspersed.
 
 See also docs/KNOWN_BUGS.txt and http://www.openswan.org/
 

--- a/docs/CHANGES.openswan
+++ b/docs/CHANGES.openswan
@@ -1,6 +1,6 @@
 
 Note that listings are in chronological order of release times, not in order
-of version numbers, so you will find 2.5.x and 2.6.x releases interspersed.
+of version numbers, so you will find 2.5.x and 2.6.x releases intersperced.
 
 See also docs/KNOWN_BUGS.txt and http://www.openswan.org/
 

--- a/docs/examples/hub-spoke.conf
+++ b/docs/examples/hub-spoke.conf
@@ -1,4 +1,4 @@
-# If you are using a hub-spoke scenario with NETKEY, you run into a
+# If you are using a hub-spoke scenario with NETKEY, you run into
 # problems with ipsec policies because netkey overrides routes by design.
 # Example: Your head office is 10.0.0.0/8. Your branch offices
 # are all ranges taken from there, eg office1 is 10.0.1.0/24, office2 is

--- a/docs/examples/xauth.conf
+++ b/docs/examples/xauth.conf
@@ -12,7 +12,7 @@ conn xauthserver
 	auto=add
 	rekey=yes
 	modecfgpull=yes
-	modecfgdns1.2.3.4,5.6.7.8
+	modecfgdns=1.2.3.4,5.6.7.8
 
 conn xauthclient
 	#

--- a/docs/nss-howto.txt
+++ b/docs/nss-howto.txt
@@ -112,7 +112,7 @@ Import a CA:
 
 Import a cert:
     certutil -A -i <cert_file>  -n "<cert_alias>" -t "C,C,C" -d /var/lib/ipsec/nss
-    example: certutil -A -i serverCert.pemm  -n "serverCert" -t "C,C,C" -d /var/lib/ipsec/nss
+    example: certutil -A -i serverCert.pem  -n "serverCert" -t "C,C,C" -d /var/lib/ipsec/nss
 
 
 Import a client cert:

--- a/docs/pluto-internals.txt
+++ b/docs/pluto-internals.txt
@@ -126,7 +126,7 @@ invariant: for all struct connections c, d:
     => c.interface == d.interface && c.this.nexthop == d.this.nexthop
 
 There are two kinds of eroutes: shunt eroutes and ones for an IPSEC SA
-Group.  Most eroutes are associated with and are represeented in a
+Group.  Most eroutes are associated with and are represented in a
 connection.  The exception is that some HOLD and PASS shunts do not
 correspond to connections; those are represented in the bare_shunt
 table.


### PR DESCRIPTION
While reading through the documentation I noticed a handful of small mistakes that are worth cleaning up.

In nss-howto.txt there was a double letter typo in a filename example, serverCert.pemm instead of serverCert.pem. In pluto-internals.txt the word represented was spelled represeented. In CHANGES.openswan the word interspersed was spelled intersperced.

On the config side, xauth.conf was missing the equals sign in the modecfgdns line which would make it an invalid config entry. And hub-spoke.conf had a grammar mistake where it said "run into a problems" which should just be "run into problems".

All changes are strictly docs and example configs, no functional code touched.