### PR TITLE
negotiationshunt: make hold an alias for drop

### DIFF
--- a/configs/d.ipsec.conf/conn/negotiationshunt.xml
+++ b/configs/d.ipsec.conf/conn/negotiationshunt.xml
@@ -5,7 +5,7 @@
   <listitem>
     <para>
       What to do with packets during the IKE negotiation.  This should
-      almost always be left to the default &hold; value to avoid
+      almost always be left to the default &drop; value to avoid
       cleartext packet leaking.  The only reason to set this to &pass;
       is if plaintext service availability is more important than
       service security or privacy, a scenario that also implies
@@ -13,7 +13,7 @@
       <option>authby=%null</option> using Opportunistic Encryption.
     </para>
     <para>
-      The default is &hold;.
+      The default is &drop;.
     </para>
   </listitem>
 </varlistentry>

--- a/configs/d.ipsec.conf/oe_conns.example
+++ b/configs/d.ipsec.conf/oe_conns.example
@@ -33,7 +33,7 @@ conn private
      leftid=%null
      rightid=%null
      right=%opportunisticgroup
-     negotiationshunt=hold
+     negotiationshunt=drop
      failureshunt=drop
      auto=ondemand
 

--- a/docs/examples/oe-authnull.conf
+++ b/docs/examples/oe-authnull.conf
@@ -1,8 +1,8 @@
 # /etc/ipsec.d/oe-authnull.conf
 #
 # Example file for Opportunstic Encryption using Auth NULL
-# During negotiation, hold traffic. On IKE Auth NULL failure, fail open
-# Traffic is held until IKE has failed or succeeded
+# During negotiation, drop traffic. On IKE Auth NULL failure, fail open
+# Traffic is dropped until IKE has failed or succeeded
 # Because it uses Auth NULL, there is no protection against active MITM attacks
 #
 # See also oe-upgrade-authnull.conf
@@ -25,7 +25,7 @@ conn clear-or-private
 	rightid=%null
 	left=%defaultroute
 	right=%opportunisticgroup
-	negotiationshunt=hold
+	negotiationshunt=drop
 	failureshunt=passthrough
 	ikev2=insist
 	# add, not route - because this policy is only for incoming IKE packets
@@ -38,7 +38,7 @@ conn private-or-clear
 	rightid=%null
 	left=%defaultroute
 	right=%opportunisticgroup
-	negotiationshunt=hold
+	negotiationshunt=drop
 	failureshunt=passthrough
 	ikev2=insist
 	auto=route
@@ -52,7 +52,7 @@ conn private
 	rightid=%null
 	left=%defaultroute
 	right=%opportunisticgroup
-	negotiationshunt=hold
+	negotiationshunt=drop
 	failureshunt=drop
 	ikev2=insist
 	auto=route

--- a/docs/examples/oe-upgrade-authnull.conf
+++ b/docs/examples/oe-upgrade-authnull.conf
@@ -56,8 +56,8 @@ conn private
 	rightid=%null
 	left=%defaultroute
 	right=%opportunisticgroup
-	# if we fail hard, we might as well hold traffic during IKE too
-	negotiationshunt=hold
+	# if we fail hard, we might as well drop traffic during IKE too
+	negotiationshunt=drop
 	failureshunt=drop
 	ikev2=insist
 	auto=route

--- a/lib/libswan/shunt_names.c
+++ b/lib/libswan/shunt_names.c
@@ -78,15 +78,15 @@ const struct sparse_names failure_shunt_names = {
 };
 
 /*
- * Values for negotiationshunt={passthrough, hold}
+ * Values for negotiationshunt={passthrough, drop}
  */
 
 const struct sparse_names negotiation_shunt_names = {
 	.list = {
 		SPARSE("pass",	      SHUNT_PASS),
 		SPARSE("passthrough", SHUNT_PASS), /* alias */
-		SPARSE("hold",        SHUNT_DROP),
-		SPARSE("drop",        SHUNT_DROP), /* alias */
+		SPARSE("drop",        SHUNT_DROP),
+		SPARSE("hold",        NAME_IMPLEMENTED_AS|SHUNT_DROP), /* alias */
 		SPARSE_NULL
 	},
 };

--- a/mk/entities.xml
+++ b/mk/entities.xml
@@ -196,7 +196,7 @@
 <!ENTITY http_method_option '{&get;|&post;}'>
 <!ENTITY keyexchange_option '{&ikev1;|&ikev2;}'>
 <!ENTITY nat_ikev1_method_option '{&drafts;|&rfc;|&both;|&none;}'>
-<!ENTITY negotiationshunt_option '{&hold;|&pass;}'>
+<!ENTITY negotiationshunt_option '{&drop;|&pass;}'>
 <!ENTITY nic_offload_option '{&no;|&crypto;|&packet;}'>
 <!ENTITY phase2_option '{&esp;|&ah;}'>
 <!ENTITY ppk_option '{&no;|&propose;|&yes;|&insist;|&never;}'>

--- a/programs/pluto/kernel_policy.c
+++ b/programs/pluto/kernel_policy.c
@@ -545,7 +545,7 @@ bool delete_spd_kernel_policy(const struct spd *spd,
 			if (BROKEN_TRANSITION &&
 			    oc->config->negotiation_shunt == SHUNT_DROP &&
 			    oc->routing.state == RT_ROUTED_NEGOTIATION) {
-				ldbg(oc->logger, "%s() skipping NEGOTIATION=HOLD", __func__);
+				ldbg(oc->logger, "%s() skipping NEGOTIATION=DROP", __func__);
 				return true;
 			}
 			return restore_spd_kernel_policy(owner->bare_policy,

--- a/programs/pluto/routing_story.c
+++ b/programs/pluto/routing_story.c
@@ -25,15 +25,15 @@ static const char *const routing_tail[] = {
 	[RT_ROUTED_NEVER_NEGOTIATE] = "prospective erouted",  /* routed, and .never_negotiate_shunt installed */
 	[RT_ROUTED_ONDEMAND] = "prospective erouted",  /* routed, and prospective shunt installed */
 	/* negotiate */
-	[RT_UNROUTED_BARE_NEGOTIATION] = "unrouted HOLD",	/* negotiating, unrouted, .negotiation_shunt not installed */
-	[RT_UNROUTED_NEGOTIATION] = "unrouted HOLD",      /* unrouted, but HOLD shunt installed */
-	[RT_ROUTED_NEGOTIATION] = "erouted HOLD",         /* routed, and HOLD shunt installed */
+	[RT_UNROUTED_BARE_NEGOTIATION] = "unrouted DROP",	/* negotiating, unrouted, .negotiation_shunt not installed */
+	[RT_UNROUTED_NEGOTIATION] = "unrouted DROP",      /* unrouted, but DROP shunt installed */
+	[RT_ROUTED_NEGOTIATION] = "erouted DROP",         /* routed, and DROP shunt installed */
 	/* fail */
 	[RT_ROUTED_FAILURE] = "fail erouted",         	  /* routed, and failure-context shunt eroute installed */
 	/* half established */
-	[RT_UNROUTED_INBOUND] = "unrouted HOLD",	/* unrouted, outbound negotiation, inbound established */
-	[RT_UNROUTED_INBOUND_NEGOTIATION] = "unrouted HOLD",	/* unrouted, outbound negotiation, inbound established */
-	[RT_ROUTED_INBOUND_NEGOTIATION] = "erouted HOLD",		/* (lie) routed, outbound negotiation, inbound established */
+	[RT_UNROUTED_INBOUND] = "unrouted DROP",	/* unrouted, outbound negotiation, inbound established */
+	[RT_UNROUTED_INBOUND_NEGOTIATION] = "unrouted DROP",	/* unrouted, outbound negotiation, inbound established */
+	[RT_ROUTED_INBOUND_NEGOTIATION] = "erouted DROP",		/* (lie) routed, outbound negotiation, inbound established */
 
 	/* fully established */
 	[RT_ROUTED_TUNNEL] = "erouted",		      	  /* routed, and erouted to an IPSEC SA group */

--- a/programs/whack/whack.c
+++ b/programs/whack/whack.c
@@ -154,7 +154,7 @@ static void help(void)
 		"	[--vti-interface <iface> ] [--vti-routing] [--vti-shared] \\\n"
 		"       [--pass | --drop]\\\n"
 		"	[--failnone | --failpass | --faildrop]\\\n"
-		"	[--negopass | --negohold]\\\n"
+		"	[--negopass | --negodrop]\\\n"
 		"	[--reauth ] \\\n"
 		"	[--nic-offload <packet|crypto|no>] \\\n"
 		"	--to\n"
@@ -832,7 +832,7 @@ const struct option optarg_options[] = {
 	{ REPLACE_OPT("reject", "drop", "5.3"), no_argument, NULL, CDS_DROP },
 
 	{ "negodrop\0", no_argument, NULL, CDS_NEGOTIATION_HOLD },
-	{ "negohold\0", no_argument, NULL, CDS_NEGOTIATION_HOLD },
+	{ "negohold\0negodrop", no_argument, NULL, CDS_NEGOTIATION_HOLD },
 	{ "negopass\0", no_argument, NULL, CDS_NEGOTIATION_PASS },
 
 	{ "faildrop\0", no_argument, NULL, CDS_FAILURE_DROP },
@@ -1743,7 +1743,7 @@ int main(int argc, char **argv)
 		case CDS_NEGOTIATION_PASS:	/* --negopass */
 			msg.wm_negotiationshunt = "pass";
 			continue;
-		case CDS_NEGOTIATION_HOLD:	/* --negohold */
+		case CDS_NEGOTIATION_HOLD:	/* --negodrop|--negohold */
 			msg.wm_negotiationshunt = "drop";
 			continue;
 

--- a/testing/pluto/addconn-48-shunts/west.console.txt
+++ b/testing/pluto/addconn-48-shunts/west.console.txt
@@ -15,6 +15,7 @@ west #
 "negotiationshunt=drop": added oriented IKEv2 connection
 west #
  ipsec add negotiationshunt=hold
+warning: "negotiationshunt=hold": "negotiationshunt=hold" implemented as "drop"
 "negotiationshunt=hold": added oriented IKEv2 connection
 west #
  ipsec add failureshunt=

--- a/testing/pluto/certoe-01-whack/east-oe.conf
+++ b/testing/pluto/certoe-01-whack/east-oe.conf
@@ -37,7 +37,7 @@ conn private
 	rightid=%fromcert
 	leftcert=east
 	right=%opportunisticgroup
-	negotiationshunt=hold
+	negotiationshunt=drop
 	failureshunt=drop
 	auto=ondemand
 

--- a/testing/pluto/certoe-01-whack/west-oe.conf
+++ b/testing/pluto/certoe-01-whack/west-oe.conf
@@ -37,7 +37,7 @@ conn private
 	rightid=%fromcert
 	leftcert=west
 	right=%opportunisticgroup
-	negotiationshunt=hold
+	negotiationshunt=drop
 	failureshunt=drop
 	auto=ondemand
 

--- a/testing/pluto/certoe-02-whack-otherca/east-oe.conf
+++ b/testing/pluto/certoe-02-whack-otherca/east-oe.conf
@@ -37,7 +37,7 @@ conn private
 	rightid=%fromcert
 	leftcert=east
 	right=%opportunisticgroup
-	negotiationshunt=hold
+	negotiationshunt=drop
 	failureshunt=drop
 	auto=ondemand
 

--- a/testing/pluto/certoe-02-whack-otherca/west-oe.conf
+++ b/testing/pluto/certoe-02-whack-otherca/west-oe.conf
@@ -37,7 +37,7 @@ conn private
 	rightid=%fromcert
 	leftcert=otherwest
 	right=%opportunisticgroup
-	negotiationshunt=hold
+	negotiationshunt=drop
 	failureshunt=drop
 	auto=ondemand
 

--- a/testing/pluto/certoe-15-poc-east-west/east-ikev2-oe.conf
+++ b/testing/pluto/certoe-15-poc-east-west/east-ikev2-oe.conf
@@ -30,7 +30,7 @@ conn private-or-clear
 conn private
 	also=oe-base
 	failureshunt=drop
-	negotiationshunt=hold
+	negotiationshunt=drop
 	auto=route
 
 conn block

--- a/testing/pluto/certoe-15-poc-east-west/west-ikev2-oe.conf
+++ b/testing/pluto/certoe-15-poc-east-west/west-ikev2-oe.conf
@@ -28,7 +28,7 @@ conn private-or-clear
 conn private
 	also=oe-base
 	failureshunt=drop
-	negotiationshunt=hold
+	negotiationshunt=drop
 	auto=route
 
 conn block

--- a/testing/pluto/ikev2-oe-09-transport-ipv4/ikev2-oe.conf
+++ b/testing/pluto/ikev2-oe-09-transport-ipv4/ikev2-oe.conf
@@ -33,7 +33,7 @@ conn private
 	leftid=%null
 	rightid=%null
 	right=%opportunisticgroup
-	negotiationshunt=hold
+	negotiationshunt=drop
 	failureshunt=drop
 	auto=route
 

--- a/testing/pluto/ikev2-oe-09-transport-ipv6/ikev2-oe.conf
+++ b/testing/pluto/ikev2-oe-09-transport-ipv6/ikev2-oe.conf
@@ -33,7 +33,7 @@ conn private
 	leftid=%null
 	rightid=%null
 	right=%opportunisticgroup
-	negotiationshunt=hold
+	negotiationshunt=drop
 	failureshunt=drop
 	auto=route
 

--- a/testing/pluto/newoe-01-whack/ikev2-oe.conf
+++ b/testing/pluto/newoe-01-whack/ikev2-oe.conf
@@ -30,7 +30,7 @@ conn private
 	leftid=%null
 	rightid=%null
 	right=%opportunisticgroup
-	negotiationshunt=hold
+	negotiationshunt=drop
 	failureshunt=drop
 	auto=route
 

--- a/testing/pluto/newoe-02-whack-wrong-mode-initiator/ikev2-oe.conf
+++ b/testing/pluto/newoe-02-whack-wrong-mode-initiator/ikev2-oe.conf
@@ -30,7 +30,7 @@ conn private
 	leftid=%null
 	rightid=%null
 	right=%opportunisticgroup
-	negotiationshunt=hold
+	negotiationshunt=drop
 	failureshunt=drop
 	auto=route
 

--- a/testing/pluto/newoe-02-whack-wrong-mode-responder/ikev2-oe.conf
+++ b/testing/pluto/newoe-02-whack-wrong-mode-responder/ikev2-oe.conf
@@ -30,7 +30,7 @@ conn private
 	leftid=%null
 	rightid=%null
 	right=%opportunisticgroup
-	negotiationshunt=hold
+	negotiationshunt=drop
 	failureshunt=drop
 	auto=route
 

--- a/testing/pluto/newoe-03-oeself/ikev2-oe.conf
+++ b/testing/pluto/newoe-03-oeself/ikev2-oe.conf
@@ -30,7 +30,7 @@ conn private
 	leftid=%null
 	rightid=%null
 	right=%opportunisticgroup
-	negotiationshunt=hold
+	negotiationshunt=drop
 	failureshunt=drop
 	auto=route
 

--- a/testing/pluto/newoe-04-pass-pass/ikev2-oe.conf
+++ b/testing/pluto/newoe-04-pass-pass/ikev2-oe.conf
@@ -30,7 +30,7 @@ conn private
 	leftid=%null
 	rightid=%null
 	right=%opportunisticgroup
-	negotiationshunt=hold
+	negotiationshunt=drop
 	failureshunt=drop
 	auto=route
 

--- a/testing/pluto/newoe-05-hold-pass/description.txt
+++ b/testing/pluto/newoe-05-hold-pass/description.txt
@@ -1,6 +1,6 @@
-Lifetime of shunts with negotiationshunt=hold and failureshunt=passthrough
+Lifetime of shunts with negotiationshunt=drop and failureshunt=passthrough
 
-This test is similar to newoe-4 except it uses negotiationshunt=hold for
+This test is similar to newoe-4 except it uses negotiationshunt=drop for
 private-or-clear
 
 To ensure we see the negotiationshunt, we allow more keying tries and

--- a/testing/pluto/newoe-05-hold-pass/ikev2-oe.conf
+++ b/testing/pluto/newoe-05-hold-pass/ikev2-oe.conf
@@ -22,7 +22,7 @@ conn private-or-clear
 	rightid=%null
 	right=%opportunisticgroup
 	failureshunt=passthrough
-	negotiationshunt=hold
+	negotiationshunt=drop
 	auto=route
 	# does not inherit from conn %default ?
 	retransmit-timeout=20s
@@ -34,7 +34,7 @@ conn private
 	leftid=%null
 	rightid=%null
 	right=%opportunisticgroup
-	negotiationshunt=hold
+	negotiationshunt=drop
 	failureshunt=drop
 	auto=route
 

--- a/testing/pluto/newoe-05-hold-pass/road.console.txt
+++ b/testing/pluto/newoe-05-hold-pass/road.console.txt
@@ -46,7 +46,7 @@ Bare Shunt list:
 road #
  # wait on OE retransmits and rekeying - shuntstatus is empty because
 road #
- # shunt 7.7.7.7 is not bare and its conn negotiationshunt=hold, so
+ # shunt 7.7.7.7 is not bare and its conn negotiationshunt=drop, so
 road #
  # ping should fail
 road #

--- a/testing/pluto/newoe-05-hold-pass/roadrun.sh
+++ b/testing/pluto/newoe-05-hold-pass/roadrun.sh
@@ -6,7 +6,7 @@
 ../../guestbin/ping-once.sh --down -I 192.1.3.209 7.7.7.7
 ipsec whack --shuntstatus
 # wait on OE retransmits and rekeying - shuntstatus is empty because
-# shunt 7.7.7.7 is not bare and its conn negotiationshunt=hold, so
+# shunt 7.7.7.7 is not bare and its conn negotiationshunt=drop, so
 # ping should fail
 sleep 3
 ipsec whack --shuntstatus

--- a/testing/pluto/newoe-06-prio/ikev2-oe.conf
+++ b/testing/pluto/newoe-06-prio/ikev2-oe.conf
@@ -30,7 +30,7 @@ conn private
 	leftid=%null
 	rightid=%null
 	right=%opportunisticgroup
-	negotiationshunt=hold
+	negotiationshunt=drop
 	failureshunt=drop
 	auto=route
 

--- a/testing/pluto/newoe-07-ike-replace-initiator-esp/ikev2-oe.conf
+++ b/testing/pluto/newoe-07-ike-replace-initiator-esp/ikev2-oe.conf
@@ -30,7 +30,7 @@ conn private
 	leftid=%null
 	rightid=%null
 	right=%opportunisticgroup
-	negotiationshunt=hold
+	negotiationshunt=drop
 	failureshunt=drop
 	auto=route
 

--- a/testing/pluto/newoe-08-restart/ikev2-oe.conf
+++ b/testing/pluto/newoe-08-restart/ikev2-oe.conf
@@ -30,7 +30,7 @@ conn private
 	leftid=%null
 	rightid=%null
 	right=%opportunisticgroup
-	negotiationshunt=hold
+	negotiationshunt=drop
 	failureshunt=drop
 	auto=route
 

--- a/testing/pluto/newoe-09-mutual/ikev2-oe.conf
+++ b/testing/pluto/newoe-09-mutual/ikev2-oe.conf
@@ -30,7 +30,7 @@ conn private
 	leftid=%null
 	rightid=%null
 	right=%opportunisticgroup
-	negotiationshunt=hold
+	negotiationshunt=drop
 	failureshunt=drop
 	auto=route
 

--- a/testing/pluto/newoe-10-expire-inactive-ike/ikev2-oe.conf
+++ b/testing/pluto/newoe-10-expire-inactive-ike/ikev2-oe.conf
@@ -30,7 +30,7 @@ conn private
 	leftid=%null
 	rightid=%null
 	right=%opportunisticgroup
-	negotiationshunt=hold
+	negotiationshunt=drop
 	failureshunt=drop
 	auto=route
 

--- a/testing/pluto/newoe-10-expire-inactive/ikev2-oe.conf
+++ b/testing/pluto/newoe-10-expire-inactive/ikev2-oe.conf
@@ -30,7 +30,7 @@ conn private
 	leftid=%null
 	rightid=%null
 	right=%opportunisticgroup
-	negotiationshunt=hold
+	negotiationshunt=drop
 	failureshunt=drop
 	auto=route
 

--- a/testing/pluto/newoe-11-failike/ikev2-oe.conf
+++ b/testing/pluto/newoe-11-failike/ikev2-oe.conf
@@ -30,7 +30,7 @@ conn private
 	leftid=%null
 	rightid=%null
 	right=%opportunisticgroup
-	negotiationshunt=hold
+	negotiationshunt=drop
 	failureshunt=drop
 	auto=route
 

--- a/testing/pluto/newoe-12-clear/ikev2-oe.conf
+++ b/testing/pluto/newoe-12-clear/ikev2-oe.conf
@@ -30,7 +30,7 @@ conn private
 	leftid=%null
 	rightid=%null
 	right=%opportunisticgroup
-	negotiationshunt=hold
+	negotiationshunt=drop
 	failureshunt=drop
 	auto=route
 

--- a/testing/pluto/newoe-13-block/ikev2-oe.conf
+++ b/testing/pluto/newoe-13-block/ikev2-oe.conf
@@ -30,7 +30,7 @@ conn private
 	leftid=%null
 	rightid=%null
 	right=%opportunisticgroup
-	negotiationshunt=hold
+	negotiationshunt=drop
 	failureshunt=drop
 	auto=route
 

--- a/testing/pluto/newoe-20-ipv6/ikev2-oe.conf
+++ b/testing/pluto/newoe-20-ipv6/ikev2-oe.conf
@@ -30,7 +30,7 @@ conn private
 	leftid=%null
 	rightid=%null
 	right=%opportunisticgroup
-	negotiationshunt=hold
+	negotiationshunt=drop
 	failureshunt=drop
 	auto=route
 


### PR DESCRIPTION
Fixes #2129

negotiationshunt=hold says "hold" but actually drops packets (SHUNT_HOLD was already merged into SHUNT_DROP in c12310856d)

Made "drop" the canonical name and "hold" a deprecated alias that warns, matching what was already done for failureshunt=hold


_**Testing**_

addconn 48 shunts verifies the warning appears and deliberately keeps negotiationshunt=hold to exercise the warning path 
24 OE test configs (newoe-*, certoe-*, ikev2-oe-*) updated from hold to drop