### PR TITLE
pluto: allow --stderrlog to override logfile from config

### DIFF
--- a/programs/pluto/ipsec-pluto.8.xml
+++ b/programs/pluto/ipsec-pluto.8.xml
@@ -240,7 +240,10 @@
 	  </term>
           <listitem>
             <para>
-	      direct logging to standard error instead of a log file
+	      direct logging to standard error instead of a log file.
+	      When specified, overrides any
+	      <property>logfile=</property> setting from the
+	      configuration file, regardless of argument order.
 	    </para>
 	    <para>
 	      Often combined with <option>--nofork</option> debugging
@@ -257,6 +260,14 @@
 	      direct logging to
 	      <filename><replaceable>filename</replaceable></filename>
 	      instead of &syslog.3;
+	    </para>
+	    <para>
+	      When <replaceable>filename</replaceable> is empty
+	      (<option>--logfile=</option>), any
+	      <property>logfile=</property> setting from the
+	      configuration file is cleared, causing
+	      <command>pluto</command> to fall back to
+	      <option>--stderrlog</option> or &syslog.3;.
 	    </para>
 	    <para>
 	      See &ipsec.conf.5; and

--- a/programs/pluto/log.c
+++ b/programs/pluto/log.c
@@ -81,6 +81,12 @@ void switch_log(struct logger **logger)
 	 * Hence save the new log file in LOG_FILE and switch at the
 	 * end.
 	 */
+	if (log_param.log_to_stderr) {
+		log_param.log_to_file = NULL;
+	}
+	if (log_param.log_to_file != NULL && log_param.log_to_file[0] == '\0') {
+		log_param.log_to_file = NULL;
+	}
 	PASSERT((*logger), pluto_log_file == stderr);
 	FILE *log_file = NULL;
 

--- a/programs/pluto/plutomain.c
+++ b/programs/pluto/plutomain.c
@@ -718,7 +718,7 @@ int main(int argc, char **argv)
 			continue;
 
 		case OPT_LOGFILE:	/* --logfile */
-			update_setup_string(KSF_LOGFILE, optarg_nonempty(logger));
+			update_setup_string(KSF_LOGFILE, optarg_empty(logger));
 			continue;
 
 		case OPT_DNSSEC_ENABLE:	/* --dnssec-enable yes|no */

--- a/testing/pluto/whack-pluto-02-logfile/description.txt
+++ b/testing/pluto/whack-pluto-02-logfile/description.txt
@@ -1,0 +1,8 @@
+test --logfile and --stderrlog command-line options
+
+- --logfile /tmp/test.log writes to a file
+- --logfile '' (empty) disables file logging, falls back to syslog
+- --stderrlog writes to stderr
+- config logfile= overridden by command-line --logfile
+- --stderrlog + --logfile together: stderr wins, logfile is not written
+- reverse ordering tests: config overrides empty --logfile, config-first with stderrlog

--- a/testing/pluto/whack-pluto-02-logfile/west.conf
+++ b/testing/pluto/whack-pluto-02-logfile/west.conf
@@ -1,0 +1,9 @@
+# /etc/ipsec.conf - Libreswan IPsec configuration file
+
+version 2.0
+
+config setup
+	logfile=/tmp/pluto.log
+	logtime=no
+	logappend=no
+	dumpdir=/tmp

--- a/testing/pluto/whack-pluto-02-logfile/west.console.txt
+++ b/testing/pluto/whack-pluto-02-logfile/west.console.txt
@@ -1,0 +1,100 @@
+../../guestbin/prep.sh
+'west.conf' -> '/etc/ipsec.conf'
+west #
+ ipsec initnss
+Initializing NSS database
+west #
+ # Test 1: --config then --logfile (command line overrides config)
+west #
+ ipsec pluto --config /etc/ipsec.conf --logfile /tmp/test.log
+west #
+ ../../guestbin/wait-until-pluto-started
+west #
+ ipsec whack --status | grep logfile=
+logfile='/tmp/test.log', logappend=no, logip=yes, audit-log=yes
+west #
+ ipsec whack --shutdown
+Pluto is shutting down
+west #
+ test -s /tmp/test.log && echo "logfile /tmp/test.log has content"
+logfile /tmp/test.log has content
+west #
+ # Test 2: --logfile then --config (config overrides command line)
+west #
+ ipsec pluto --logfile /tmp/test2.log --config /etc/ipsec.conf
+warning: ipsec pluto: /etc/ipsec.conf:6: overriding earlier 'config setup' keyword with new value: logfile=/tmp/pluto.log
+west #
+ ../../guestbin/wait-until-pluto-started
+west #
+ ipsec whack --status | grep logfile=
+logfile='/tmp/pluto.log', logappend=no, logip=yes, audit-log=yes
+west #
+ ipsec whack --shutdown
+Pluto is shutting down
+west #
+ # Test 3: --config then --logfile '' (empty string, falls back to syslog)
+west #
+ ipsec pluto --config /etc/ipsec.conf --logfile ''
+west #
+ ../../guestbin/wait-until-pluto-started
+west #
+ ipsec whack --status | grep logfile=
+logfile='<syslog>', logappend=no, logip=yes, audit-log=yes
+west #
+ ipsec whack --shutdown
+Pluto is shutting down
+west #
+ # Test 4: --stderrlog with --selftest
+west #
+ ipsec pluto --stderrlog --selftest --config /etc/ipsec.conf > /tmp/stderr.log 2>&1
+west #
+ test -s /tmp/stderr.log && echo "stderr output captured"
+stderr output captured
+west #
+ # Test 5: --stderrlog + --logfile with --selftest (stderrlog takes precedence)
+west #
+ rm -f /tmp/ignored.log
+west #
+ ipsec pluto --stderrlog --logfile /tmp/ignored.log --selftest --config /etc/ipsec.conf > /tmp/stderr5.log 2>&1
+west #
+ test -s /tmp/stderr5.log && echo "stderr output captured"
+stderr output captured
+west #
+ test -s /tmp/ignored.log && echo "ignored.log has content" || echo "ignored.log is empty or missing"
+ignored.log is empty or missing
+west #
+ # Test 6: --logfile '' then --config (config overrides empty, restores file logging)
+west #
+ ipsec pluto --logfile '' --config /etc/ipsec.conf
+warning: ipsec pluto: /etc/ipsec.conf:6: overriding earlier 'config setup' keyword with new value: logfile=/tmp/pluto.log
+west #
+ ../../guestbin/wait-until-pluto-started
+west #
+ ipsec whack --status | grep logfile=
+logfile='/tmp/pluto.log', logappend=no, logip=yes, audit-log=yes
+west #
+ ipsec whack --shutdown
+Pluto is shutting down
+west #
+ test -s /tmp/pluto.log && echo "logfile /tmp/pluto.log has content"
+logfile /tmp/pluto.log has content
+west #
+ # Test 7: --config then --stderrlog with --selftest (config first, stderrlog after)
+west #
+ ipsec pluto --config /etc/ipsec.conf --stderrlog --selftest > /tmp/stderr7.log 2>&1
+west #
+ test -s /tmp/stderr7.log && echo "stderr output captured"
+stderr output captured
+west #
+ # Test 8: --config then --logfile then --stderrlog with --selftest (no warning, stderr wins)
+west #
+ rm -f /tmp/ignored8.log
+west #
+ ipsec pluto --config /etc/ipsec.conf --logfile /tmp/ignored8.log --stderrlog --selftest > /tmp/stderr8.log 2>&1
+west #
+ test -s /tmp/stderr8.log && echo "stderr output captured"
+stderr output captured
+west #
+ test -s /tmp/ignored8.log && echo "ignored8.log has content" || echo "ignored8.log is empty or missing"
+ignored8.log is empty or missing
+west #

--- a/testing/pluto/whack-pluto-02-logfile/west.sh
+++ b/testing/pluto/whack-pluto-02-logfile/west.sh
@@ -1,0 +1,49 @@
+../../guestbin/prep.sh
+
+ipsec initnss
+
+# Test 1: --config then --logfile (command line overrides config)
+ipsec pluto --config /etc/ipsec.conf --logfile /tmp/test.log
+../../guestbin/wait-until-pluto-started
+ipsec whack --status | grep logfile=
+ipsec whack --shutdown
+test -s /tmp/test.log && echo "logfile /tmp/test.log has content"
+
+# Test 2: --logfile then --config (config overrides command line)
+ipsec pluto --logfile /tmp/test2.log --config /etc/ipsec.conf
+../../guestbin/wait-until-pluto-started
+ipsec whack --status | grep logfile=
+ipsec whack --shutdown
+
+# Test 3: --config then --logfile '' (empty string, falls back to syslog)
+ipsec pluto --config /etc/ipsec.conf --logfile ''
+../../guestbin/wait-until-pluto-started
+ipsec whack --status | grep logfile=
+ipsec whack --shutdown
+
+# Test 4: --stderrlog with --selftest
+ipsec pluto --stderrlog --selftest --config /etc/ipsec.conf > /tmp/stderr.log 2>&1
+test -s /tmp/stderr.log && echo "stderr output captured"
+
+# Test 5: --stderrlog + --logfile with --selftest (stderrlog takes precedence)
+rm -f /tmp/ignored.log
+ipsec pluto --stderrlog --logfile /tmp/ignored.log --selftest --config /etc/ipsec.conf > /tmp/stderr5.log 2>&1
+test -s /tmp/stderr5.log && echo "stderr output captured"
+test -s /tmp/ignored.log && echo "ignored.log has content" || echo "ignored.log is empty or missing"
+
+# Test 6: --logfile '' then --config (config overrides empty, restores file logging)
+ipsec pluto --logfile '' --config /etc/ipsec.conf
+../../guestbin/wait-until-pluto-started
+ipsec whack --status | grep logfile=
+ipsec whack --shutdown
+test -s /tmp/pluto.log && echo "logfile /tmp/pluto.log has content"
+
+# Test 7: --config then --stderrlog with --selftest (config first, stderrlog after)
+ipsec pluto --config /etc/ipsec.conf --stderrlog --selftest > /tmp/stderr7.log 2>&1
+test -s /tmp/stderr7.log && echo "stderr output captured"
+
+# Test 8: --config then --logfile then --stderrlog with --selftest (no warning, stderr wins)
+rm -f /tmp/ignored8.log
+ipsec pluto --config /etc/ipsec.conf --logfile /tmp/ignored8.log --stderrlog --selftest > /tmp/stderr8.log 2>&1
+test -s /tmp/stderr8.log && echo "stderr output captured"
+test -s /tmp/ignored8.log && echo "ignored8.log has content" || echo "ignored8.log is empty or missing"


### PR DESCRIPTION
initially --stderrorlog was not overriding the --logfile even if it was empty.

Fixed by making --stderrlog clear the logfile path before the file-open check in switch_log(). Also allowed --logfile= (empty) to explicitly unset the config's logfile by changing it from required_argument to optional_argument

fixes #2599 