### PR TITLE
Remove redundancy from configs/clear-or-private.in

### DIFF
--- a/configs/clear-or-private.in
+++ b/configs/clear-or-private.in
@@ -1,8 +1,3 @@
-# This file defines the set of CIDRs (network/mask-length) to which
-# we will communicate in the clear, or, if the other side initiates IPSEC,
-# using encryption.  This behaviour is also called "Opportunistic Responder".
-# One IPv4 or IPv6 CIDR per line.
-
 # This file defines the set of network destinations for which
 # communications will be in the clear, or if the other side initiates IPsec
 # to use, will be encrypted on their request. This behaviour is also called


### PR DESCRIPTION
I was browsing through some config files on my machine, and noticed `configs/clear-or-private.in` repeats the same information twice. I looked through the commit history and to find out which paragraph was added later, so that I know which one to remove. I could not find any contributors guideline, so please let me know if you have any comments.  