### PR TITLE
pluto:extract KYN_IKE_SOCKET_ERRQUEUE during daemon startup

### DIFF
--- a/programs/pluto/plutomain.c
+++ b/programs/pluto/plutomain.c
@@ -1076,6 +1076,7 @@ int main(int argc, char **argv)
 	/* IKEv2 ignoring OPPO? */
 	pluto_drop_oppo_null = config_setup_yn(KYN_DROP_OPPO_NULL);
 
+	pluto_ike_socket_errqueue = config_setup_yn(KYN_IKE_SOCKET_ERRQUEUE);
 	/* redirect|to */
 
 	init_global_redirect(config_setup_option(KBF_GLOBAL_REDIRECT),

--- a/testing/pluto/addconn-52-config-setup-ike-socket/description.txt
+++ b/testing/pluto/addconn-52-config-setup-ike-socket/description.txt
@@ -1,0 +1,1 @@
+ike-socket-errqueue and ike-socket-bufsize in ipsec.conf and CLI

--- a/testing/pluto/addconn-52-config-setup-ike-socket/west-cli.conf
+++ b/testing/pluto/addconn-52-config-setup-ike-socket/west-cli.conf
@@ -1,0 +1,8 @@
+# /etc/ipsec.conf - Libreswan IPsec configuration file
+
+config setup
+	logfile=/tmp/pluto.log
+	logtime=no
+	logappend=no
+	plutodebug=all
+	dumpdir=/tmp

--- a/testing/pluto/addconn-52-config-setup-ike-socket/west.conf
+++ b/testing/pluto/addconn-52-config-setup-ike-socket/west.conf
@@ -1,0 +1,10 @@
+# /etc/ipsec.conf - Libreswan IPsec configuration file
+
+config setup
+	logfile=/tmp/pluto.log
+	logtime=no
+	logappend=no
+	plutodebug=all
+	dumpdir=/tmp
+	ike-socket-errqueue=no
+	ike-socket-bufsize=32768

--- a/testing/pluto/addconn-52-config-setup-ike-socket/west.console.txt
+++ b/testing/pluto/addconn-52-config-setup-ike-socket/west.console.txt
@@ -1,0 +1,33 @@
+/testing/guestbin/swan-prep --nokeys
+Creating empty NSS database
+west #
+ echo "initdone"
+initdone
+west #
+ # Test 1: options from config setup in ipsec.conf
+west #
+ ipsec pluto --config west.conf
+west #
+ ../../guestbin/wait-until-pluto-started
+west #
+ ipsec status | grep "ikebuf="
+ikebuf=32768, msg_errqueue=no, crl-strict=no, crlcheckinterval=0, listen=<any>, nflog-all=0, dns-resolver=file,
+west #
+ ipsec whack --shutdown
+Pluto is shutting down
+west #
+ # Test 2: options from command line arguments
+west #
+ ipsec pluto --config west-cli.conf --ike-socket-errqueue=no --ike-socket-bufsize=65535
+west #
+ ../../guestbin/wait-until-pluto-started
+west #
+ ipsec status | grep "ikebuf="
+ikebuf=65535, msg_errqueue=no, crl-strict=no, crlcheckinterval=0, listen=<any>, nflog-all=0, dns-resolver=file,
+west #
+ ipsec whack --shutdown
+Pluto is shutting down
+west #
+ echo done
+done
+west #

--- a/testing/pluto/addconn-52-config-setup-ike-socket/westrun.sh
+++ b/testing/pluto/addconn-52-config-setup-ike-socket/westrun.sh
@@ -1,0 +1,16 @@
+/testing/guestbin/swan-prep --nokeys
+echo "initdone"
+
+# Test 1: options from config setup in ipsec.conf
+ipsec pluto --config west.conf
+../../guestbin/wait-until-pluto-started
+ipsec status | grep "ikebuf="
+ipsec whack --shutdown
+
+# Test 2: options from command line arguments
+ipsec pluto --config west-cli.conf --ike-socket-errqueue=no --ike-socket-bufsize=65535
+../../guestbin/wait-until-pluto-started
+ipsec status | grep "ikebuf="
+ipsec whack --shutdown
+
+echo done


### PR DESCRIPTION
fixes #2548 
Just extracted the KYN_IKE_SOCKET_ERRQUEUE in plutomain.
Manually verified by setting ike-socket-errqueue=no in ipsec.conf.