### PR TITLE
pluto: split updown command into argv[] when updown-config=exec

### DIFF
--- a/programs/pluto/updown.c
+++ b/programs/pluto/updown.c
@@ -131,10 +131,10 @@ static bool build_updown_exec(struct updown_exec *exec,
 				return false;
 		}
 
-		// convert the command string into a shrunk
+		// convert the command string into a shunk
 		shunk_t input = {
-				.ptr = exec->cmd,
-				.len = strlen(exec->cmd),
+			.ptr = exec->cmd,
+			.len = strlen(exec->cmd),
 		};
 
 		// get tokens by splitting on whitespace or tab by using ttoshunks
@@ -150,20 +150,17 @@ static bool build_updown_exec(struct updown_exec *exec,
 		for (unsigned i = 0; i < toks->len; i++) {
 
 			if (argv >= exec->arg + elemsof(exec->arg) - 1) {
-				// if we have too many tokens, log and return false
-				llog(RC_LOG, verbose.logger, "updown command has too many words");
+				llog(RC_LOG, verbose.logger, "updown command has too many arguments");
 				pfreeany(toks);
 				return false;
 			}
 
-			shunk_t t = toks->item[i];
+			char* s = clone_hunk_as_string(&toks->item[i], "updown arg");
 
-			//write a null terminator at the end of the token so we can use it as a C string
-			((char *)t.ptr)[t.len] = '\0';
-
-			*argv++ = t.ptr;
+			*argv++ = s;
 		}
 
+		*argv = NULL;
 		pfreeany(toks);
 
 	} else {

--- a/programs/pluto/updown.c
+++ b/programs/pluto/updown.c
@@ -95,11 +95,16 @@ static void jam_clean_xauth_username(struct jambuf *buf,
  * note: this mutates *st by calling get_sa_bundle_info().
  */
 
+
+#define UPDOWN_ARGV_MAX 32
+
 struct updown_exec {
-	char buffer[2048];
-	const char *env[100];
-	const char *arg[4];
+    char buffer[2048];
+    const char *env[100];
+    const char *arg[UPDOWN_ARGV_MAX];
+    char cmd[512]; // writable copy of the command used for tokenization
 };
+
 
 static bool build_updown_exec(struct updown_exec *exec,
 			      const char *verb, const char *verb_suffix,
@@ -109,19 +114,68 @@ static bool build_updown_exec(struct updown_exec *exec,
 			      struct updown_env updown_env,
 			      struct verbose verbose/*C-or-CHILD*/)
 {
+
 	/*
-	 * Build argv[]
-	 */
+	* Build argv[]
+	*/
+	
+	const char *cmd = c->local->config->child.updown.command;
 	const char **argv = exec->arg;
+
 	if (c->local->config->child.updown.updown_config_exec) {
-		(*argv++) = c->local->config->child.updown.command;
+
+		// copy the command string inside exec->cmd so we can modify it for tokenization
+		if (strlcpy(exec->cmd, cmd, sizeof(exec->cmd)) >= sizeof(exec->cmd)) {
+				// if it doesn't fit, log and return false
+				llog(RC_LOG, verbose.logger, "updown command too long");
+				return false;
+		}
+
+		// convert the command string into a shrunk
+		shunk_t input = {
+				.ptr = exec->cmd,
+				.len = strlen(exec->cmd),
+		};
+
+		// get tokens by splitting on whitespace or tab by using ttoshunks
+		struct shunks *toks = ttoshunks(input, " \t", EAT_EMPTY_SHUNKS);
+
+		if (toks == NULL || toks->len == 0) {
+			// if there are no tokens, log and return false
+			llog(RC_LOG, verbose.logger, "updown command is empty");
+			pfreeany(toks);
+			return false;
+		}
+
+		for (unsigned i = 0; i < toks->len; i++) {
+
+			if (argv >= exec->arg + elemsof(exec->arg) - 1) {
+				// if we have too many tokens, log and return false
+				llog(RC_LOG, verbose.logger, "updown command has too many words");
+				pfreeany(toks);
+				return false;
+			}
+
+			shunk_t t = toks->item[i];
+
+			//write a null terminator at the end of the token so we can use it as a C string
+			((char *)t.ptr)[t.len] = '\0';
+
+			*argv++ = t.ptr;
+		}
+
+		pfreeany(toks);
+
 	} else {
-		(*argv++) = "/bin/sh";
-		(*argv++) = "-c";
-		(*argv++) = c->local->config->child.updown.command;
+		*argv++ = "/bin/sh";
+		*argv++ = "-c";
+		*argv++ = cmd;
 	}
-	(*argv++) = NULL;
+
+	*argv++ = NULL;
 	vassert(argv <= exec->arg + elemsof(exec->arg));
+	
+
 
 	/*
 	 * Build envp[]


### PR DESCRIPTION
Fixes #2628 

When updown-config is in exec mode the command was passed to execve() as a single string ("ipsec _updown").

This patch tokenizes the updown command using ttoshunks() as suggested in the issue.

Tested with testing/pluto/basic-pluto-*