### PR TITLE
testing: remove internal state names from ipsec status output

### DIFF
--- a/programs/pluto/whack_showstates.c
+++ b/programs/pluto/whack_showstates.c
@@ -187,7 +187,7 @@ static void show_state(struct show *s, struct state *st, const monotime_t now)
 		if (st->st_iface_endpoint->io->protocol == &ip_protocol_tcp) {
 			jam(buf, "(tcp)");
 		}
-		jam(buf, " %s (%s);", st->st_state->name, st->st_state->story);
+		jam(buf, " %s;", st->st_state->story);
 
 		/*
 		 * Hunt and peck for events (needs fixing).

--- a/testing/pluto/certoe-16-rhbz1724200-halfopen-shunt/road.console.txt
+++ b/testing/pluto/certoe-16-rhbz1724200-halfopen-shunt/road.console.txt
@@ -38,8 +38,8 @@ road #
  # state #1 should be gone by now. State #2 and #3 should be there.
 road #
  ipsec showstates
-#2: "private#192.1.2.23/32"[2] ...192.1.2.23:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#3: "private#192.1.2.23/32"[2] ...192.1.2.23:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #2; idle;
+#2: "private#192.1.2.23/32"[2] ...192.1.2.23:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#3: "private#192.1.2.23/32"[2] ...192.1.2.23:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #2; idle;
 #3: "private#192.1.2.23/32"[2] ...192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 road #
  # confirm it didn't create a shunt and did not nuke out policy

--- a/testing/pluto/certoe-17-ike-replace-initiator/road.console.txt
+++ b/testing/pluto/certoe-17-ike-replace-initiator/road.console.txt
@@ -33,7 +33,7 @@ road #
  # wait on OE retransmits and rekeying
 road #
  ../../guestbin/wait-for.sh --match '#8:.*established' -- ipsec status
-#8: "private#192.1.2.0/24"[1] ...192.1.2.23:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #7; idle;
+#8: "private#192.1.2.0/24"[1] ...192.1.2.23:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #7; idle;
 road #
  ../../guestbin/ping-once.sh --up -I 192.1.3.209 192.1.2.23
 up
@@ -81,7 +81,7 @@ road #
  # go for broke, let IKE sa establish
 road #
  ../../guestbin/wait-for.sh --match '#26:.*established IKE SA' -- ipsec status
-#26: "private#192.1.2.0/24"[1] ...192.1.2.23:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
+#26: "private#192.1.2.0/24"[1] ...192.1.2.23:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
 road #
  ../../guestbin/ping-once.sh --up -I 192.1.3.209 192.1.2.23
 up

--- a/testing/pluto/certoe-18-pass-then-go-slash24-keyingtries1/east.console.txt
+++ b/testing/pluto/certoe-18-pass-then-go-slash24-keyingtries1/east.console.txt
@@ -49,8 +49,8 @@ east #
  # there should be no %pass shunts on either side and an active tunnel and no partial IKE states
 east #
  ipsec showstates
-#1: "private-or-clear#192.1.3.0/24"[1] ...192.1.3.209:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "private-or-clear#192.1.3.0/24"[1] ...192.1.3.209:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "private-or-clear#192.1.3.0/24"[1] ...192.1.3.209:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "private-or-clear#192.1.3.0/24"[1] ...192.1.3.209:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "private-or-clear#192.1.3.0/24"[1] ...192.1.3.209 esp.ESPSPIi@192.1.3.209 esp.ESPSPIi@192.1.2.23 tun.0@192.1.3.209 tun.0@192.1.2.23 Traffic: ESPin=252B ESPout=252B ESPmax=2^63B 
 east #
  ipsec trafficstatus

--- a/testing/pluto/certoe-18-pass-then-go-slash24-keyingtries1/road.console.txt
+++ b/testing/pluto/certoe-18-pass-then-go-slash24-keyingtries1/road.console.txt
@@ -83,8 +83,8 @@ road #
  # there should be no %pass shunts on either side and an active tunnel and no partial IKE states
 road #
  ipsec showstates
-#2: "private-or-clear#192.1.2.0/24"[2] ...192.1.2.23:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#3: "private-or-clear#192.1.2.0/24"[2] ...192.1.2.23:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #2; idle;
+#2: "private-or-clear#192.1.2.0/24"[2] ...192.1.2.23:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#3: "private-or-clear#192.1.2.0/24"[2] ...192.1.2.23:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #2; idle;
 #3: "private-or-clear#192.1.2.0/24"[2] ...192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=252B ESPout=252B ESPmax=2^63B 
 road #
  ipsec trafficstatus

--- a/testing/pluto/certoe-18-pass-then-go-slash24/east.console.txt
+++ b/testing/pluto/certoe-18-pass-then-go-slash24/east.console.txt
@@ -49,8 +49,8 @@ east #
  # there should be no %pass shunts on either side and an active tunnel and no partial states
 east #
  ipsec showstates
-#1: "private-or-clear#192.1.3.0/24"[1] ...192.1.3.209:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "private-or-clear#192.1.3.0/24"[1] ...192.1.3.209:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "private-or-clear#192.1.3.0/24"[1] ...192.1.3.209:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "private-or-clear#192.1.3.0/24"[1] ...192.1.3.209:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "private-or-clear#192.1.3.0/24"[1] ...192.1.3.209 esp.ESPSPIi@192.1.3.209 esp.ESPSPIi@192.1.2.23 tun.0@192.1.3.209 tun.0@192.1.2.23 Traffic: ESPin=252B ESPout=252B ESPmax=2^63B 
 east #
  ipsec trafficstatus

--- a/testing/pluto/certoe-18-pass-then-go-slash24/road.console.txt
+++ b/testing/pluto/certoe-18-pass-then-go-slash24/road.console.txt
@@ -82,8 +82,8 @@ road #
  # there should be no %pass shunts on either side and an active tunnel and no partial states
 road #
  ipsec showstates
-#2: "private-or-clear#192.1.2.0/24"[2] ...192.1.2.23:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#3: "private-or-clear#192.1.2.0/24"[2] ...192.1.2.23:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #2; idle;
+#2: "private-or-clear#192.1.2.0/24"[2] ...192.1.2.23:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#3: "private-or-clear#192.1.2.0/24"[2] ...192.1.2.23:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #2; idle;
 #3: "private-or-clear#192.1.2.0/24"[2] ...192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=252B ESPout=252B ESPmax=2^63B 
 road #
  ipsec trafficstatus

--- a/testing/pluto/certoe-18-pass-then-go-slash32-keyingtries1/east.console.txt
+++ b/testing/pluto/certoe-18-pass-then-go-slash32-keyingtries1/east.console.txt
@@ -51,8 +51,8 @@ east #
  # there should be no %pass shunts on either side and an active tunnel and no partial IKE states
 east #
  ipsec showstates
-#1: "private-or-clear#192.1.3.0/24"[1] ...192.1.3.209:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "private-or-clear#192.1.3.0/24"[1] ...192.1.3.209:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "private-or-clear#192.1.3.0/24"[1] ...192.1.3.209:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "private-or-clear#192.1.3.0/24"[1] ...192.1.3.209:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "private-or-clear#192.1.3.0/24"[1] ...192.1.3.209 esp.ESPSPIi@192.1.3.209 esp.ESPSPIi@192.1.2.23 tun.0@192.1.3.209 tun.0@192.1.2.23 Traffic: ESPin=252B ESPout=252B ESPmax=2^63B 
 east #
  ipsec trafficstatus

--- a/testing/pluto/certoe-18-pass-then-go-slash32-keyingtries1/road.console.txt
+++ b/testing/pluto/certoe-18-pass-then-go-slash32-keyingtries1/road.console.txt
@@ -76,8 +76,8 @@ road #
  # there should be no %pass shunts on either side and an active tunnel and no partial IKE states
 road #
  ipsec showstates
-#2: "private-or-clear#192.1.2.23/32"[2] ...192.1.2.23:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#3: "private-or-clear#192.1.2.23/32"[2] ...192.1.2.23:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #2; idle;
+#2: "private-or-clear#192.1.2.23/32"[2] ...192.1.2.23:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#3: "private-or-clear#192.1.2.23/32"[2] ...192.1.2.23:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #2; idle;
 #3: "private-or-clear#192.1.2.23/32"[2] ...192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=252B ESPout=252B ESPmax=2^63B 
 road #
  ipsec trafficstatus

--- a/testing/pluto/certoe-19-bareshunts-expire/road.console.txt
+++ b/testing/pluto/certoe-19-bareshunts-expire/road.console.txt
@@ -41,7 +41,7 @@ road #
  # partial STATE
 road #
  ../../guestbin/wait-for.sh --match '#1:.*sent IKE_SA_INIT request' -- ipsec status
-#1: "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23:500 IKE_SA_INIT_I (sent IKE_SA_INIT request); RETRANSMIT in XXs; idle;
+#1: "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23:500 sent IKE_SA_INIT request; RETRANSMIT in XXs; idle;
 road #
  ipsec whack --shuntstatus
 Bare Shunt list:
@@ -90,7 +90,7 @@ road #
  # already and should show show partial STATE
 road #
  ../../guestbin/wait-for.sh --match '#2:.*sent IKE_SA_INIT request' -- ipsec status
-#2: "private#192.1.3.0/24"[1] ...192.1.3.46:500 IKE_SA_INIT_I (sent IKE_SA_INIT request); RETRANSMIT in XXs; idle;
+#2: "private#192.1.3.0/24"[1] ...192.1.3.46:500 sent IKE_SA_INIT request; RETRANSMIT in XXs; idle;
 road #
  ipsec whack --shuntstatus
 Bare Shunt list:

--- a/testing/pluto/crossing-streams-01-ikev2-github-1211/east.console.txt
+++ b/testing/pluto/crossing-streams-01-ikev2-github-1211/east.console.txt
@@ -18,11 +18,11 @@ east #
 "east-west" #1: initiating IKEv2 connection to 192.1.2.45 using UDP
 east #
  ipsec showstates
-#1: "east-west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "east-west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; idle;
-#3: "east-west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "east-west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "east-west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; idle;
+#3: "east-west":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #3: "east-west" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#4: "east-west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; IKE SA #2; idle;
+#4: "east-west":500 established Child SA; REKEY in XXs; REPLACE in XXs; IKE SA #2; idle;
 #4: "east-west" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
 east #
  ipsec down '#1'

--- a/testing/pluto/crossing-streams-11-eewww-ikev2-permanent/east.console.txt
+++ b/testing/pluto/crossing-streams-11-eewww-ikev2-permanent/east.console.txt
@@ -19,10 +19,10 @@ east #
 up
 east #
  ipsec showstates
-#1: "east-west":500 ESTABLISHED_IKE_SA (established IKE SA); RETRANSMIT in XXs; REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "east-west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; IKE SA #1; idle;
+#1: "east-west":500 established IKE SA; RETRANSMIT in XXs; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "east-west":500 established Child SA; REKEY in XXs; REPLACE in XXs; IKE SA #1; idle;
 #2: "east-west" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#4: "east-west":500 NEW_CHILD_I1 (sent CREATE_CHILD_SA request for new IPsec SA); eroute owner; idle;
+#4: "east-west":500 sent CREATE_CHILD_SA request for new IPsec SA; eroute owner; idle;
 east #
  ipsec trafficstatus
 #2: "east-west", type=ESP, add_time=1234567890, inBytes=0, outBytes=0, maxBytes=2^63B, id='@west'

--- a/testing/pluto/crossing-streams-11-eweww-ikev2-permanent/east.console.txt
+++ b/testing/pluto/crossing-streams-11-eweww-ikev2-permanent/east.console.txt
@@ -19,10 +19,10 @@ east #
 up
 east #
  ipsec showstates
-#1: "east-west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "east-west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "east-west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "east-west":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "east-west" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=168B ESPout=168B ESPmax=2^63B 
-#3: "east-west":500 IKE_SA_INIT_R (sent IKE_SA_INIT response, waiting for IKE_INTERMEDIATE or IKE_AUTH request); DISCARD in XXs; idle;
+#3: "east-west":500 sent IKE_SA_INIT response, waiting for IKE_INTERMEDIATE or IKE_AUTH request; DISCARD in XXs; idle;
 east #
  ipsec trafficstatus
 #2: "east-west", type=ESP, add_time=1234567890, inBytes=168, outBytes=168, maxBytes=2^63B, id='@west'

--- a/testing/pluto/crossing-streams-11-ewwew-ikev2-permanent/east.console.txt
+++ b/testing/pluto/crossing-streams-11-ewwew-ikev2-permanent/east.console.txt
@@ -20,11 +20,11 @@ east #
 up
 east #
  ipsec showstates
-#1: "east-west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "east-west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "east-west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "east-west":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "east-west" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=0B ESPout=168B ESPmax=2^63B 
-#3: "east-west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; idle;
-#4: "east-west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; IKE SA #3; idle;
+#3: "east-west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; idle;
+#4: "east-west":500 established Child SA; REKEY in XXs; REPLACE in XXs; IKE SA #3; idle;
 #4: "east-west" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=168B ESPout=0B ESPmax=2^63B 
 east #
  ipsec trafficstatus

--- a/testing/pluto/crossing-streams-11-ewwew-ikev2-permanent/west.console.txt
+++ b/testing/pluto/crossing-streams-11-ewwew-ikev2-permanent/west.console.txt
@@ -79,11 +79,11 @@ west #
 up
 west #
  ipsec showstates
-#1: "east-west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; idle;
-#2: "east-west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#3: "east-west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #2; idle;
+#1: "east-west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; idle;
+#2: "east-west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#3: "east-west":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #2; idle;
 #3: "east-west" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=84B ESPmax=2^63B 
-#4: "east-west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; IKE SA #1; idle;
+#4: "east-west":500 established Child SA; REKEY in XXs; REPLACE in XXs; IKE SA #1; idle;
 #4: "east-west" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=0B ESPmax=2^63B 
 west #
  ipsec trafficstatus

--- a/testing/pluto/crossing-streams-11-ewwwe-ikev2-permanent/east.console.txt
+++ b/testing/pluto/crossing-streams-11-ewwwe-ikev2-permanent/east.console.txt
@@ -20,11 +20,11 @@ east #
 up
 east #
  ipsec showstates
-#1: "east-west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "east-west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "east-west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "east-west":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "east-west" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=168B ESPout=168B ESPmax=2^63B 
-#3: "east-west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; idle;
-#4: "east-west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; IKE SA #3; idle;
+#3: "east-west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; idle;
+#4: "east-west":500 established Child SA; REKEY in XXs; REPLACE in XXs; IKE SA #3; idle;
 #4: "east-west" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
 east #
  ipsec trafficstatus

--- a/testing/pluto/crossing-streams-11-ewwwe-ikev2-permanent/west.console.txt
+++ b/testing/pluto/crossing-streams-11-ewwwe-ikev2-permanent/west.console.txt
@@ -79,11 +79,11 @@ west #
 up
 west #
  ipsec showstates
-#1: "east-west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "east-west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; idle;
-#3: "east-west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; IKE SA #2; idle;
+#1: "east-west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "east-west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; idle;
+#3: "east-west":500 established Child SA; REKEY in XXs; REPLACE in XXs; IKE SA #2; idle;
 #3: "east-west" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#4: "east-west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#4: "east-west":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #4: "east-west" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 west #
  ipsec trafficstatus

--- a/testing/pluto/crossing-streams-11-weeww-ikev2-permanent/east.console.txt
+++ b/testing/pluto/crossing-streams-11-weeww-ikev2-permanent/east.console.txt
@@ -19,9 +19,9 @@ east #
 up
 east #
  ipsec showstates
-#1: "east-west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "east-west":500 IKE_SA_INIT_R (sent IKE_SA_INIT response, waiting for IKE_INTERMEDIATE or IKE_AUTH request); DISCARD in XXs; idle;
-#3: "east-west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "east-west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "east-west":500 sent IKE_SA_INIT response, waiting for IKE_INTERMEDIATE or IKE_AUTH request; DISCARD in XXs; idle;
+#3: "east-west":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #3: "east-west" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=168B ESPout=168B ESPmax=2^63B 
 east #
  ipsec trafficstatus

--- a/testing/pluto/crossing-streams-11-wewew-ikev2-permanent/east.console.txt
+++ b/testing/pluto/crossing-streams-11-wewew-ikev2-permanent/east.console.txt
@@ -20,11 +20,11 @@ east #
 up
 east #
  ipsec showstates
-#1: "east-west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "east-west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; idle;
-#3: "east-west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "east-west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "east-west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; idle;
+#3: "east-west":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #3: "east-west" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=0B ESPout=168B ESPmax=2^63B 
-#4: "east-west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; IKE SA #2; idle;
+#4: "east-west":500 established Child SA; REKEY in XXs; REPLACE in XXs; IKE SA #2; idle;
 #4: "east-west" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=168B ESPout=0B ESPmax=2^63B 
 east #
  ipsec trafficstatus

--- a/testing/pluto/crossing-streams-11-wewew-ikev2-permanent/west.console.txt
+++ b/testing/pluto/crossing-streams-11-wewew-ikev2-permanent/west.console.txt
@@ -79,11 +79,11 @@ west #
 up
 west #
  ipsec showstates
-#1: "east-west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "east-west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; idle;
-#3: "east-west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "east-west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "east-west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; idle;
+#3: "east-west":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #3: "east-west" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=84B ESPmax=2^63B 
-#4: "east-west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; IKE SA #2; idle;
+#4: "east-west":500 established Child SA; REKEY in XXs; REPLACE in XXs; IKE SA #2; idle;
 #4: "east-west" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=0B ESPmax=2^63B 
 west #
  ipsec trafficstatus

--- a/testing/pluto/crossing-streams-11-wewwe-ikev2-permanent/east.console.txt
+++ b/testing/pluto/crossing-streams-11-wewwe-ikev2-permanent/east.console.txt
@@ -20,11 +20,11 @@ east #
 up
 east #
  ipsec showstates
-#1: "east-west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "east-west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; idle;
-#3: "east-west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "east-west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "east-west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; idle;
+#3: "east-west":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #3: "east-west" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=168B ESPout=168B ESPmax=2^63B 
-#4: "east-west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; IKE SA #2; idle;
+#4: "east-west":500 established Child SA; REKEY in XXs; REPLACE in XXs; IKE SA #2; idle;
 #4: "east-west" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
 east #
  ipsec trafficstatus

--- a/testing/pluto/crossing-streams-11-wewwe-ikev2-permanent/west.console.txt
+++ b/testing/pluto/crossing-streams-11-wewwe-ikev2-permanent/west.console.txt
@@ -79,11 +79,11 @@ west #
 up
 west #
  ipsec showstates
-#1: "east-west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; idle;
-#2: "east-west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#3: "east-west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; IKE SA #1; idle;
+#1: "east-west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; idle;
+#2: "east-west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#3: "east-west":500 established Child SA; REKEY in XXs; REPLACE in XXs; IKE SA #1; idle;
 #3: "east-west" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#4: "east-west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #2; idle;
+#4: "east-west":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #2; idle;
 #4: "east-west" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 west #
  ipsec trafficstatus

--- a/testing/pluto/crossing-streams-11-wwewe-ikev2-permanent/east.console.txt
+++ b/testing/pluto/crossing-streams-11-wwewe-ikev2-permanent/east.console.txt
@@ -19,8 +19,8 @@ east #
 up
 east #
  ipsec showstates
-#2: "east-west":500 ESTABLISHED_IKE_SA (established IKE SA); RETRANSMIT in XXs; REKEY in XXs; REPLACE in XXs; newest; idle;
-#4: "east-west":500 NEW_CHILD_I1 (sent CREATE_CHILD_SA request for new IPsec SA); eroute owner; idle;
+#2: "east-west":500 established IKE SA; RETRANSMIT in XXs; REKEY in XXs; REPLACE in XXs; newest; idle;
+#4: "east-west":500 sent CREATE_CHILD_SA request for new IPsec SA; eroute owner; idle;
 east #
  ipsec trafficstatus
 east #

--- a/testing/pluto/crossing-streams-11-wwwee-ikev2-permanent/east.console.txt
+++ b/testing/pluto/crossing-streams-11-wwwee-ikev2-permanent/east.console.txt
@@ -19,8 +19,8 @@ east #
 up
 east #
  ipsec showstates
-#2: "east-west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#3: "east-west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #2; idle;
+#2: "east-west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#3: "east-west":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #2; idle;
 #3: "east-west" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=168B ESPout=168B ESPmax=2^63B 
 east #
  ipsec trafficstatus

--- a/testing/pluto/crossing-streams-22-ikev2-ipsec-interface/east.console.txt
+++ b/testing/pluto/crossing-streams-22-ikev2-ipsec-interface/east.console.txt
@@ -6,9 +6,9 @@ east #
  ../../guestbin/wait-until-pluto-started
 east #
  ipsec showstates
-#4: "static":500 IKE_SA_INIT_I (sent IKE_SA_INIT request); RETRANSMIT in XXs; idle;
+#4: "static":500 sent IKE_SA_INIT request; RETRANSMIT in XXs; idle;
 #4: pending Child SA for "static"
-#5: "static":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#6: "static":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #5; idle;
+#5: "static":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#6: "static":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #5; idle;
 #6: "static" esp.ESPSPIi@192.1.3.209 esp.ESPSPIi@192.1.2.23 tun.0@192.1.3.209 tun.0@192.1.2.23 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 east #

--- a/testing/pluto/crossing-streams-22-ikev2-ipsec-interface/road.console.txt
+++ b/testing/pluto/crossing-streams-22-ikev2-ipsec-interface/road.console.txt
@@ -83,7 +83,7 @@ road #
 #2: "static", type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='@east'
 road #
  ipsec showstates
-#1: "static":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "static":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "static":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "static":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "static" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 road #

--- a/testing/pluto/delete-ikev1-sa-01-isakmp-initiator/east.console.txt
+++ b/testing/pluto/delete-ikev1-sa-01-isakmp-initiator/east.console.txt
@@ -15,6 +15,6 @@ east #
  # both east and west should still have one IKE SA #1
 east #
  ipsec showstates
-#2: "west-east":500 STATE_QUICK_R2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#2: "west-east":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #2: "west-east" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=168B ESPout=168B ESPmax=2^63B 
 east #

--- a/testing/pluto/delete-ikev1-sa-01-isakmp-initiator/west.console.txt
+++ b/testing/pluto/delete-ikev1-sa-01-isakmp-initiator/west.console.txt
@@ -43,6 +43,6 @@ west #
  # both east and west should still have one IKE SA #1
 west #
  ipsec showstates
-#2: "west-east":500 STATE_QUICK_I2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#2: "west-east":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #2: "west-east" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=168B ESPout=168B ESPmax=2^63B 
 west #

--- a/testing/pluto/delete-ikev1-sa-01-isakmp-responder/east.console.txt
+++ b/testing/pluto/delete-ikev1-sa-01-isakmp-responder/east.console.txt
@@ -24,6 +24,6 @@ east #
  # both east and west should still have one IKE SA #1
 east #
  ipsec showstates
-#2: "west-east":500 STATE_QUICK_R2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#2: "west-east":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #2: "west-east" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=168B ESPout=168B ESPmax=2^63B 
 east #

--- a/testing/pluto/delete-ikev1-sa-01-isakmp-responder/west.console.txt
+++ b/testing/pluto/delete-ikev1-sa-01-isakmp-responder/west.console.txt
@@ -34,6 +34,6 @@ west #
  # both east and west should still have one IKE SA #1
 west #
  ipsec showstates
-#2: "west-east":500 STATE_QUICK_I2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#2: "west-east":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #2: "west-east" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=168B ESPout=168B ESPmax=2^63B 
 west #

--- a/testing/pluto/delete-ikev1-sa-02-ipsec-initiator/east.console.txt
+++ b/testing/pluto/delete-ikev1-sa-02-ipsec-initiator/east.console.txt
@@ -15,7 +15,7 @@ east #
  # both east and west should still have one IKE SA #1
 east #
  ipsec showstates
-#1: "west-east":500 STATE_MAIN_R3 (ISAKMP SA established); REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
-#3: "west-east":500 STATE_QUICK_R2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#1: "west-east":500 ISAKMP SA established; REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
+#3: "west-east":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #3: "west-east" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 east #

--- a/testing/pluto/delete-ikev1-sa-02-ipsec-initiator/west.console.txt
+++ b/testing/pluto/delete-ikev1-sa-02-ipsec-initiator/west.console.txt
@@ -48,7 +48,7 @@ west #
  # both east and west should still have one IKE SA #1
 west #
  ipsec showstates
-#1: "west-east":500 STATE_MAIN_I4 (ISAKMP SA established); REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
-#3: "west-east":500 STATE_QUICK_I2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#1: "west-east":500 ISAKMP SA established; REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
+#3: "west-east":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #3: "west-east" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 west #

--- a/testing/pluto/delete-ikev1-sa-02-ipsec-responder/east.console.txt
+++ b/testing/pluto/delete-ikev1-sa-02-ipsec-responder/east.console.txt
@@ -28,7 +28,7 @@ east #
  # both east and west should still have one IKE SA #1
 east #
  ipsec showstates
-#1: "west-east":500 STATE_MAIN_R3 (ISAKMP SA established); REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
-#3: "west-east":500 STATE_QUICK_R2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#1: "west-east":500 ISAKMP SA established; REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
+#3: "west-east":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #3: "west-east" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 east #

--- a/testing/pluto/delete-ikev1-sa-02-ipsec-responder/west.console.txt
+++ b/testing/pluto/delete-ikev1-sa-02-ipsec-responder/west.console.txt
@@ -34,7 +34,7 @@ west #
  # both east and west should still have one IKE SA #1
 west #
  ipsec showstates
-#1: "west-east":500 STATE_MAIN_I4 (ISAKMP SA established); REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
-#3: "west-east":500 STATE_QUICK_I2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#1: "west-east":500 ISAKMP SA established; REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
+#3: "west-east":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #3: "west-east" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 west #

--- a/testing/pluto/delete-ikev1-sa-03-conn-responder/east.console.txt
+++ b/testing/pluto/delete-ikev1-sa-03-conn-responder/east.console.txt
@@ -30,7 +30,7 @@ east #
  # both east and west should still have one IKE SA #1
 east #
  ipsec showstates
-#3: "west-east":500 STATE_MAIN_R3 (ISAKMP SA established); REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
-#4: "west-east":500 STATE_QUICK_R2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #3; idle;
+#3: "west-east":500 ISAKMP SA established; REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
+#4: "west-east":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #3; idle;
 #4: "west-east" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 east #

--- a/testing/pluto/delete-ikev1-sa-03-conn-responder/west.console.txt
+++ b/testing/pluto/delete-ikev1-sa-03-conn-responder/west.console.txt
@@ -34,7 +34,7 @@ west #
  # both east and west should still have one IKE SA #1
 west #
  ipsec showstates
-#4: "west-east":500 STATE_MAIN_I4 (ISAKMP SA established); REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
-#5: "west-east":500 STATE_QUICK_I2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #4; idle;
+#4: "west-east":500 ISAKMP SA established; REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
+#5: "west-east":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #4; idle;
 #5: "west-east" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 west #

--- a/testing/pluto/delete-ikev1-sa-04-multi-initiator/east.console.txt
+++ b/testing/pluto/delete-ikev1-sa-04-multi-initiator/east.console.txt
@@ -19,9 +19,9 @@ east #
 initdone
 east #
  ipsec showstates
-#3: "west-east-b":500 STATE_QUICK_R2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#3: "west-east-b":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #3: "west-east-b" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#1: "west-east-c":500 STATE_MAIN_R3 (ISAKMP SA established); REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
-#4: "west-east-c":500 STATE_QUICK_R2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#1: "west-east-c":500 ISAKMP SA established; REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
+#4: "west-east-c":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #4: "west-east-c" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
 east #

--- a/testing/pluto/delete-ikev1-sa-04-multi-initiator/west.console.txt
+++ b/testing/pluto/delete-ikev1-sa-04-multi-initiator/west.console.txt
@@ -49,9 +49,9 @@ west #
 "west-east" #2: ESP traffic information: in=0B out=0B
 west #
  ipsec showstates
-#1: "west-east":500 STATE_MAIN_I4 (ISAKMP SA established); REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
-#3: "west-east-b":500 STATE_QUICK_I2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#1: "west-east":500 ISAKMP SA established; REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
+#3: "west-east-b":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #3: "west-east-b" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#4: "west-east-c":500 STATE_QUICK_I2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#4: "west-east-c":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #4: "west-east-c" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
 west #

--- a/testing/pluto/delete-ikev1-sa-04-multi-responder/east.console.txt
+++ b/testing/pluto/delete-ikev1-sa-04-multi-responder/east.console.txt
@@ -41,11 +41,11 @@ east #
  # both east and west should still have one IKE SA #1
 east #
  ipsec showstates
-#1: "west-east":500 STATE_MAIN_R3 (ISAKMP SA established); REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
-#5: "west-east":500 STATE_QUICK_R2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#1: "west-east":500 ISAKMP SA established; REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
+#5: "west-east":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #5: "west-east" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#3: "west-east-b":500 STATE_QUICK_R2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#3: "west-east-b":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #3: "west-east-b" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#4: "west-east-c":500 STATE_QUICK_R2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#4: "west-east-c":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #4: "west-east-c" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
 east #

--- a/testing/pluto/delete-ikev1-sa-04-multi-responder/west.console.txt
+++ b/testing/pluto/delete-ikev1-sa-04-multi-responder/west.console.txt
@@ -45,11 +45,11 @@ west #
  # both east and west should still have one IKE SA #1
 west #
  ipsec showstates
-#1: "west-east":500 STATE_MAIN_I4 (ISAKMP SA established); REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
-#5: "west-east":500 STATE_QUICK_I2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#1: "west-east":500 ISAKMP SA established; REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
+#5: "west-east":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #5: "west-east" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#3: "west-east-b":500 STATE_QUICK_I2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#3: "west-east-b":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #3: "west-east-b" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#4: "west-east-c":500 STATE_QUICK_I2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#4: "west-east-c":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #4: "west-east-c" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
 west #

--- a/testing/pluto/delete-sa-02/east.console.txt
+++ b/testing/pluto/delete-sa-02/east.console.txt
@@ -14,4 +14,4 @@ initdone
 east #
  ../../guestbin/wait-for-pluto.sh '^".*#2: IPsec SA established'
 "west-east" #2: IPsec SA established tunnel mode {ESP=>0xESPESP <0xESPESP xfrm=AES_CBC_128-HMAC_SHA1_96 DPD=passive}
-east # 
+east #

--- a/testing/pluto/dpd-10-alias/north.console.txt
+++ b/testing/pluto/dpd-10-alias/north.console.txt
@@ -103,9 +103,9 @@ north #
 "north-dpd/0x2":   conn serial: $2;
 "north-dpd/0x2":   aliases: north-dpd
 "north-dpd/0x2":   IKEv1 algorithm newest: AES_CBC_256-HMAC_SHA2_256-MODP2048
-#5: "north-dpd/0x1":500 STATE_QUICK_I1 (sent Quick Mode request); RETRANSMIT in XXs; lastdpd=-1s(seq in:0 out:0); idle;
-#1: "north-dpd/0x2":500 STATE_MAIN_I4 (ISAKMP SA established); REPLACE in XXs; newest; lastdpd=30s(seq in:XXXXX out:YYYYY); idle;
-#4: "north-dpd/0x2":500 STATE_QUICK_I1 (sent Quick Mode request); RETRANSMIT in XXs; lastdpd=-1s(seq in:0 out:0); idle;
+#5: "north-dpd/0x1":500 sent Quick Mode request; RETRANSMIT in XXs; lastdpd=-1s(seq in:0 out:0); idle;
+#1: "north-dpd/0x2":500 ISAKMP SA established; REPLACE in XXs; newest; lastdpd=30s(seq in:XXXXX out:YYYYY); idle;
+#4: "north-dpd/0x2":500 sent Quick Mode request; RETRANSMIT in XXs; lastdpd=-1s(seq in:0 out:0); idle;
 north #
  ../../guestbin/ip-route.sh del unreachable 192.1.2.23
 north #

--- a/testing/pluto/github-1188-lost-policy/road.console.txt
+++ b/testing/pluto/github-1188-lost-policy/road.console.txt
@@ -33,7 +33,7 @@ road #
  # dump state/policy for larval OE connection
 road #
  ipsec showstates
-#1: "private#192.1.2.0/24"[1] ...192.1.2.23:500 IKE_SA_INIT_I (sent IKE_SA_INIT request); RETRANSMIT in XXs; idle;
+#1: "private#192.1.2.0/24"[1] ...192.1.2.23:500 sent IKE_SA_INIT request; RETRANSMIT in XXs; idle;
 #1: pending CHILD SA for "private#192.1.2.0/24"[1] ...192.1.2.23
 road #
  ipsec _kernel policy
@@ -48,10 +48,10 @@ road #
 #3: "private#192.1.2.0/24"[1] ...192.1.2.23, type=ESP, add_time=1234567890, inBytes=0, outBytes=0, maxBytes=2^63B, id='@id'
 road #
  ipsec showstates
-#1: "private#192.1.2.0/24"[1] ...192.1.2.23:500 IKE_SA_INIT_I (sent IKE_SA_INIT request); RETRANSMIT in XXs; idle;
+#1: "private#192.1.2.0/24"[1] ...192.1.2.23:500 sent IKE_SA_INIT request; RETRANSMIT in XXs; idle;
 #1: pending CHILD SA for "private#192.1.2.0/24"[1] ...192.1.2.23
-#2: "private#192.1.2.0/24"[1] ...192.1.2.23:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#3: "private#192.1.2.0/24"[1] ...192.1.2.23:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #2; idle;
+#2: "private#192.1.2.0/24"[1] ...192.1.2.23:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#3: "private#192.1.2.0/24"[1] ...192.1.2.23:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #2; idle;
 #3: "private#192.1.2.0/24"[1] ...192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
 road #
  # now check policy/state

--- a/testing/pluto/ikev1-hostpair-01/east.console.txt
+++ b/testing/pluto/ikev1-hostpair-01/east.console.txt
@@ -63,11 +63,11 @@ east #
 "roadnet-eastnet-ipv4-psk-ikev1"[1]:   conn serial: $2, instantiated from: $1;
 "roadnet-eastnet-ipv4-psk-ikev1"[1]:   IKEv1 algorithm newest: AES_CBC_256-HMAC_SHA2_256-MODP2048
 "roadnet-eastnet-ipv4-psk-ikev1"[1]:   ESP algorithm newest: AES_CBC_128-HMAC_SHA1_96; pfsgroup=<Phase1>
-#1: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254:EPHEM STATE_MAIN_R3 (ISAKMP SA established); REPLACE in XXs; lastdpd=-1s(seq in:0 out:0); idle;
-#2: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254:EPHEM STATE_QUICK_R2 (IPsec SA established); REPLACE in XXs; ISAKMP SA #1; idle;
+#1: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254:EPHEM ISAKMP SA established; REPLACE in XXs; lastdpd=-1s(seq in:0 out:0); idle;
+#2: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254:EPHEM IPsec SA established; REPLACE in XXs; ISAKMP SA #1; idle;
 #2: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254 esp.ESPSPIi@192.1.2.254 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.254 tun.0@192.1.2.23 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B username=use3
-#3: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254:EPHEM STATE_MAIN_R3 (ISAKMP SA established); REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
-#4: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254:EPHEM STATE_QUICK_R2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #3; idle;
+#3: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254:EPHEM ISAKMP SA established; REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
+#4: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254:EPHEM IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #3; idle;
 #4: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254 esp.ESPSPIi@192.1.2.254 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.254 tun.0@192.1.2.23 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B username=use3
 east #
  # should show no hits

--- a/testing/pluto/ikev1-hostpair-01/road.console.txt
+++ b/testing/pluto/ikev1-hostpair-01/road.console.txt
@@ -126,8 +126,8 @@ road #
 "westnet-eastnet-ipv4-psk-ikev1":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev1":   IKEv1 algorithm newest: AES_CBC_256-HMAC_SHA2_256-MODP2048
 "westnet-eastnet-ipv4-psk-ikev1":   ESP algorithm newest: AES_CBC_128-HMAC_SHA1_96; pfsgroup=<Phase1>
-#1: "westnet-eastnet-ipv4-psk-ikev1":4500 STATE_MAIN_I4 (ISAKMP SA established); RETRANSMIT in XXs; NAT_KEEPALIVE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
-#2: "westnet-eastnet-ipv4-psk-ikev1":4500 STATE_QUICK_I2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#1: "westnet-eastnet-ipv4-psk-ikev1":4500 ISAKMP SA established; RETRANSMIT in XXs; NAT_KEEPALIVE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
+#2: "westnet-eastnet-ipv4-psk-ikev1":4500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #2: "westnet-eastnet-ipv4-psk-ikev1" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.210 tun.0@192.1.2.23 tun.0@192.1.3.210 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B username=use3
 road #
  # should show no hits

--- a/testing/pluto/ikev1-hostpair-02/east.console.txt
+++ b/testing/pluto/ikev1-hostpair-02/east.console.txt
@@ -23,17 +23,17 @@ east #
 "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254 #8: IPsec SA established tunnel mode {ESPinUDP=>0xESPESP <0xESPESP xfrm=AES_CBC_128-HMAC_SHA1_96 NATD=192.1.2.254:4500 DPD=passive username=use3}
 east #
  ipsec showstates
-#1: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254:4500 STATE_MAIN_R3 (ISAKMP SA established); REPLACE in XXs; lastdpd=-1s(seq in:0 out:0); idle;
-#2: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254:4500 STATE_QUICK_R2 (IPsec SA established); REPLACE in XXs; ISAKMP SA #1; idle;
+#1: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254:4500 ISAKMP SA established; REPLACE in XXs; lastdpd=-1s(seq in:0 out:0); idle;
+#2: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254:4500 IPsec SA established; REPLACE in XXs; ISAKMP SA #1; idle;
 #2: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254 esp.ESPSPIi@192.1.2.254 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.254 tun.0@192.1.2.23 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B username=use3
-#3: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254:4500 STATE_MAIN_R3 (ISAKMP SA established); REPLACE in XXs; lastdpd=-1s(seq in:0 out:0); idle;
-#4: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254:4500 STATE_QUICK_R2 (IPsec SA established); REPLACE in XXs; ISAKMP SA #3; idle;
+#3: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254:4500 ISAKMP SA established; REPLACE in XXs; lastdpd=-1s(seq in:0 out:0); idle;
+#4: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254:4500 IPsec SA established; REPLACE in XXs; ISAKMP SA #3; idle;
 #4: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254 esp.ESPSPIi@192.1.2.254 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.254 tun.0@192.1.2.23 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B username=use3
-#5: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254:4500 STATE_MAIN_R3 (ISAKMP SA established); REPLACE in XXs; lastdpd=-1s(seq in:0 out:0); idle;
-#6: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254:4500 STATE_QUICK_R2 (IPsec SA established); REPLACE in XXs; ISAKMP SA #5; idle;
+#5: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254:4500 ISAKMP SA established; REPLACE in XXs; lastdpd=-1s(seq in:0 out:0); idle;
+#6: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254:4500 IPsec SA established; REPLACE in XXs; ISAKMP SA #5; idle;
 #6: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254 esp.ESPSPIi@192.1.2.254 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.254 tun.0@192.1.2.23 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B username=use3
-#7: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254:4500 STATE_MAIN_R3 (ISAKMP SA established); REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
-#8: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254:4500 STATE_QUICK_R2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #7; idle;
+#7: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254:4500 ISAKMP SA established; REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
+#8: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254:4500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #7; idle;
 #8: "roadnet-eastnet-ipv4-psk-ikev1"[1] 192.1.2.254 esp.ESPSPIi@192.1.2.254 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.254 tun.0@192.1.2.23 Traffic: ESPin=168B ESPout=168B ESPmax=2^63B username=use3
 east #
  ipsec _kernel policy

--- a/testing/pluto/ikev1-hostpair-02/road.console.txt
+++ b/testing/pluto/ikev1-hostpair-02/road.console.txt
@@ -163,8 +163,8 @@ road #
 #8: "westnet-eastnet-ipv4-psk-ikev1", username=use3, type=ESP, add_time=1234567890, inBytes=168, outBytes=168, maxBytes=2^63B, lease=192.0.2.1/32
 road #
  ipsec showstates
-#7: "westnet-eastnet-ipv4-psk-ikev1":4500 STATE_MAIN_I4 (ISAKMP SA established); NAT_KEEPALIVE in XXs; RETRANSMIT in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
-#8: "westnet-eastnet-ipv4-psk-ikev1":4500 STATE_QUICK_I2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #7; idle;
+#7: "westnet-eastnet-ipv4-psk-ikev1":4500 ISAKMP SA established; NAT_KEEPALIVE in XXs; RETRANSMIT in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
+#8: "westnet-eastnet-ipv4-psk-ikev1":4500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #7; idle;
 #8: "westnet-eastnet-ipv4-psk-ikev1" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=168B ESPout=168B ESPmax=2^63B username=use3
 road #
  ipsec _kernel policy

--- a/testing/pluto/ikev1-hub-spoke/north.console.txt
+++ b/testing/pluto/ikev1-hub-spoke/north.console.txt
@@ -138,8 +138,8 @@ State Information: DDoS cookies not required, Accepting new IKE connections
 IKE SAs: total(1), half-open(0), open(0), authenticated(1), anonymous(0)
 IPsec SAs: total(1), authenticated(1), anonymous(0)
  
-#1: "northnet-westnet-ipv4-psk":500 STATE_MAIN_I4 (ISAKMP SA established); REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
-#2: "northnet-westnet-ipv4-psk":500 STATE_QUICK_I2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#1: "northnet-westnet-ipv4-psk":500 ISAKMP SA established; REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
+#2: "northnet-westnet-ipv4-psk":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #2: "northnet-westnet-ipv4-psk" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.33 tun.0@192.1.2.23 tun.0@192.1.3.33 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
  
 Bare Shunt list:

--- a/testing/pluto/ikev1-rekey-connswitch/west.console.txt
+++ b/testing/pluto/ikev1-rekey-connswitch/west.console.txt
@@ -97,9 +97,9 @@ west #
 "TUNNEL-B":   conn serial: $3;
 "TUNNEL-C":   routing: routed-tunnel; established IPsec SA: #4;
 "TUNNEL-C":   conn serial: $1;
-#2: "TUNNEL-A":500 STATE_QUICK_I2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
-#3: "TUNNEL-B":500 STATE_QUICK_I2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
-#4: "TUNNEL-C":500 STATE_QUICK_I2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#2: "TUNNEL-A":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#3: "TUNNEL-B":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#4: "TUNNEL-C":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 west #
  sleep 60
 west #
@@ -112,9 +112,9 @@ west #
 "TUNNEL-B":   conn serial: $3;
 "TUNNEL-C":   routing: routed-tunnel; established IPsec SA: #4;
 "TUNNEL-C":   conn serial: $1;
-#2: "TUNNEL-A":500 STATE_QUICK_I2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
-#3: "TUNNEL-B":500 STATE_QUICK_I2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
-#4: "TUNNEL-C":500 STATE_QUICK_I2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#2: "TUNNEL-A":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#3: "TUNNEL-B":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#4: "TUNNEL-C":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 west #
  ipsec auto --down TUNNEL-B
 "TUNNEL-B": terminating SAs using this connection
@@ -196,9 +196,9 @@ west #
 "TUNNEL-C":   routing: routed-tunnel; established IPsec SA: #4;
 "TUNNEL-C":   conn serial: $1;
 "TUNNEL-C":   ESP algorithm newest: AES_CBC_128-HMAC_SHA1_96; pfsgroup=<Phase1>
-#2: "TUNNEL-A":500 STATE_QUICK_I2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#2: "TUNNEL-A":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #2: "TUNNEL-A" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=336B ESPout=336B ESPmax=2^63B 
-#4: "TUNNEL-C":500 STATE_QUICK_I2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#4: "TUNNEL-C":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #4: "TUNNEL-C" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=336B ESPout=336B ESPmax=2^63B 
 west #
  ipsec auto --delete TUNNEL-B
@@ -255,9 +255,9 @@ west #
 "TUNNEL-C":   routing: routed-tunnel; established IPsec SA: #4;
 "TUNNEL-C":   conn serial: $1;
 "TUNNEL-C":   ESP algorithm newest: AES_CBC_128-HMAC_SHA1_96; pfsgroup=<Phase1>
-#2: "TUNNEL-A":500 STATE_QUICK_I2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#2: "TUNNEL-A":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #2: "TUNNEL-A" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=336B ESPout=336B ESPmax=2^63B 
-#4: "TUNNEL-C":500 STATE_QUICK_I2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#4: "TUNNEL-C":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #4: "TUNNEL-C" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=336B ESPout=336B ESPmax=2^63B 
 west #
  echo done

--- a/testing/pluto/ikev1-xauth-30-retransmit-xchg-mode-cfg-request/road.console.txt
+++ b/testing/pluto/ikev1-xauth-30-retransmit-xchg-mode-cfg-request/road.console.txt
@@ -45,8 +45,8 @@ road #
  # note there should NOT be any incomplete IKE SA attempting to do ModeCFG
 road #
  ipsec showstates
-#1: "xauth-road-eastnet":500 STATE_MAIN_I4 (ISAKMP SA established); REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
-#2: "xauth-road-eastnet":500 STATE_QUICK_I2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#1: "xauth-road-eastnet":500 ISAKMP SA established; REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
+#2: "xauth-road-eastnet":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #2: "xauth-road-eastnet" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B username=use1
 road #
  echo done

--- a/testing/pluto/ikev1-xauth-31-one-each-way/road.console.txt
+++ b/testing/pluto/ikev1-xauth-31-one-each-way/road.console.txt
@@ -48,8 +48,8 @@ road #
  # note there should NOT be any incomplete IKE SA attempting to do ModeCFG
 road #
  ipsec showstates
-#1: "xauth-road-to-east-on-road":500 STATE_MAIN_I4 (ISAKMP SA established); REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
-#2: "xauth-road-to-east-on-road":500 STATE_QUICK_I2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#1: "xauth-road-to-east-on-road":500 ISAKMP SA established; REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
+#2: "xauth-road-to-east-on-road":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #2: "xauth-road-to-east-on-road" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B username=use1
 road #
  ../../guestbin/ipsec-look.sh

--- a/testing/pluto/ikev2-16-alias-whack-start/north.console.txt
+++ b/testing/pluto/ikev2-16-alias-whack-start/north.console.txt
@@ -82,10 +82,10 @@ north #
 "northnet-eastnets/0x2":   conn serial: $2;
 "northnet-eastnets/0x2":   aliases: northnet-eastnets
 "northnet-eastnets/0x2":   ESP algorithm newest: AES_GCM_16_256; pfsgroup=<Phase1>
-#1: "northnet-eastnets/0x1":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "northnet-eastnets/0x1":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "northnet-eastnets/0x1":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "northnet-eastnets/0x1":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "northnet-eastnets/0x1" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.33 tun.0@192.1.2.23 tun.0@192.1.3.33 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#3: "northnet-eastnets/0x2":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#3: "northnet-eastnets/0x2":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #3: "northnet-eastnets/0x2" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.33 tun.0@192.1.2.23 tun.0@192.1.3.33 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
 north #
  ../../guestbin/ping-once.sh --up -I 192.0.3.254 192.0.2.254

--- a/testing/pluto/ikev2-16-alias-whack-up/north.console.txt
+++ b/testing/pluto/ikev2-16-alias-whack-up/north.console.txt
@@ -82,10 +82,10 @@ north #
 "northnet-eastnets/0x2":   conn serial: $2;
 "northnet-eastnets/0x2":   aliases: northnet-eastnets
 "northnet-eastnets/0x2":   ESP algorithm newest: AES_GCM_16_256; pfsgroup=<Phase1>
-#1: "northnet-eastnets/0x1":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "northnet-eastnets/0x1":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "northnet-eastnets/0x1":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "northnet-eastnets/0x1":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "northnet-eastnets/0x1" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.33 tun.0@192.1.2.23 tun.0@192.1.3.33 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#3: "northnet-eastnets/0x2":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#3: "northnet-eastnets/0x2":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #3: "northnet-eastnets/0x2" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.33 tun.0@192.1.2.23 tun.0@192.1.3.33 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
 north #
  ../../guestbin/ping-once.sh --up -I 192.0.3.254 192.0.2.254

--- a/testing/pluto/ikev2-20-ikesa-reauth/east.console.txt
+++ b/testing/pluto/ikev2-20-ikesa-reauth/east.console.txt
@@ -16,6 +16,6 @@ east #
 #4: "westnet-eastnet-ikev2", type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'
 east #
  ipsec status | grep "ESTABLISHED_"
-#3: "westnet-eastnet-ikev2":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#4: "westnet-eastnet-ikev2":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #3; idle;
+#3: "westnet-eastnet-ikev2":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#4: "westnet-eastnet-ikev2":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #3; idle;
 east #

--- a/testing/pluto/ikev2-20-ikesa-reauth/east.console.txt
+++ b/testing/pluto/ikev2-20-ikesa-reauth/east.console.txt
@@ -15,7 +15,9 @@ east #
  ipsec whack --trafficstatus
 #4: "westnet-eastnet-ikev2", type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'
 east #
- ipsec status | grep "ESTABLISHED_"
-#3: "westnet-eastnet-ikev2":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
-#4: "westnet-eastnet-ikev2":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #3; idle;
+ # either west or westnet-eastnet-ikev2
+east #
+ ipsec connectionstatus | grep "established .* SA"
+"westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45; established IKE SA: #3;
+"westnet-eastnet-ikev2":   routing: routed-tunnel; owner: Child SA #4; established IKE SA: #3; established Child SA: #4;
 east #

--- a/testing/pluto/ikev2-20-ikesa-reauth/final.sh
+++ b/testing/pluto/ikev2-20-ikesa-reauth/final.sh
@@ -1,2 +1,3 @@
 ipsec whack --trafficstatus
-ipsec status | grep "established "
+# either west or westnet-eastnet-ikev2
+ipsec connectionstatus | grep "established .* SA"

--- a/testing/pluto/ikev2-20-ikesa-reauth/final.sh
+++ b/testing/pluto/ikev2-20-ikesa-reauth/final.sh
@@ -1,2 +1,2 @@
 ipsec whack --trafficstatus
-ipsec status | grep "ESTABLISHED_"
+ipsec status | grep "established "

--- a/testing/pluto/ikev2-20-ikesa-reauth/west.console.txt
+++ b/testing/pluto/ikev2-20-ikesa-reauth/west.console.txt
@@ -46,7 +46,9 @@ west #
  ipsec whack --trafficstatus
 #4: "west", type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org'
 west #
- ipsec status | grep "ESTABLISHED_"
-#3: "west":500 established IKE SA; REPLACE in XXs; newest; idle;
-#4: "west":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #3; idle;
+ # either west or westnet-eastnet-ikev2
+west #
+ ipsec connectionstatus | grep "established .* SA"
+"west":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23; established IKE SA: #3;
+"west":   routing: routed-tunnel; owner: Child SA #4; established IKE SA: #3; established Child SA: #4;
 west #

--- a/testing/pluto/ikev2-20-ikesa-reauth/west.console.txt
+++ b/testing/pluto/ikev2-20-ikesa-reauth/west.console.txt
@@ -47,6 +47,6 @@ west #
 #4: "west", type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org'
 west #
  ipsec status | grep "ESTABLISHED_"
-#3: "west":500 ESTABLISHED_IKE_SA (established IKE SA); REPLACE in XXs; newest; idle;
-#4: "west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #3; idle;
+#3: "west":500 established IKE SA; REPLACE in XXs; newest; idle;
+#4: "west":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #3; idle;
 west #

--- a/testing/pluto/ikev2-29-no-rekey/west.console.txt
+++ b/testing/pluto/ikev2-29-no-rekey/west.console.txt
@@ -187,8 +187,8 @@ State Information: DDoS cookies not required, Accepting new IKE connections
 IKE SAs: total(1), half-open(0), open(0), authenticated(1), anonymous(0)
 IPsec SAs: total(1), authenticated(1), anonymous(0)
  
-#1: "westnet-eastnet-ikev2":500 ESTABLISHED_IKE_SA (established IKE SA); EXPIRE in XXs; newest; idle;
-#2: "westnet-eastnet-ikev2":500 ESTABLISHED_CHILD_SA (established Child SA); EXPIRE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "westnet-eastnet-ikev2":500 established IKE SA; EXPIRE in XXs; newest; idle;
+#2: "westnet-eastnet-ikev2":500 established Child SA; EXPIRE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "westnet-eastnet-ikev2" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
  
 Bare Shunt list:

--- a/testing/pluto/ikev2-41-rw-replace/road.console.txt
+++ b/testing/pluto/ikev2-41-rw-replace/road.console.txt
@@ -173,8 +173,8 @@ State Information: DDoS cookies not required, Accepting new IKE connections
 IKE SAs: total(1), half-open(0), open(0), authenticated(1), anonymous(0)
 IPsec SAs: total(1), authenticated(1), anonymous(0)
  
-#1: "road-east-x509-ipv4"[1] 192.1.2.23:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "road-east-x509-ipv4"[1] 192.1.2.23:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "road-east-x509-ipv4"[1] 192.1.2.23:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "road-east-x509-ipv4"[1] 192.1.2.23:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "road-east-x509-ipv4"[1] 192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
  
 Bare Shunt list:
@@ -346,9 +346,9 @@ State Information: DDoS cookies not required, Accepting new IKE connections
 IKE SAs: total(1), half-open(0), open(0), authenticated(1), anonymous(0)
 IPsec SAs: total(1), authenticated(1), anonymous(0)
  
-#2: "road-east-x509-ipv4"[1] 192.1.2.23:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #3; idle;
+#2: "road-east-x509-ipv4"[1] 192.1.2.23:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #3; idle;
 #2: "road-east-x509-ipv4"[1] 192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=168B ESPout=168B ESPmax=2^63B 
-#3: "road-east-x509-ipv4"[1] 192.1.2.23:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
+#3: "road-east-x509-ipv4"[1] 192.1.2.23:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
  
 Bare Shunt list:
  

--- a/testing/pluto/ikev2-42-rw-replace-responder/road.console.txt
+++ b/testing/pluto/ikev2-42-rw-replace-responder/road.console.txt
@@ -195,9 +195,9 @@ State Information: DDoS cookies not required, Accepting new IKE connections
 IKE SAs: total(1), half-open(0), open(0), authenticated(1), anonymous(0)
 IPsec SAs: total(1), authenticated(1), anonymous(0)
  
-#2: "road-east-x509-ipv4"[1] 192.1.2.23:500 ESTABLISHED_CHILD_SA (established Child SA); EXPIRE in XXs; newest; eroute owner; IKE SA #3; idle;
+#2: "road-east-x509-ipv4"[1] 192.1.2.23:500 established Child SA; EXPIRE in XXs; newest; eroute owner; IKE SA #3; idle;
 #2: "road-east-x509-ipv4"[1] 192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=168B ESPout=168B ESPmax=2^63B 
-#3: "road-east-x509-ipv4"[1] 192.1.2.23:500 ESTABLISHED_IKE_SA (established IKE SA); EXPIRE in XXs; newest; idle;
+#3: "road-east-x509-ipv4"[1] 192.1.2.23:500 established IKE SA; EXPIRE in XXs; newest; idle;
  
 Bare Shunt list:
  

--- a/testing/pluto/ikev2-49-hub-spoke/north.console.txt
+++ b/testing/pluto/ikev2-49-hub-spoke/north.console.txt
@@ -139,8 +139,8 @@ State Information: DDoS cookies not required, Accepting new IKE connections
 IKE SAs: total(1), half-open(0), open(0), authenticated(1), anonymous(0)
 IPsec SAs: total(1), authenticated(1), anonymous(0)
  
-#1: "northnet-westnet-ipv4-psk":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "northnet-westnet-ipv4-psk":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "northnet-westnet-ipv4-psk":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "northnet-westnet-ipv4-psk":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "northnet-westnet-ipv4-psk" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.33 tun.0@192.1.2.23 tun.0@192.1.3.33 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
  
 Bare Shunt list:

--- a/testing/pluto/ikev2-53-clean-pending/west.console.txt
+++ b/testing/pluto/ikev2-53-clean-pending/west.console.txt
@@ -29,7 +29,7 @@ west #
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted-bare-negotiation; owner: IKE SA #1; negotiating IKE SA: #1;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
-#1: "westnet-eastnet-ipv4-psk-ikev2":500 IKE_SA_INIT_I (sent IKE_SA_INIT request); RETRANSMIT in XXs; idle;
+#1: "westnet-eastnet-ipv4-psk-ikev2":500 sent IKE_SA_INIT request; RETRANSMIT in XXs; idle;
 #1: pending Child SA for "westnet-eastnet-ipv4-psk-ikev2"
 west #
  echo "initdone"
@@ -58,7 +58,7 @@ west #
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted-bare-negotiation; owner: IKE SA #1; negotiating IKE SA: #1;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
-#1: "westnet-eastnet-ipv4-psk-ikev2":500 IKE_SA_INIT_I (sent IKE_SA_INIT request); RETRANSMIT in XXs; idle;
+#1: "westnet-eastnet-ipv4-psk-ikev2":500 sent IKE_SA_INIT request; RETRANSMIT in XXs; idle;
 #1: pending Child SA for "westnet-eastnet-ipv4-psk-ikev2"
 west #
  # wait for the IKE SA to die
@@ -89,7 +89,7 @@ west #
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted-bare-negotiation; owner: IKE SA #2; negotiating IKE SA: #2;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
-#2: "westnet-eastnet-ipv4-psk-ikev2":500 IKE_SA_INIT_I (sent IKE_SA_INIT request); RETRANSMIT in XXs; idle;
+#2: "westnet-eastnet-ipv4-psk-ikev2":500 sent IKE_SA_INIT request; RETRANSMIT in XXs; idle;
 #2: pending Child SA for "westnet-eastnet-ipv4-psk-ikev2"
 west #
  ipsec _kernel state

--- a/testing/pluto/ikev2-59-multiple-acquires-alias/north.console.txt
+++ b/testing/pluto/ikev2-59-multiple-acquires-alias/north.console.txt
@@ -91,10 +91,10 @@ north #
 "north-eastnets/0x2":   IKEv2 algorithm newest: AES_CBC_256-HMAC_SHA2_256-DH19
 "north-eastnets/0x2":   ESP algorithms: AES_CBC_128-HMAC_SHA2_512_256-MODP3072
 "north-eastnets/0x2":   ESP algorithm newest: AES_CBC_128-HMAC_SHA2_512_256; pfsgroup=<Phase1>
-#2: "north-eastnets/0x1":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#2: "north-eastnets/0x1":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "north-eastnets/0x1" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.33 tun.0@192.1.2.23 tun.0@192.1.3.33 Traffic: ESPin=252B ESPout=252B ESPmax=2^63B 
-#1: "north-eastnets/0x2":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#3: "north-eastnets/0x2":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "north-eastnets/0x2":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#3: "north-eastnets/0x2":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #3: "north-eastnets/0x2" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.33 tun.0@192.1.2.23 tun.0@192.1.3.33 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 north #
  ../../guestbin/ping-once.sh --up -I 192.0.3.254 192.0.2.254

--- a/testing/pluto/ikev2-child-rekey-01/east.console.txt
+++ b/testing/pluto/ikev2-child-rekey-01/east.console.txt
@@ -16,7 +16,7 @@ east #
 #3: "east", type=ESP, add_time=1234567890, inBytes=168, outBytes=168, maxBytes=2^63B, id='@west'
 east #
  ipsec showstates
-#1: "east":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#3: "east":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "east":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#3: "east":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #3: "east" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=168B ESPout=168B ESPmax=2^63B 
 east #

--- a/testing/pluto/ikev2-child-rekey-01/west.console.txt
+++ b/testing/pluto/ikev2-child-rekey-01/west.console.txt
@@ -56,7 +56,7 @@ west #
 #3: "west", type=ESP, add_time=1234567890, inBytes=168, outBytes=168, maxBytes=2^63B, id='@east'
 west #
  ipsec showstates
-#1: "west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#3: "west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#3: "west":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #3: "west" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=168B ESPout=168B ESPmax=2^63B 
 west #

--- a/testing/pluto/ikev2-child-rekey-02/east.console.txt
+++ b/testing/pluto/ikev2-child-rekey-02/east.console.txt
@@ -32,11 +32,11 @@ east #
 #10: "westnet-eastnet-ikev2c", type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='@west'
 east #
  ipsec showstates
-#8: "westnet-eastnet-ikev2a":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#8: "westnet-eastnet-ikev2a":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #8: "westnet-eastnet-ikev2a" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
-#9: "westnet-eastnet-ikev2b":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#9: "westnet-eastnet-ikev2b":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #9: "westnet-eastnet-ikev2b" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
-#1: "westnet-eastnet-ikev2c":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#10: "westnet-eastnet-ikev2c":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "westnet-eastnet-ikev2c":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#10: "westnet-eastnet-ikev2c":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #10: "westnet-eastnet-ikev2c" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 east #

--- a/testing/pluto/ikev2-child-rekey-02/west.console.txt
+++ b/testing/pluto/ikev2-child-rekey-02/west.console.txt
@@ -166,11 +166,11 @@ west #
 #10: "westnet-eastnet-ikev2c", type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='@east'
 west #
  ipsec showstates
-#1: "westnet-eastnet-ikev2a":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#8: "westnet-eastnet-ikev2a":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "westnet-eastnet-ikev2a":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#8: "westnet-eastnet-ikev2a":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #8: "westnet-eastnet-ikev2a" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
-#9: "westnet-eastnet-ikev2b":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#9: "westnet-eastnet-ikev2b":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #9: "westnet-eastnet-ikev2b" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
-#10: "westnet-eastnet-ikev2c":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#10: "westnet-eastnet-ikev2c":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #10: "westnet-eastnet-ikev2c" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 west #

--- a/testing/pluto/ikev2-child-rekey-08-deadlock/west.console.txt
+++ b/testing/pluto/ikev2-child-rekey-08-deadlock/west.console.txt
@@ -42,11 +42,11 @@ west #
  # state #1(ESTABLISHED_IKE_SA), #2, #3, #4, and #5
 west #
  ipsec status | grep STATE_
-#2: "west-east/1x0":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
-#3: "west-east/2x0":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
-#4: "west-east/3x0":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
-#1: "west-east/4x0":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#5: "west-east/4x0":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#2: "west-east/1x0":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#3: "west-east/2x0":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#4: "west-east/3x0":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "west-east/4x0":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#5: "west-east/4x0":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 west #
  ipsec whack --rekey-child --name west-east/1x0
 west #
@@ -63,11 +63,11 @@ west #
  # anything other state is a sign of regression
 west #
  ipsec status | grep STATE_
-#6: "west-east/1x0":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
-#7: "west-east/2x0":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
-#8: "west-east/3x0":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
-#1: "west-east/4x0":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#9: "west-east/4x0":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#6: "west-east/1x0":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#7: "west-east/2x0":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#8: "west-east/3x0":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "west-east/4x0":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#9: "west-east/4x0":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 west #
  # this is complex grep line susceptible to changes to log lines.
 west #

--- a/testing/pluto/ikev2-child-rekey/west.console.txt
+++ b/testing/pluto/ikev2-child-rekey/west.console.txt
@@ -58,8 +58,8 @@ west #
  # expect IKE #1 CHILD #3
 west #
  ipsec showstates
-#1: "west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#3: "west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#3: "west":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #3: "west" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
 west #
  ../../guestbin/ping-once.sh --up -I 192.0.1.254 192.0.2.254
@@ -92,8 +92,8 @@ west #
  # expect IKE #1 CHILD #4
 west #
  ipsec showstates
-#1: "west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#4: "west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#4: "west":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #4: "west" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
 west #
  ../../guestbin/ping-once.sh --up -I 192.0.1.254 192.0.2.254

--- a/testing/pluto/ikev2-delete-01/west.console.txt
+++ b/testing/pluto/ikev2-delete-01/west.console.txt
@@ -166,8 +166,8 @@ State Information: DDoS cookies not required, Accepting new IKE connections
 IKE SAs: total(1), half-open(0), open(0), authenticated(1), anonymous(0)
 IPsec SAs: total(1), authenticated(1), anonymous(0)
  
-#1: "westnet-eastnet-ipv4-psk-ikev2":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "westnet-eastnet-ipv4-psk-ikev2":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "westnet-eastnet-ipv4-psk-ikev2":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "westnet-eastnet-ipv4-psk-ikev2":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "westnet-eastnet-ipv4-psk-ikev2" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
  
 Bare Shunt list:

--- a/testing/pluto/ikev2-delete-02/west.console.txt
+++ b/testing/pluto/ikev2-delete-02/west.console.txt
@@ -62,8 +62,8 @@ src 192.0.2.0/24 dst 192.0.1.0/24
 		proto esp reqid REQID mode tunnel
 west #
  ipsec whack --showstates
-#1: "west-east-delete1":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "west-east-delete1":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "west-east-delete1":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "west-east-delete1":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "west-east-delete1" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 west #
  echo "sleeping a bit.. then deleting child"
@@ -86,7 +86,7 @@ src 192.0.1.0/24 dst 192.0.2.0/24
 		proto esp reqid 0 mode transport
 west #
  ipsec whack --showstates
-#1: "west-east-delete1":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
+#1: "west-east-delete1":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
 west #
  echo "sleeping a bit.. then deleting ike"
 sleeping a bit.. then deleting ike

--- a/testing/pluto/ikev2-delete-04/west.console.txt
+++ b/testing/pluto/ikev2-delete-04/west.console.txt
@@ -51,8 +51,8 @@ west #
 up
 west #
  ipsec showstates
-#1: "west-east-delete1":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "west-east-delete1":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "west-east-delete1":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "west-east-delete1":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "west-east-delete1" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 west #
  echo "sleeping a bit.. 2"
@@ -71,8 +71,8 @@ west #
  sleep 2
 west #
  ipsec showstates
-#1: "west-east-delete1":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#3: "west-east-delete1":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "west-east-delete1":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#3: "west-east-delete1":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #3: "west-east-delete1" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
 west #
  ipsec whack --trafficstatus

--- a/testing/pluto/ikev2-hostpair-01/east.console.txt
+++ b/testing/pluto/ikev2-hostpair-01/east.console.txt
@@ -14,7 +14,7 @@ east #
  echo "initdone"
 initdone
 east #
- ipsec status | grep eastnet | sed "s/192.1.2.254:[0-9]* STATE_/192.1.2.254:PORT STATE_/"
+ ipsec status | grep eastnet | sed "s/192.1.2.254:[0-9]* /192.1.2.254:PORT /"
 "roadnet-eastnet-ipv4-psk-ikev2": 192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...%any[%fromcert]==={192.0.2.1-192.0.2.200}; unrouted; my_ip=unset; their_ip=unset;
 "roadnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.23; remote: %any;
 "roadnet-eastnet-ipv4-psk-ikev2":   mycert=east;
@@ -65,9 +65,9 @@ east #
 "roadnet-eastnet-ipv4-psk-ikev2"[1]:   conn serial: $2, instantiated from: $1;
 "roadnet-eastnet-ipv4-psk-ikev2"[1]:   IKEv2 algorithm newest: AES_GCM_16_256-HMAC_SHA2_512-DH19
 "roadnet-eastnet-ipv4-psk-ikev2"[1]:   ESP algorithm newest: AES_GCM_16_256; pfsgroup=<Phase1>
-#1: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:EPHEM ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; idle;
-#3: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:EPHEM ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#4: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:EPHEM ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #3; idle;
+#1: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:PORT established IKE SA; REKEY in XXs; REPLACE in XXs; idle;
+#3: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:PORT established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#4: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:PORT established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #3; idle;
 #4: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254 esp.ESPSPIi@192.1.2.254 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.254 tun.0@192.1.2.23 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 east #
  # should show no hits

--- a/testing/pluto/ikev2-hostpair-01/final.sh
+++ b/testing/pluto/ikev2-hostpair-01/final.sh
@@ -1,4 +1,4 @@
-ipsec status | grep eastnet | sed "s/192.1.2.254:[0-9]* STATE_/192.1.2.254:PORT STATE_/"
+ipsec status | grep eastnet | sed "s/192.1.2.254:[0-9]* /192.1.2.254:PORT /"
 # should show no hits
 grep INVALID_IKE_SPI /tmp/pluto.log
 grep MSG_TRUNC /tmp/pluto.log

--- a/testing/pluto/ikev2-hostpair-01/road.console.txt
+++ b/testing/pluto/ikev2-hostpair-01/road.console.txt
@@ -82,7 +82,7 @@ road #
  echo done
 done
 road #
- ipsec status | grep eastnet | sed "s/192.1.2.254:[0-9]* STATE_/192.1.2.254:PORT STATE_/"
+ ipsec status | grep eastnet | sed "s/192.1.2.254:[0-9]* /192.1.2.254:PORT /"
 "westnet-eastnet-ipv4-psk-ikev2": 192.1.3.210[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org]---192.1.3.254...192.1.2.23[%fromcert]; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.3.210; nexthop: 192.1.3.254; remote: 192.1.2.23;
 "westnet-eastnet-ipv4-psk-ikev2":   mycert=road;
@@ -133,8 +133,8 @@ road #
 "westnet-eastnet-ipv4-psk-ikev2"[1]:   conn serial: $2, instantiated from: $1;
 "westnet-eastnet-ipv4-psk-ikev2"[1]:   IKEv2 algorithm newest: AES_GCM_16_256-HMAC_SHA2_512-DH19
 "westnet-eastnet-ipv4-psk-ikev2"[1]:   ESP algorithm newest: AES_GCM_16_256; pfsgroup=<Phase1>
-#1: "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23:4500 ESTABLISHED_IKE_SA (established IKE SA); NAT_KEEPALIVE in XXs; REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23:4500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23:4500 established IKE SA; NAT_KEEPALIVE in XXs; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23:4500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.210 tun.0@192.1.2.23 tun.0@192.1.3.210 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 road #
  # should show no hits

--- a/testing/pluto/ikev2-hostpair-02/east.console.txt
+++ b/testing/pluto/ikev2-hostpair-02/east.console.txt
@@ -15,17 +15,17 @@ east #
 initdone
 east #
  ipsec showstates
-#1: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:4500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; idle;
-#2: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:4500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; IKE SA #1; idle;
+#1: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:4500 established IKE SA; REKEY in XXs; REPLACE in XXs; idle;
+#2: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:4500 established Child SA; REKEY in XXs; REPLACE in XXs; IKE SA #1; idle;
 #2: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254 esp.ESPSPIi@192.1.2.254 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.254 tun.0@192.1.2.23 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
-#3: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:4500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; idle;
-#4: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:4500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; IKE SA #3; idle;
+#3: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:4500 established IKE SA; REKEY in XXs; REPLACE in XXs; idle;
+#4: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:4500 established Child SA; REKEY in XXs; REPLACE in XXs; IKE SA #3; idle;
 #4: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254 esp.ESPSPIi@192.1.2.254 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.254 tun.0@192.1.2.23 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#5: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:4500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; idle;
-#6: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:4500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; IKE SA #5; idle;
+#5: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:4500 established IKE SA; REKEY in XXs; REPLACE in XXs; idle;
+#6: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:4500 established Child SA; REKEY in XXs; REPLACE in XXs; IKE SA #5; idle;
 #6: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254 esp.ESPSPIi@192.1.2.254 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.254 tun.0@192.1.2.23 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#7: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:4500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#8: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:4500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #7; idle;
+#7: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:4500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#8: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:4500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #7; idle;
 #8: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254 esp.ESPSPIi@192.1.2.254 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.254 tun.0@192.1.2.23 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 east #
  ipsec _kernel policy

--- a/testing/pluto/ikev2-hostpair-02/road.console.txt
+++ b/testing/pluto/ikev2-hostpair-02/road.console.txt
@@ -116,8 +116,8 @@ road #
 done
 road #
  ipsec showstates
-#7: "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23:4500 ESTABLISHED_IKE_SA (established IKE SA); NAT_KEEPALIVE in XXs; REKEY in XXs; REPLACE in XXs; newest; idle;
-#8: "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23:4500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #7; idle;
+#7: "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23:4500 established IKE SA; NAT_KEEPALIVE in XXs; REKEY in XXs; REPLACE in XXs; newest; idle;
+#8: "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23:4500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #7; idle;
 #8: "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 road #
  ipsec _kernel policy

--- a/testing/pluto/ikev2-hostpair-03-initial-contact/east.console.txt
+++ b/testing/pluto/ikev2-hostpair-03-initial-contact/east.console.txt
@@ -15,11 +15,11 @@ east #
 initdone
 east #
  ipsec showstates
-#1: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:4500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; idle;
-#3: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:4500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; idle;
-#5: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:4500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; idle;
-#7: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:4500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#8: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:4500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #7; idle;
+#1: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:4500 established IKE SA; REKEY in XXs; REPLACE in XXs; idle;
+#3: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:4500 established IKE SA; REKEY in XXs; REPLACE in XXs; idle;
+#5: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:4500 established IKE SA; REKEY in XXs; REPLACE in XXs; idle;
+#7: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:4500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#8: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254:4500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #7; idle;
 #8: "roadnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.254 esp.ESPSPIi@192.1.2.254 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.254 tun.0@192.1.2.23 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 east #
  ipsec _kernel policy

--- a/testing/pluto/ikev2-hostpair-03-initial-contact/road.console.txt
+++ b/testing/pluto/ikev2-hostpair-03-initial-contact/road.console.txt
@@ -120,8 +120,8 @@ road #
 done
 road #
  ipsec showstates
-#7: "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23:4500 ESTABLISHED_IKE_SA (established IKE SA); NAT_KEEPALIVE in XXs; REKEY in XXs; REPLACE in XXs; newest; idle;
-#8: "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23:4500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #7; idle;
+#7: "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23:4500 established IKE SA; NAT_KEEPALIVE in XXs; REKEY in XXs; REPLACE in XXs; newest; idle;
+#8: "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23:4500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #7; idle;
 #8: "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 road #
  ipsec _kernel policy

--- a/testing/pluto/ikev2-ike-rekey-01/east.console.txt
+++ b/testing/pluto/ikev2-ike-rekey-01/east.console.txt
@@ -16,7 +16,7 @@ east #
 #2: "east", type=ESP, add_time=1234567890, inBytes=252, outBytes=252, maxBytes=2^63B, id='@west'
 east #
  ipsec showstates
-#2: "east":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #4; idle;
+#2: "east":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #4; idle;
 #2: "east" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=252B ESPout=252B ESPmax=2^63B 
-#4: "east":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
+#4: "east":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
 east #

--- a/testing/pluto/ikev2-ike-rekey-01/west.console.txt
+++ b/testing/pluto/ikev2-ike-rekey-01/west.console.txt
@@ -54,9 +54,9 @@ west #
 #2: "west", type=ESP, add_time=1234567890, inBytes=168, outBytes=168, maxBytes=2^63B, id='@east'
 west #
  ipsec showstates
-#2: "west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #3; idle;
+#2: "west":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #3; idle;
 #2: "west" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=168B ESPout=168B ESPmax=2^63B 
-#3: "west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
+#3: "west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
 west #
  # why?
 west #
@@ -74,15 +74,15 @@ west #
 up
 west #
  ipsec showstates
-#2: "west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #4; idle;
+#2: "west":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #4; idle;
 #2: "west" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=252B ESPout=252B ESPmax=2^63B 
-#4: "west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
+#4: "west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
 west #
  ipsec whack --trafficstatus
 #2: "west", type=ESP, add_time=1234567890, inBytes=252, outBytes=252, maxBytes=2^63B, id='@east'
 west #
  ipsec showstates
-#2: "west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #4; idle;
+#2: "west":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #4; idle;
 #2: "west" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=252B ESPout=252B ESPmax=2^63B 
-#4: "west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
+#4: "west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
 west #

--- a/testing/pluto/ikev2-ike-rekey-02/east.console.txt
+++ b/testing/pluto/ikev2-ike-rekey-02/east.console.txt
@@ -16,7 +16,7 @@ east #
 #5: "east", type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='@west'
 east #
  ipsec showstates
-#4: "east":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#5: "east":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #4; idle;
+#4: "east":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#5: "east":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #4; idle;
 #5: "east" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 east #

--- a/testing/pluto/ikev2-ike-rekey-02/west.console.txt
+++ b/testing/pluto/ikev2-ike-rekey-02/west.console.txt
@@ -45,8 +45,8 @@ west #
 #3: "west", type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='@east'
 west #
  ipsec showstates
-#1: "west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#3: "west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#3: "west":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #3: "west" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 west #
  echo "sleep 50"
@@ -64,7 +64,7 @@ west #
 #5: "west", type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='@east'
 west #
  ipsec showstates
-#4: "west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#5: "west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #4; idle;
+#4: "west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#5: "west":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #4; idle;
 #5: "west" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 west #

--- a/testing/pluto/ikev2-ike-rekey-03/east.console.txt
+++ b/testing/pluto/ikev2-ike-rekey-03/east.console.txt
@@ -32,12 +32,12 @@ east #
 #10: "westnet-eastnet-ikev2c", type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='@west'
 east #
  ipsec showstates | sort
-#10: "westnet-eastnet-ikev2c":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #11; idle;
+#10: "westnet-eastnet-ikev2c":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #11; idle;
 #10: "westnet-eastnet-ikev2c" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
-#11: "westnet-eastnet-ikev2c":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#8: "westnet-eastnet-ikev2a":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #11; idle;
+#11: "westnet-eastnet-ikev2c":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#8: "westnet-eastnet-ikev2a":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #11; idle;
 #8: "westnet-eastnet-ikev2a" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
-#9: "westnet-eastnet-ikev2b":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #11; idle;
+#9: "westnet-eastnet-ikev2b":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #11; idle;
 #9: "westnet-eastnet-ikev2b" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 east #
  # there should be only one IKE_INIT exchange created on west

--- a/testing/pluto/ikev2-ike-rekey-03/west.console.txt
+++ b/testing/pluto/ikev2-ike-rekey-03/west.console.txt
@@ -82,12 +82,12 @@ west #
 #4: "westnet-eastnet-ikev2c", type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='@east'
 west #
  ipsec showstates
-#1: "westnet-eastnet-ikev2a":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "westnet-eastnet-ikev2a":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "westnet-eastnet-ikev2a":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "westnet-eastnet-ikev2a":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "westnet-eastnet-ikev2a" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
-#3: "westnet-eastnet-ikev2b":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#3: "westnet-eastnet-ikev2b":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #3: "westnet-eastnet-ikev2b" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
-#4: "westnet-eastnet-ikev2c":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#4: "westnet-eastnet-ikev2c":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #4: "westnet-eastnet-ikev2c" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 west #
  # Wait intil 30(23+10) - between 23 and 46
@@ -113,12 +113,12 @@ west #
 #7: "westnet-eastnet-ikev2c", type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='@east'
 west #
  ipsec showstates|sort
-#1: "westnet-eastnet-ikev2a":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#5: "westnet-eastnet-ikev2a":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "westnet-eastnet-ikev2a":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#5: "westnet-eastnet-ikev2a":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #5: "westnet-eastnet-ikev2a" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
-#6: "westnet-eastnet-ikev2b":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#6: "westnet-eastnet-ikev2b":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #6: "westnet-eastnet-ikev2b" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
-#7: "westnet-eastnet-ikev2c":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#7: "westnet-eastnet-ikev2c":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #7: "westnet-eastnet-ikev2c" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 west #
  # Wait intil 60(30+30) - between 46 and 69, after 53
@@ -151,12 +151,12 @@ west #
 #10: "westnet-eastnet-ikev2c", type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='@east'
 west #
  ipsec showstates | sort
-#10: "westnet-eastnet-ikev2c":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #11; idle;
+#10: "westnet-eastnet-ikev2c":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #11; idle;
 #10: "westnet-eastnet-ikev2c" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
-#11: "westnet-eastnet-ikev2a":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#8: "westnet-eastnet-ikev2a":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #11; idle;
+#11: "westnet-eastnet-ikev2a":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#8: "westnet-eastnet-ikev2a":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #11; idle;
 #8: "westnet-eastnet-ikev2a" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
-#9: "westnet-eastnet-ikev2b":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #11; idle;
+#9: "westnet-eastnet-ikev2b":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #11; idle;
 #9: "westnet-eastnet-ikev2b" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 west #
  # there should be only one IKE_INIT exchange created on west

--- a/testing/pluto/ikev2-ike-rekey-04/east.console.txt
+++ b/testing/pluto/ikev2-ike-rekey-04/east.console.txt
@@ -27,12 +27,12 @@ east #
 initdone
 east #
  ipsec showstates
-#12: "westnet-eastnet-ikev2a":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #8; idle;
+#12: "westnet-eastnet-ikev2a":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #8; idle;
 #12: "westnet-eastnet-ikev2a" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#13: "westnet-eastnet-ikev2b":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #8; idle;
+#13: "westnet-eastnet-ikev2b":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #8; idle;
 #13: "westnet-eastnet-ikev2b" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#8: "westnet-eastnet-ikev2c":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#14: "westnet-eastnet-ikev2c":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #8; idle;
+#8: "westnet-eastnet-ikev2c":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#14: "westnet-eastnet-ikev2c":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #8; idle;
 #14: "westnet-eastnet-ikev2c" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
 east #
  # there should be only one IKE_INIT exchange

--- a/testing/pluto/ikev2-ike-rekey-04/west.console.txt
+++ b/testing/pluto/ikev2-ike-rekey-04/west.console.txt
@@ -64,12 +64,12 @@ west #
  # confirm
 west #
  ipsec showstates # expect: IKE #1 Child #2 #3 #4
-#1: "westnet-eastnet-ikev2a":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "westnet-eastnet-ikev2a":500 ESTABLISHED_CHILD_SA (established Child SA); LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "westnet-eastnet-ikev2a":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "westnet-eastnet-ikev2a":500 established Child SA; LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "westnet-eastnet-ikev2a" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#3: "westnet-eastnet-ikev2b":500 ESTABLISHED_CHILD_SA (established Child SA); LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#3: "westnet-eastnet-ikev2b":500 established Child SA; LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #3: "westnet-eastnet-ikev2b" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#4: "westnet-eastnet-ikev2c":500 ESTABLISHED_CHILD_SA (established Child SA); LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#4: "westnet-eastnet-ikev2c":500 established Child SA; LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #4: "westnet-eastnet-ikev2c" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
 west #
  # wait for Child SAs to rekey
@@ -77,12 +77,12 @@ west #
  sleep 30
 west #
  ipsec showstates # expect: IKE #1 Child #5 #6 #7
-#1: "westnet-eastnet-ikev2a":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#5: "westnet-eastnet-ikev2a":500 ESTABLISHED_CHILD_SA (established Child SA); LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "westnet-eastnet-ikev2a":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#5: "westnet-eastnet-ikev2a":500 established Child SA; LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #5: "westnet-eastnet-ikev2a" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#6: "westnet-eastnet-ikev2b":500 ESTABLISHED_CHILD_SA (established Child SA); LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#6: "westnet-eastnet-ikev2b":500 established Child SA; LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #6: "westnet-eastnet-ikev2b" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#7: "westnet-eastnet-ikev2c":500 ESTABLISHED_CHILD_SA (established Child SA); LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#7: "westnet-eastnet-ikev2c":500 established Child SA; LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #7: "westnet-eastnet-ikev2c" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
 west #
  # wait for IKE SA to rekey
@@ -90,12 +90,12 @@ west #
  sleep 20
 west #
  ipsec showstates # expect: IKE #8 Child #9 #10 #11
-#8: "westnet-eastnet-ikev2a":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#9: "westnet-eastnet-ikev2a":500 ESTABLISHED_CHILD_SA (established Child SA); LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #8; idle;
+#8: "westnet-eastnet-ikev2a":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#9: "westnet-eastnet-ikev2a":500 established Child SA; LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #8; idle;
 #9: "westnet-eastnet-ikev2a" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#10: "westnet-eastnet-ikev2b":500 ESTABLISHED_CHILD_SA (established Child SA); LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #8; idle;
+#10: "westnet-eastnet-ikev2b":500 established Child SA; LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #8; idle;
 #10: "westnet-eastnet-ikev2b" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#11: "westnet-eastnet-ikev2c":500 ESTABLISHED_CHILD_SA (established Child SA); LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #8; idle;
+#11: "westnet-eastnet-ikev2c":500 established Child SA; LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #8; idle;
 #11: "westnet-eastnet-ikev2c" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
 west #
  # wait for Child SAs to rekey again
@@ -103,24 +103,24 @@ west #
  sleep 30
 west #
  ipsec showstates # expect: IKE #8 Child #12 #13 #14
-#8: "westnet-eastnet-ikev2a":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#12: "westnet-eastnet-ikev2a":500 ESTABLISHED_CHILD_SA (established Child SA); LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #8; idle;
+#8: "westnet-eastnet-ikev2a":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#12: "westnet-eastnet-ikev2a":500 established Child SA; LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #8; idle;
 #12: "westnet-eastnet-ikev2a" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#13: "westnet-eastnet-ikev2b":500 ESTABLISHED_CHILD_SA (established Child SA); LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #8; idle;
+#13: "westnet-eastnet-ikev2b":500 established Child SA; LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #8; idle;
 #13: "westnet-eastnet-ikev2b" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#14: "westnet-eastnet-ikev2c":500 ESTABLISHED_CHILD_SA (established Child SA); LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #8; idle;
+#14: "westnet-eastnet-ikev2c":500 established Child SA; LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #8; idle;
 #14: "westnet-eastnet-ikev2c" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
 west #
  echo done
 done
 west #
  ipsec showstates
-#8: "westnet-eastnet-ikev2a":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#12: "westnet-eastnet-ikev2a":500 ESTABLISHED_CHILD_SA (established Child SA); LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #8; idle;
+#8: "westnet-eastnet-ikev2a":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#12: "westnet-eastnet-ikev2a":500 established Child SA; LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #8; idle;
 #12: "westnet-eastnet-ikev2a" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#13: "westnet-eastnet-ikev2b":500 ESTABLISHED_CHILD_SA (established Child SA); LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #8; idle;
+#13: "westnet-eastnet-ikev2b":500 established Child SA; LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #8; idle;
 #13: "westnet-eastnet-ikev2b" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#14: "westnet-eastnet-ikev2c":500 ESTABLISHED_CHILD_SA (established Child SA); LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #8; idle;
+#14: "westnet-eastnet-ikev2c":500 established Child SA; LIVENESS in XXs; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #8; idle;
 #14: "westnet-eastnet-ikev2c" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
 west #
  # there should be only one IKE_INIT exchange

--- a/testing/pluto/ikev2-ike-rekey-05/east.console.txt
+++ b/testing/pluto/ikev2-ike-rekey-05/east.console.txt
@@ -32,13 +32,13 @@ east #
 #14: "westnet-eastnet-c", type=ESP, add_time=1234567890, inBytes=0, outBytes=0, maxBytes=2^63B, id='@west'
 east #
  ipsec showstates
-#13: "westnet-eastnet-a":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #17; idle;
+#13: "westnet-eastnet-a":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #17; idle;
 #13: "westnet-eastnet-a" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#15: "westnet-eastnet-b":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #17; idle;
+#15: "westnet-eastnet-b":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #17; idle;
 #15: "westnet-eastnet-b" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#14: "westnet-eastnet-c":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #17; idle;
+#14: "westnet-eastnet-c":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #17; idle;
 #14: "westnet-eastnet-c" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#17: "westnet-eastnet-c":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
+#17: "westnet-eastnet-c":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
 east #
  # there should be only one IKE_SA_INIT exchange
 east #

--- a/testing/pluto/ikev2-ike-rekey-05/west.console.txt
+++ b/testing/pluto/ikev2-ike-rekey-05/west.console.txt
@@ -74,12 +74,12 @@ west #
 #4: "westnet-eastnet-c", type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='@east'
 west #
  ipsec showstates
-#1: "westnet-eastnet-a":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "westnet-eastnet-a":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "westnet-eastnet-a":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "westnet-eastnet-a":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "westnet-eastnet-a" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
-#3: "westnet-eastnet-b":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#3: "westnet-eastnet-b":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #3: "westnet-eastnet-b" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
-#4: "westnet-eastnet-c":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#4: "westnet-eastnet-c":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #4: "westnet-eastnet-c" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 west #
  echo sleep 3m
@@ -97,12 +97,12 @@ west #
 #4: "westnet-eastnet-c", type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='@east'
 west #
  ipsec showstates
-#2: "westnet-eastnet-a":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #7; idle;
+#2: "westnet-eastnet-a":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #7; idle;
 #2: "westnet-eastnet-a" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
-#7: "westnet-eastnet-a":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#6: "westnet-eastnet-b":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #7; idle;
+#7: "westnet-eastnet-a":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#6: "westnet-eastnet-b":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #7; idle;
 #6: "westnet-eastnet-b" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#4: "westnet-eastnet-c":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #7; idle;
+#4: "westnet-eastnet-c":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #7; idle;
 #4: "westnet-eastnet-c" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 west #
  sleep 60
@@ -113,12 +113,12 @@ west #
 #9: "westnet-eastnet-c", type=ESP, add_time=1234567890, inBytes=0, outBytes=0, maxBytes=2^63B, id='@east'
 west #
  ipsec showstates
-#7: "westnet-eastnet-a":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#8: "westnet-eastnet-a":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #7; idle;
+#7: "westnet-eastnet-a":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#8: "westnet-eastnet-a":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #7; idle;
 #8: "westnet-eastnet-a" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#6: "westnet-eastnet-b":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #7; idle;
+#6: "westnet-eastnet-b":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #7; idle;
 #6: "westnet-eastnet-b" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#9: "westnet-eastnet-c":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #7; idle;
+#9: "westnet-eastnet-c":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #7; idle;
 #9: "westnet-eastnet-c" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
 west #
  sleep 60
@@ -140,12 +140,12 @@ west #
 #14: "westnet-eastnet-c", type=ESP, add_time=1234567890, inBytes=0, outBytes=0, maxBytes=2^63B, id='@east'
 west #
  ipsec showstates
-#13: "westnet-eastnet-a":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #17; idle;
+#13: "westnet-eastnet-a":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #17; idle;
 #13: "westnet-eastnet-a" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#17: "westnet-eastnet-a":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#15: "westnet-eastnet-b":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #17; idle;
+#17: "westnet-eastnet-a":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#15: "westnet-eastnet-b":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #17; idle;
 #15: "westnet-eastnet-b" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#14: "westnet-eastnet-c":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #17; idle;
+#14: "westnet-eastnet-c":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #17; idle;
 #14: "westnet-eastnet-c" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
 west #
  # there should be only one IKE_SA_INIT exchange

--- a/testing/pluto/ikev2-labeled-ipsec-01-ike-childless-enforcing/east.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-01-ike-childless-enforcing/east.console.txt
@@ -88,7 +88,7 @@ east #
  # The IKE SA should be associated with the template connection
 east #
  ipsec showstates
-#1: "labeled"[1] 192.1.2.45:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "labeled"[1][1] 192.1.2.45:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "labeled"[1] 192.1.2.45:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "labeled"[1][1] 192.1.2.45:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "labeled"[1][1] 192.1.2.45 esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 Traffic: ESPin=64B ESPout=64B ESPmax=2^63B 
 east #

--- a/testing/pluto/ikev2-labeled-ipsec-01-ike-childless-enforcing/west.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-01-ike-childless-enforcing/west.console.txt
@@ -138,7 +138,7 @@ west #
  # The IKE SA should be associated with the template connection
 west #
  ipsec showstates
-#1: "labeled"[1] 192.1.2.23:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "labeled"[1][1] 192.1.2.23:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "labeled"[1] 192.1.2.23:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "labeled"[1][1] 192.1.2.23:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "labeled"[1][1] 192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 Traffic: ESPin=64B ESPout=64B ESPmax=2^63B 
 west #

--- a/testing/pluto/ikev2-labeled-ipsec-01-ike-childless-permissive/east.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-01-ike-childless-permissive/east.console.txt
@@ -70,7 +70,7 @@ east #
  # The IKE SA should be associated with the template connection
 east #
  ipsec showstates
-#1: "labeled"[1] 192.1.2.45:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "labeled"[1][1] 192.1.2.45:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "labeled"[1] 192.1.2.45:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "labeled"[1][1] 192.1.2.45:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "labeled"[1][1] 192.1.2.45 esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 Traffic: ESPin=64B ESPout=64B ESPmax=2^63B 
 east #

--- a/testing/pluto/ikev2-labeled-ipsec-01-ike-childless-permissive/west.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-01-ike-childless-permissive/west.console.txt
@@ -120,7 +120,7 @@ west #
  # The IKE SA should be associated with the template connection
 west #
  ipsec showstates
-#1: "labeled"[1] 192.1.2.23:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "labeled"[1][1] 192.1.2.23:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "labeled"[1] 192.1.2.23:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "labeled"[1][1] 192.1.2.23:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "labeled"[1][1] 192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 Traffic: ESPin=64B ESPout=64B ESPmax=2^63B 
 west #

--- a/testing/pluto/ikev2-labeled-ipsec-01-ike-ondemand-enforcing/east.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-01-ike-ondemand-enforcing/east.console.txt
@@ -88,7 +88,7 @@ east #
  # The IKE SA should be associated with the template connection
 east #
  ipsec showstates
-#1: "labeled"[1] 192.1.2.45:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "labeled"[1][1] 192.1.2.45:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "labeled"[1] 192.1.2.45:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "labeled"[1][1] 192.1.2.45:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "labeled"[1][1] 192.1.2.45 esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 Traffic: ESPin=64B ESPout=64B ESPmax=2^63B 
 east #

--- a/testing/pluto/ikev2-labeled-ipsec-01-ike-ondemand-enforcing/west.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-01-ike-ondemand-enforcing/west.console.txt
@@ -131,7 +131,7 @@ west #
  # The IKE SA should be associated with the template connection
 west #
  ipsec showstates
-#1: "labeled"[1] 192.1.2.23:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "labeled"[1][1] 192.1.2.23:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "labeled"[1] 192.1.2.23:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "labeled"[1][1] 192.1.2.23:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "labeled"[1][1] 192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 Traffic: ESPin=64B ESPout=64B ESPmax=2^63B 
 west #

--- a/testing/pluto/ikev2-labeled-ipsec-01-ike-ondemand-permissive/east.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-01-ike-ondemand-permissive/east.console.txt
@@ -70,7 +70,7 @@ east #
  # The IKE SA should be associated with the template connection
 east #
  ipsec showstates
-#1: "labeled"[1] 192.1.2.45:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "labeled"[1][1] 192.1.2.45:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "labeled"[1] 192.1.2.45:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "labeled"[1][1] 192.1.2.45:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "labeled"[1][1] 192.1.2.45 esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 Traffic: ESPin=64B ESPout=64B ESPmax=2^63B 
 east #

--- a/testing/pluto/ikev2-labeled-ipsec-01-ike-ondemand-permissive/west.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-01-ike-ondemand-permissive/west.console.txt
@@ -113,7 +113,7 @@ west #
  # The IKE SA should be associated with the template connection
 west #
  ipsec showstates
-#1: "labeled"[1] 192.1.2.23:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "labeled"[1][1] 192.1.2.23:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "labeled"[1] 192.1.2.23:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "labeled"[1][1] 192.1.2.23:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "labeled"[1][1] 192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 Traffic: ESPin=64B ESPout=64B ESPmax=2^63B 
 west #

--- a/testing/pluto/ikev2-labeled-ipsec-03-multi-acquires-enforcing/west.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-03-multi-acquires-enforcing/west.console.txt
@@ -76,8 +76,8 @@ Bare Shunt list:
  
 west #
  ipsec showstates
-#1: "labeled"[1] 192.1.2.23:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "labeled"[1][1] 192.1.2.23:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "labeled"[1] 192.1.2.23:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "labeled"[1][1] 192.1.2.23:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "labeled"[1][1] 192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=40B ESPout=60B ESPmax=2^63B 
 west #
  ipsec _kernel state
@@ -140,8 +140,8 @@ Bare Shunt list:
  
 west #
  ipsec showstates
-#1: "labeled"[1] 192.1.2.23:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "labeled"[1][1] 192.1.2.23:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "labeled"[1] 192.1.2.23:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "labeled"[1][1] 192.1.2.23:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "labeled"[1][1] 192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=40B ESPout=60B ESPmax=2^63B 
 west #
  ipsec _kernel state

--- a/testing/pluto/ikev2-labeled-ipsec-03-multi-acquires-permissive/west.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-03-multi-acquires-permissive/west.console.txt
@@ -74,8 +74,8 @@ Bare Shunt list:
  
 west #
  ipsec showstates
-#1: "labeled"[1] 192.1.2.23:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "labeled"[1][1] 192.1.2.23:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "labeled"[1] 192.1.2.23:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "labeled"[1][1] 192.1.2.23:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "labeled"[1][1] 192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=40B ESPout=60B ESPmax=2^63B 
 west #
  ipsec _kernel state
@@ -160,10 +160,10 @@ Bare Shunt list:
  
 west #
  ipsec showstates
-#1: "labeled"[1] 192.1.2.23:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "labeled"[1][1] 192.1.2.23:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "labeled"[1] 192.1.2.23:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "labeled"[1][1] 192.1.2.23:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "labeled"[1][1] 192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=40B ESPout=60B ESPmax=2^63B 
-#3: "labeled"[1][2] 192.1.2.23:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#3: "labeled"[1][2] 192.1.2.23:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #3: "labeled"[1][2] 192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=377B ESPout=429B ESPmax=2^63B 
 west #
  ipsec _kernel state

--- a/testing/pluto/ikev2-labeled-ipsec-03-multi-acquires-rekey/west.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-03-multi-acquires-rekey/west.console.txt
@@ -74,8 +74,8 @@ Bare Shunt list:
  
 west #
  ipsec showstates
-#1: "labeled"[1] 192.1.2.23:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "labeled"[1][1] 192.1.2.23:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "labeled"[1] 192.1.2.23:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "labeled"[1][1] 192.1.2.23:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "labeled"[1][1] 192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=40B ESPout=60B ESPmax=2^63B 
 west #
  ipsec _kernel state
@@ -160,10 +160,10 @@ Bare Shunt list:
  
 west #
  ipsec showstates
-#1: "labeled"[1] 192.1.2.23:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "labeled"[1][1] 192.1.2.23:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "labeled"[1] 192.1.2.23:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "labeled"[1][1] 192.1.2.23:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "labeled"[1][1] 192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=40B ESPout=60B ESPmax=2^63B 
-#3: "labeled"[1][2] 192.1.2.23:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#3: "labeled"[1][2] 192.1.2.23:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #3: "labeled"[1][2] 192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=377B ESPout=325B ESPmax=2^63B 
 west #
  ipsec _kernel state

--- a/testing/pluto/ikev2-labeled-ipsec-05-any/east.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-05-any/east.console.txt
@@ -101,9 +101,9 @@ east #
  # The IKE SA should be associated with the template connection
 east #
  ipsec showstates | sed -e 's/=[1-9][0-9]*B/=<NNN>B/g'
-#1: "labeled"[1] 192.1.3.209:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "labeled"[1][1] 192.1.3.209:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "labeled"[1] 192.1.3.209:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "labeled"[1][1] 192.1.3.209:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "labeled"[1][1] 192.1.3.209 esp.ESPSPIi@192.1.3.209 esp.ESPSPIi@192.1.2.23 tun.0@192.1.3.209 tun.0@192.1.2.23 Traffic: ESPin=<NNN>B ESPout=0B ESPmax=2^63B 
-#3: "labeled"[1][2] 192.1.3.209:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#3: "labeled"[1][2] 192.1.3.209:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #3: "labeled"[1][2] 192.1.3.209 esp.ESPSPIi@192.1.3.209 esp.ESPSPIi@192.1.2.23 tun.0@192.1.3.209 tun.0@192.1.2.23 Traffic: ESPin=0B ESPout=<NNN>B ESPmax=2^63B 
 east #

--- a/testing/pluto/ikev2-labeled-ipsec-05-any/road.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-05-any/road.console.txt
@@ -156,9 +156,9 @@ road #
  # The IKE SA should be associated with the template connection
 road #
  ipsec showstates | sed -e 's/=[1-9][0-9]*B/=<NNN>B/g'
-#1: "labeled"[1] 192.1.2.23:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "labeled"[1][1] 192.1.2.23:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "labeled"[1] 192.1.2.23:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "labeled"[1][1] 192.1.2.23:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "labeled"[1][1] 192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=0B ESPout=<NNN>B ESPmax=2^63B 
-#3: "labeled"[1][2] 192.1.2.23:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#3: "labeled"[1][2] 192.1.2.23:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #3: "labeled"[1][2] 192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=<NNN>B ESPout=0B ESPmax=2^63B 
 road #

--- a/testing/pluto/ikev2-labeled-ipsec-06-reauth-ike-acquire/east.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-06-reauth-ike-acquire/east.console.txt
@@ -94,10 +94,10 @@ east #
  # The IKE SA should be associated with the template connection
 east #
  ipsec showstates
-#1: "labeled"[1] 192.1.2.45:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; idle;
-#3: "labeled"[1] 192.1.2.45:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "labeled"[1][1] 192.1.2.45:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; IKE SA #1; idle;
+#1: "labeled"[1] 192.1.2.45:500 established IKE SA; REKEY in XXs; REPLACE in XXs; idle;
+#3: "labeled"[1] 192.1.2.45:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "labeled"[1][1] 192.1.2.45:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; IKE SA #1; idle;
 #2: "labeled"[1][1] 192.1.2.45 esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 Traffic: ESPin=64B ESPout=64B ESPmax=2^63B 
-#4: "labeled"[1][2] 192.1.2.45:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; IKE SA #3; idle;
+#4: "labeled"[1][2] 192.1.2.45:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; IKE SA #3; idle;
 #4: "labeled"[1][2] 192.1.2.45 esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 Traffic: ESPin=269B ESPout=257B ESPmax=2^63B 
 east #

--- a/testing/pluto/ikev2-labeled-ipsec-06-reauth-ike-acquire/west.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-06-reauth-ike-acquire/west.console.txt
@@ -65,7 +65,7 @@ west #
 "labeled"[1] 192.1.2.23 #1: calling REAUTH event handler
 west #
  ../../guestbin/wait-for.sh --match PARENT_I1 -- ipsec whack --showstates
-#3: "labeled"[1] 192.1.2.23:500 IKE_SA_INIT_I (sent IKE_SA_INIT request); RETRANSMIT in XXs; idle;
+#3: "labeled"[1] 192.1.2.23:500 sent IKE_SA_INIT request; RETRANSMIT in XXs; idle;
 west #
  # let another on-demand label establish
 west #
@@ -165,10 +165,10 @@ west #
  # The IKE SA should be associated with the template connection
 west #
  ipsec showstates
-#1: "labeled"[1] 192.1.2.23:500 ESTABLISHED_IKE_SA (established IKE SA); REPLACE in XXs; idle;
-#3: "labeled"[1] 192.1.2.23:500 ESTABLISHED_IKE_SA (established IKE SA); REPLACE in XXs; newest; idle;
-#2: "labeled"[1][1] 192.1.2.23:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; IKE SA #1; idle;
+#1: "labeled"[1] 192.1.2.23:500 established IKE SA; REPLACE in XXs; idle;
+#3: "labeled"[1] 192.1.2.23:500 established IKE SA; REPLACE in XXs; newest; idle;
+#2: "labeled"[1][1] 192.1.2.23:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; IKE SA #1; idle;
 #2: "labeled"[1][1] 192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 Traffic: ESPin=64B ESPout=64B ESPmax=2^63B 
-#4: "labeled"[1][2] 192.1.2.23:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; IKE SA #3; idle;
+#4: "labeled"[1][2] 192.1.2.23:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; IKE SA #3; idle;
 #4: "labeled"[1][2] 192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 Traffic: ESPin=257B ESPout=269B ESPmax=2^63B 
 west #

--- a/testing/pluto/ikev2-labeled-ipsec-06-rekey-ike-acquire/east.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-06-rekey-ike-acquire/east.console.txt
@@ -68,8 +68,8 @@ east #
  # The IKE SA should be associated with the template connection
 east #
  ipsec showstates
-#1: "labeled"[1] 192.1.2.45:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; idle;
-#2: "labeled"[1] 192.1.2.45:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#3: "labeled"[1][1] 192.1.2.45:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #2; idle;
+#1: "labeled"[1] 192.1.2.45:500 established IKE SA; REKEY in XXs; REPLACE in XXs; idle;
+#2: "labeled"[1] 192.1.2.45:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#3: "labeled"[1][1] 192.1.2.45:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #2; idle;
 #3: "labeled"[1][1] 192.1.2.45 esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 Traffic: ESPin=64B ESPout=64B ESPmax=2^63B 
 east #

--- a/testing/pluto/ikev2-labeled-ipsec-06-rekey-ike-acquire/west.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-06-rekey-ike-acquire/west.console.txt
@@ -58,7 +58,7 @@ west #
  ipsec whack --rekey-ike --asynchronous --name labeled
 west #
  ../../guestbin/wait-for.sh --match REKEY_IKE_I1 -- ipsec whack --showstates
-#2: "labeled"[1] 192.1.2.23:500 REKEY_IKE_I1 (sent CREATE_CHILD_SA request to rekey IKE SA); idle;
+#2: "labeled"[1] 192.1.2.23:500 sent CREATE_CHILD_SA request to rekey IKE SA; idle;
 west #
  # Trigger traffic using the predefined ping_t context.  Because the
 west #
@@ -139,9 +139,9 @@ west #
  # The IKE SA should be associated with the template connection
 west #
  ipsec showstates
-#1: "labeled"[1] 192.1.2.23:500 ESTABLISHED_IKE_SA (established IKE SA); RETRANSMIT in XXs; REPLACE in XXs; idle;
-#2: "labeled"[1] 192.1.2.23:500 REKEY_IKE_I1 (sent CREATE_CHILD_SA request to rekey IKE SA); idle;
-#3: "labeled"[1] 192.1.2.23:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#4: "labeled"[1][1] 192.1.2.23:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #3; idle;
+#1: "labeled"[1] 192.1.2.23:500 established IKE SA; RETRANSMIT in XXs; REPLACE in XXs; idle;
+#2: "labeled"[1] 192.1.2.23:500 sent CREATE_CHILD_SA request to rekey IKE SA; idle;
+#3: "labeled"[1] 192.1.2.23:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#4: "labeled"[1][1] 192.1.2.23:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #3; idle;
 #4: "labeled"[1][1] 192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 Traffic: ESPin=64B ESPout=64B ESPmax=2^63B 
 west #

--- a/testing/pluto/ikev2-labeled-ipsec-06-rekey-ike-acquire/west.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-06-rekey-ike-acquire/west.console.txt
@@ -57,7 +57,7 @@ IMPAIR: will drop outbound message 1
 west #
  ipsec whack --rekey-ike --asynchronous --name labeled
 west #
- ../../guestbin/wait-for.sh --match REKEY_IKE_I1 -- ipsec whack --showstates
+ ../../guestbin/wait-for.sh --match 'request to rekey' -- ipsec whack --showstates
 #2: "labeled"[1] 192.1.2.23:500 sent CREATE_CHILD_SA request to rekey IKE SA; idle;
 west #
  # Trigger traffic using the predefined ping_t context.  Because the

--- a/testing/pluto/ikev2-labeled-ipsec-06-rekey-ike-acquire/westrun.sh
+++ b/testing/pluto/ikev2-labeled-ipsec-06-rekey-ike-acquire/westrun.sh
@@ -9,7 +9,7 @@ ipsec _kernel policy
 # retransmit, scheduled for 10s, will unstick it.
 ipsec whack --impair drop_outbound:1
 ipsec whack --rekey-ike --asynchronous --name labeled
-../../guestbin/wait-for.sh --match REKEY_IKE_I1 -- ipsec whack --showstates
+../../guestbin/wait-for.sh --match 'request to rekey' -- ipsec whack --showstates
 
 # Trigger traffic using the predefined ping_t context.  Because the
 # rekey SA is stuck it will start on the old #1 IKE SA's queue and

--- a/testing/pluto/ikev2-rw-multiple-subnets-4-mismatch-split-up/road.console.txt
+++ b/testing/pluto/ikev2-rw-multiple-subnets-4-mismatch-split-up/road.console.txt
@@ -78,10 +78,10 @@ road #
 #4: "road/0x3", type=ESP, add_time=1234567890, inBytes=0, outBytes=0, maxBytes=2^63B, id='C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org'
 road #
  ipsec showstates
-#1: "road/0x1":4500 ESTABLISHED_IKE_SA (established IKE SA); NAT_KEEPALIVE in XXs; REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "road/0x1":4500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "road/0x1":4500 established IKE SA; NAT_KEEPALIVE in XXs; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "road/0x1":4500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "road/0x1" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#4: "road/0x3":4500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#4: "road/0x3":4500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #4: "road/0x3" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
 road #
  echo done

--- a/testing/pluto/ikev2-rw-multiple-subnets-4-mismatch/road.console.txt
+++ b/testing/pluto/ikev2-rw-multiple-subnets-4-mismatch/road.console.txt
@@ -77,18 +77,18 @@ road #
 #9: "road/0x8", type=ESP, add_time=1234567890, inBytes=0, outBytes=0, maxBytes=2^63B, id='C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org'
 road #
  ipsec showstates
-#1: "road/0x1":4500 ESTABLISHED_IKE_SA (established IKE SA); NAT_KEEPALIVE in XXs; REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "road/0x1":4500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "road/0x1":4500 established IKE SA; NAT_KEEPALIVE in XXs; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "road/0x1":4500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "road/0x1" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#4: "road/0x3":4500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#4: "road/0x3":4500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #4: "road/0x3" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#6: "road/0x5":4500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#6: "road/0x5":4500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #6: "road/0x5" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#7: "road/0x6":4500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#7: "road/0x6":4500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #7: "road/0x6" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#8: "road/0x7":4500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#8: "road/0x7":4500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #8: "road/0x7" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#9: "road/0x8":4500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#9: "road/0x8":4500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #9: "road/0x8" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
 road #
  echo done

--- a/testing/pluto/ikev2-rw-multiple-subnets-5-mismatch-frst/road.console.txt
+++ b/testing/pluto/ikev2-rw-multiple-subnets-5-mismatch-frst/road.console.txt
@@ -53,10 +53,10 @@ road #
 #4: "road/0x3", type=ESP, add_time=1234567890, inBytes=0, outBytes=0, maxBytes=2^63B, id='C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org'
 road #
  ipsec showstates
-#1: "road/0x1":4500 ESTABLISHED_IKE_SA (established IKE SA); NAT_KEEPALIVE in XXs; REKEY in XXs; REPLACE in XXs; newest; idle;
-#3: "road/0x2":4500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "road/0x1":4500 established IKE SA; NAT_KEEPALIVE in XXs; REKEY in XXs; REPLACE in XXs; newest; idle;
+#3: "road/0x2":4500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #3: "road/0x2" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#4: "road/0x3":4500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#4: "road/0x3":4500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #4: "road/0x3" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
 road #
  echo done

--- a/testing/pluto/ikev2-xfrmi-11-default-manual-route/east.console.txt
+++ b/testing/pluto/ikev2-xfrmi-11-default-manual-route/east.console.txt
@@ -136,8 +136,8 @@ State Information: DDoS cookies not required, Accepting new IKE connections
 IKE SAs: total(1), half-open(0), open(0), authenticated(1), anonymous(0)
 IPsec SAs: total(1), authenticated(1), anonymous(0)
  
-#1: "westnet-eastnet":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "westnet-eastnet":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "westnet-eastnet":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "westnet-eastnet":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "westnet-eastnet" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
  
 Bare Shunt list:

--- a/testing/pluto/ikev2-xfrmi-11-default-manual-route/west.console.txt
+++ b/testing/pluto/ikev2-xfrmi-11-default-manual-route/west.console.txt
@@ -185,8 +185,8 @@ State Information: DDoS cookies not required, Accepting new IKE connections
 IKE SAs: total(1), half-open(0), open(0), authenticated(1), anonymous(0)
 IPsec SAs: total(1), authenticated(1), anonymous(0)
  
-#1: "west":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "west":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "west":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "west":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "west" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
  
 Bare Shunt list:

--- a/testing/pluto/interop-ikev2-strongswan-15-child-sa-responder/west.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-15-child-sa-responder/west.console.txt
@@ -141,12 +141,12 @@ west #
 "westnet-eastnet-ikev2c":   IKE algorithms: 3DES_CBC-HMAC_MD5-MODP2048
 "westnet-eastnet-ikev2c":   ESP algorithms: AES_CBC_128-HMAC_SHA2_512_256
 "westnet-eastnet-ikev2c":   ESP algorithm newest: AES_CBC_128-HMAC_SHA2_512_256; pfsgroup=<N/A>
-#1: "westnet-eastnet-ikev2a":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "westnet-eastnet-ikev2a":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "westnet-eastnet-ikev2a":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "westnet-eastnet-ikev2a":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "westnet-eastnet-ikev2a" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
-#3: "westnet-eastnet-ikev2b":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#3: "westnet-eastnet-ikev2b":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #3: "westnet-eastnet-ikev2b" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
-#4: "westnet-eastnet-ikev2c":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#4: "westnet-eastnet-ikev2c":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #4: "westnet-eastnet-ikev2c" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
 west #
  echo done

--- a/testing/pluto/interop-ikev2-strongswan-29-rekey/east.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-29-rekey/east.console.txt
@@ -37,9 +37,9 @@ east #
 "westnet-eastnet-ikev2":   conn serial: $1;
 "westnet-eastnet-ikev2":   IKEv2 algorithm newest: AES_CBC_256-HMAC_SHA2_512-MODP2048
 "westnet-eastnet-ikev2":   ESP algorithm newest: AES_CBC_256-HMAC_SHA2_512_256; pfsgroup=<Phase1>
-#2: "westnet-eastnet-ikev2":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #4; idle;
+#2: "westnet-eastnet-ikev2":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #4; idle;
 #2: "westnet-eastnet-ikev2" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=336B ESPout=336B ESPmax=2^63B 
-#4: "westnet-eastnet-ikev2":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
+#4: "westnet-eastnet-ikev2":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
 east #
  if [ -f /var/run/charon.pid -o -f /var/run/strongswan/charon.pid ]; then strongswan status ; fi
 east #

--- a/testing/pluto/interop-ikev2-strongswan-29-responder-rekey/east.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-29-responder-rekey/east.console.txt
@@ -36,9 +36,9 @@ east #
 "westnet-eastnet-ikev2":   IKEv2 algorithm newest: AES_CBC_256-HMAC_SHA2_512-MODP2048
 "westnet-eastnet-ikev2":   ESP algorithms: AES_CBC_256-HMAC_SHA2_512_256-MODP2048
 "westnet-eastnet-ikev2":   ESP algorithm newest: AES_CBC_256-HMAC_SHA2_512_256; pfsgroup=<Phase1>
-#2: "westnet-eastnet-ikev2":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #4; idle;
+#2: "westnet-eastnet-ikev2":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #4; idle;
 #2: "westnet-eastnet-ikev2" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=252B ESPout=252B ESPmax=2^63B 
-#4: "westnet-eastnet-ikev2":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
+#4: "westnet-eastnet-ikev2":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
 east #
  if [ -f /var/run/charon.pid -o -f /var/run/strongswan/charon.pid ]; then strongswan status ; fi
 east #

--- a/testing/pluto/interop-ikev2-strongswan-35-initiator-rekey/west.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-35-initiator-rekey/west.console.txt
@@ -94,8 +94,8 @@ west #
 "westnet-eastnet":   IKEv2 algorithm newest: AES_CBC_256-HMAC_SHA2_512-MODP2048
 "westnet-eastnet":   ESP algorithms: AES_CBC_256-HMAC_SHA2_512_256-MODP2048
 "westnet-eastnet":   ESP algorithm newest: AES_CBC_256-HMAC_SHA2_512_256; pfsgroup=<Phase1>
-#1: "westnet-eastnet":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#3: "westnet-eastnet":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "westnet-eastnet":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#3: "westnet-eastnet":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #3: "westnet-eastnet" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.2.45 tun.0@192.1.2.23 tun.0@192.1.2.45 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 west #
  # give time to strongswan to expire old one

--- a/testing/pluto/newoe-07-ike-replace-initiator/road.console.txt
+++ b/testing/pluto/newoe-07-ike-replace-initiator/road.console.txt
@@ -39,9 +39,9 @@ road #
  # parent state must be #3 and the latest ISAKMP
 road #
  ipsec showstates
-#2: "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #3; idle;
+#2: "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #3; idle;
 #2: "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=0B ESPout=0B ESPmax=2^63B 
-#3: "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
+#3: "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
 road #
  ipsec whack --trafficstatus
 #2: "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23, type=ESP, add_time=1234567890, inBytes=0, outBytes=0, maxBytes=2^63B, id='ID_NULL'

--- a/testing/pluto/newoe-27-replace-sa-auth-authnull/east.console.txt
+++ b/testing/pluto/newoe-27-replace-sa-auth-authnull/east.console.txt
@@ -33,7 +33,7 @@ east #
  # additional 'authenticated' partial state lingers
 east #
  ipsec showstates
-#1: "authenticated"[1] 192.1.3.209:500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "authenticated"[1] 192.1.3.209:500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "authenticated"[1] 192.1.3.209:500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "authenticated"[1] 192.1.3.209:500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "authenticated"[1] 192.1.3.209 esp.ESPSPIi@192.1.3.209 esp.ESPSPIi@192.1.2.23 tun.0@192.1.3.209 tun.0@192.1.2.23 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 east #

--- a/testing/pluto/pluto-rekey-01/west.console.txt
+++ b/testing/pluto/pluto-rekey-01/west.console.txt
@@ -52,7 +52,7 @@ west #
 "westnet-eastnet-ipv4-psk-ikev2" #3: initiating IKEv1 Main Mode connection to replace #1
 west #
  ../../guestbin/wait-for.sh --match '#3: .* SA established' -- ipsec whack --showstates
-#3: "westnet-eastnet-ipv4-psk-ikev2":500 STATE_MAIN_I4 (ISAKMP SA established); REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
+#3: "westnet-eastnet-ipv4-psk-ikev2":500 ISAKMP SA established; REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
 west #
  # because both ends are fighting over who is establishing the ISAKMP
 west #

--- a/testing/pluto/whack-delete-05-responder-ikev1/east.console.txt
+++ b/testing/pluto/whack-delete-05-responder-ikev1/east.console.txt
@@ -11,12 +11,20 @@ east #
  echo "initdone"
 initdone
 east #
+ # Confirm that east is trying to revive; note that with IKEv1, the
+east #
+ # Child (IPsec) SAs, and then the IKE (IPsec) SA gets deleted.  The
+east #
+ # below is the Child SA trying to revive using the doomed IKE SA.
+east #
+ # When the IKE SA is deleted, there'll be a further revival but with a
+east #
+ # few seconds delay.
+east #
+ ../../guestbin/wait-for-pluto.sh --match '#2: connection is supposed to remain up'
+"west-east-auto" #2: connection is supposed to remain up; revival attempt 1 scheduled in 0 seconds
+east #
  # There should be no IKE SA and no IPsec SA
 east #
  ipsec trafficstatus
-east #
- # east howvever, should be attempting to connect to west because it has auto=start
-east #
- ipsec status |grep RETRANSMIT | sed "s/RETRANSMIT in .*$/RETRANSMIT in .../"
-#5: "west-east-auto":500 sent Main Mode request; RETRANSMIT in ...
 east #

--- a/testing/pluto/whack-delete-05-responder-ikev1/east.console.txt
+++ b/testing/pluto/whack-delete-05-responder-ikev1/east.console.txt
@@ -18,5 +18,5 @@ east #
  # east howvever, should be attempting to connect to west because it has auto=start
 east #
  ipsec status |grep RETRANSMIT | sed "s/RETRANSMIT in .*$/RETRANSMIT in .../"
-#5: "west-east-auto":500 STATE_MAIN_I1 (sent Main Mode request); RETRANSMIT in ...
+#5: "west-east-auto":500 sent Main Mode request; RETRANSMIT in ...
 east #

--- a/testing/pluto/whack-delete-05-responder-ikev2/east.console.txt
+++ b/testing/pluto/whack-delete-05-responder-ikev2/east.console.txt
@@ -18,7 +18,7 @@ east #
  # only on east, pluto should be attempting to connect to west because it has auto=start
 east #
  ipsec showstates
-#3: "west-east-auto":500 IKE_SA_INIT_I (sent IKE_SA_INIT request); RETRANSMIT in XXs; idle;
+#3: "west-east-auto":500 sent IKE_SA_INIT request; RETRANSMIT in XXs; idle;
 #3: pending Child SA for "west-east-auto"
 east #
  # confirm the revive conn code triggered on east

--- a/testing/pluto/whack-deleteid-01-psk-ikev1/east.console.txt
+++ b/testing/pluto/whack-deleteid-01-psk-ikev1/east.console.txt
@@ -13,8 +13,8 @@ east #
 initdone
 east #
  ipsec showstates
-#1: "road-eastnet-psk"[1] 192.1.3.209:500 STATE_AGGR_R2 (ISAKMP SA established); REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
-#2: "road-eastnet-psk"[1] 192.1.3.209:500 STATE_QUICK_R2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#1: "road-eastnet-psk"[1] 192.1.3.209:500 ISAKMP SA established; REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
+#2: "road-eastnet-psk"[1] 192.1.3.209:500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #2: "road-eastnet-psk"[1] 192.1.3.209 esp.ESPSPIi@192.1.3.209 esp.ESPSPIi@192.1.2.23 tun.0@192.1.3.209 tun.0@192.1.2.23 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 east #
  ipsec trafficstatus

--- a/testing/pluto/whack-deleteid-01-psk-ikev2/east.console.txt
+++ b/testing/pluto/whack-deleteid-01-psk-ikev2/east.console.txt
@@ -13,8 +13,8 @@ east #
 initdone
 east #
  ipsec showstates
-#1: "westnet-eastnet-ipv4-psk-ikev2":500 ESTABLISHED_IKE_SA (established IKE SA); REKEY in XXs; REPLACE in XXs; newest; idle;
-#2: "westnet-eastnet-ipv4-psk-ikev2":500 ESTABLISHED_CHILD_SA (established Child SA); REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
+#1: "westnet-eastnet-ipv4-psk-ikev2":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
+#2: "westnet-eastnet-ipv4-psk-ikev2":500 established Child SA; REKEY in XXs; REPLACE in XXs; newest; eroute owner; IKE SA #1; idle;
 #2: "westnet-eastnet-ipv4-psk-ikev2" esp.ESPSPIi@192.1.2.45 esp.ESPSPIi@192.1.2.23 tun.0@192.1.2.45 tun.0@192.1.2.23 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B 
 east #
  ipsec trafficstatus

--- a/testing/pluto/whack-deleteuser-01/east.console.txt
+++ b/testing/pluto/whack-deleteuser-01/east.console.txt
@@ -13,8 +13,8 @@ east #
 initdone
 east #
  ipsec showstates
-#1: "xauth-road-eastnet"[1] 192.1.3.209:500 STATE_MAIN_R3 (ISAKMP SA established); REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
-#2: "xauth-road-eastnet"[1] 192.1.3.209:500 STATE_QUICK_R2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#1: "xauth-road-eastnet"[1] 192.1.3.209:500 ISAKMP SA established; REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
+#2: "xauth-road-eastnet"[1] 192.1.3.209:500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #2: "xauth-road-eastnet"[1] 192.1.3.209 esp.ESPSPIi@192.1.3.209 esp.ESPSPIi@192.1.2.23 tun.0@192.1.3.209 tun.0@192.1.2.23 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B username=use1
 east #
  ipsec trafficstatus

--- a/testing/pluto/xauth-pluto-03/road.console.txt
+++ b/testing/pluto/xauth-pluto-03/road.console.txt
@@ -40,8 +40,8 @@ road #
  # note there should NOT be any incomplete IKE SA attempting to do ModeCFG
 road #
  ipsec showstates
-#1: "xauth-road-eastnet":500 STATE_MAIN_I4 (ISAKMP SA established); REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
-#2: "xauth-road-eastnet":500 STATE_QUICK_I2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#1: "xauth-road-eastnet":500 ISAKMP SA established; REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
+#2: "xauth-road-eastnet":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #2: "xauth-road-eastnet" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B username=use1
 road #
  echo done

--- a/testing/pluto/xauth-pluto-04/road.console.txt
+++ b/testing/pluto/xauth-pluto-04/road.console.txt
@@ -48,8 +48,8 @@ road #
  # note there should NOT be any incomplete IKE SA attempting to do ModeCFG or EVENT_RETRANSMIT
 road #
  ipsec showstates
-#1: "xauth-road-eastnet-psk":500 STATE_AGGR_I2 (ISAKMP SA established); REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
-#2: "xauth-road-eastnet-psk":500 STATE_QUICK_I2 (IPsec SA established); REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
+#1: "xauth-road-eastnet-psk":500 ISAKMP SA established; REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
+#2: "xauth-road-eastnet-psk":500 IPsec SA established; REPLACE in XXs; newest; eroute owner; ISAKMP SA #1; idle;
 #2: "xauth-road-eastnet-psk" esp.ESPSPIi@192.1.2.23 esp.ESPSPIi@192.1.3.209 tun.0@192.1.2.23 tun.0@192.1.3.209 Traffic: ESPin=84B ESPout=84B ESPmax=2^63B username=use2
 road #
  echo done

--- a/testing/pluto/xauth-pluto-29-nopw/road.console.txt
+++ b/testing/pluto/xauth-pluto-29-nopw/road.console.txt
@@ -71,8 +71,8 @@ road #
  # note there should NOT be any incomplete IKE SA attempting to do ModeCFG or EVENT_RETRANSMIT
 road #
  ipsec status |grep STATE
-#2: "xauth-road-eastnet-psk":500 STATE_AGGR_I2 (sent AI2, ISAKMP SA established); REKEY in XXs; REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
-#3: "xauth-road-eastnet-psk":500 STATE_QUICK_I2 (sent QI2, IPsec SA established); REKEY in XXs; REPLACE in XXs; newest; eroute owner; ISAKMP SA #2; idle;
+#2: "xauth-road-eastnet-psk":500 sent AI2, ISAKMP SA established; REKEY in XXs; REPLACE in XXs; newest; lastdpd=-1s(seq in:0 out:0); idle;
+#3: "xauth-road-eastnet-psk":500 sent QI2, IPsec SA established; REKEY in XXs; REPLACE in XXs; newest; eroute owner; ISAKMP SA #2; idle;
 road #
  echo done
 done


### PR DESCRIPTION
Following the suggestion in issue #1670, I have updated the ipsec status output to remove internal all-caps state names. 

To prevent regressions, I have also updated approximately 93 test scripts and console output files in testing/pluto/ to match the new format.