### PR TITLE
kernel: include selectors in xfrm policy error messages

### DIFF
--- a/programs/pluto/kernel_xfrm.c
+++ b/programs/pluto/kernel_xfrm.c
@@ -1085,11 +1085,18 @@ static bool kernel_xfrm_policy_add(enum kernel_policy_op op,
 			xfrm_dir, sizeof(req.data), logger);
 	add_sec_label(&req.n, policy->sec_label, logger);
 
+	/*
+	 * Build "SELECTORS" for error messages.
+	 * For example: "192.0.2.0/24===192.0.1.0/24"
+	 */
+	selector_pair_buf spb;
+	str_selector_pair(src_client, dst_client, &spb);
+
 	enum expect_kernel_policy what_about_inbound =
 		(op == KERNEL_POLICY_OP_ADD ? KERNEL_POLICY_PRESENT_OR_MISSING :
 		 KERNEL_POLICY_PRESENT);
 	bool ok = sendrecv_xfrm_policy(&req.n, what_about_inbound, policy_name,
-				       (dir == DIRECTION_OUTBOUND ? "(out)" : "(in)"),
+				       spb.buf,
 				       logger, func);
 
 	/*
@@ -1113,7 +1120,7 @@ static bool kernel_xfrm_policy_add(enum kernel_policy_op op,
 			ldbg(logger, "%s() adding policy forward (suspect a tunnel)", __func__);
 			info->dir = XFRM_POLICY_FWD;
 			ok &= sendrecv_xfrm_policy(&req.n, what_about_inbound,
-						   policy_name, "(fwd)",
+						   policy_name, spb.buf,
 						   logger, func);
 			break;
 		default:
@@ -1171,10 +1178,15 @@ static bool kernel_xfrm_policy_del(enum direction direction,
 	add_xfrmi_marks(&req.n, sa_marks, xfrmi, xfrm_dir, sizeof(req.data), logger);
 	add_sec_label(&req.n, sec_label, logger);
 
+	/*
+	 * Build "SELECTORS" for error messages.
+	 * For example: "192.0.2.0/24===192.0.1.0/24"
+	 */
+	selector_pair_buf spb;
+	str_selector_pair(src_child, dst_child, &spb);
+
 	bool ok = sendrecv_xfrm_policy(&req.n, expect_kernel_policy, "delete",
-				       (direction == DIRECTION_OUTBOUND ? "(out)" :
-					direction == DIRECTION_INBOUND ? "(in)" :
-					NULL),
+				       spb.buf,
 				       logger, func);
 
 	/*
@@ -1195,7 +1207,7 @@ static bool kernel_xfrm_policy_del(enum direction direction,
 		    __func__);
 		id->dir = XFRM_POLICY_FWD;
 		ok &= sendrecv_xfrm_policy(&req.n, KERNEL_POLICY_PRESENT_OR_MISSING,
-					   "delete", "(fwd)",
+					   "delete", spb.buf,
 					   logger, func);
 	}
 	return ok;

--- a/testing/pluto/connalias-01-conflict/west.console.txt
+++ b/testing/pluto/connalias-01-conflict/west.console.txt
@@ -97,13 +97,13 @@ initiating 2 connections
 "westnet-eastnet-alias" #2: cannot install kernel policy 192.0.1.0/24===192.0.2.0/24; in use by negotiating Child SA "westnet-eastnet-second" #3 with routing unrouted-bare-negotiation
 "westnet-eastnet-alias" #2: state transition failed: failed
 "westnet-eastnet-alias" #2: connection is supposed to remain up; revival attempt 1 scheduled in 0 seconds
-ERROR: "westnet-eastnet-alias" #2: kernel: xfrm XFRM_MSG_DELPOLICY delete response for flow (in): No such file or directory (errno 2)
+ERROR: "westnet-eastnet-alias" #2: kernel: xfrm XFRM_MSG_DELPOLICY delete response for flow 192.0.2.0/24===192.0.1.0/24: No such file or directory (errno 2)
 "westnet-eastnet-alias" #2: deleting IPsec SA (QUICK_I1) and NOT sending notification
 ERROR: "westnet-eastnet-alias" #2: netlink response for Del SA esp.ESPSPIi@192.1.2.23: No such process (errno 3)
 "westnet-eastnet-second" #3: cannot install kernel policy 192.0.1.0/24===192.0.2.0/24; in use by negotiating Child SA "westnet-eastnet-alias" #4 with routing unrouted-bare-negotiation
 "westnet-eastnet-second" #3: state transition failed: failed
 "westnet-eastnet-second" #3: connection is supposed to remain up; revival attempt 1 scheduled in 0 seconds
-ERROR: "westnet-eastnet-second" #3: kernel: xfrm XFRM_MSG_DELPOLICY delete response for flow (in): No such file or directory (errno 2)
+ERROR: "westnet-eastnet-second" #3: kernel: xfrm XFRM_MSG_DELPOLICY delete response for flow 192.0.2.0/24===192.0.1.0/24: No such file or directory (errno 2)
 "westnet-eastnet-second" #3: deleting IPsec SA (QUICK_I1) and NOT sending notification
 ERROR: "westnet-eastnet-second" #3: netlink response for Del SA esp.ESPSPIi@192.1.2.23: No such process (errno 3)
 west #

--- a/testing/pluto/impair-install-ipsec-sa-inbound-policy-initiator-ikev1/east.console.txt
+++ b/testing/pluto/impair-install-ipsec-sa-inbound-policy-initiator-ikev1/east.console.txt
@@ -45,7 +45,7 @@ east #
  ipsec unroute west-east
 "west-east": terminating SAs using this connection
 "west-east" #3: deleting IPsec SA (QUICK_R1) and sending notification using ISAKMP SA #1
-ERROR: "west-east" #3: kernel: xfrm XFRM_MSG_DELPOLICY delete response for flow (out): No such file or directory (errno 2)
+ERROR: "west-east" #3: kernel: xfrm XFRM_MSG_DELPOLICY delete response for flow 192.0.2.0/24===192.0.1.0/24: No such file or directory (errno 2)
 ERROR: "west-east" #3: netlink response for Get SA esp.ESPSPIi@192.1.2.45: No such process (errno 3)
 "west-east" #3: failed to pull traffic counters from outbound IPsec SA
 "west-east" #3: ESP traffic information: in=0B out=0B

--- a/testing/pluto/impair-install-ipsec-sa-inbound-policy-responder-ikev1/west.console.txt
+++ b/testing/pluto/impair-install-ipsec-sa-inbound-policy-responder-ikev1/west.console.txt
@@ -692,7 +692,7 @@ output: | kernel_xfrm_policy_add() IPsec SA SPD priority set to 1757393
 output: | kernel_xfrm_policy_add() adding xfrm_user_tmpl reqid=0 id.proto=50 optional=0 family=2 mode=0 saddr=<unset-address> daddr=<unset-address>
 output: | sendrecv_xfrm_msg() sending 25 policy %trap(allow)
 output: | sendrecv_xfrm_msg() recvfrom() returned 36 bytes
-output: | kernel_ops_policy_add()   XFRM_MSG_UPDPOLICY for flow %trap(allow) (out) had A policy
+output: | kernel_ops_policy_add()   XFRM_MSG_UPDPOLICY for flow %trap(allow) 192.0.1.0/24===192.0.2.0/24 had A policy
 output: | "west-east" #2: routing:   ... yes
 output: | "west-east" #2: .st_on_delete.skip_send_delete no->true (delete_child_sa() +758 programs/pluto/state.c)
 output: | "west-east" #2: delete_state() skipping log_message:no
@@ -817,7 +817,7 @@ output: | kernel_xfrm_policy_add() adding xfrm_user_tmpl reqid=0 id.proto=50 opt
 output: | sendrecv_xfrm_msg() sending 25 policy %hold(block)
 output: | job 4 helper 1 #3 quick_outI1 (dh): started
 output: | sendrecv_xfrm_msg() recvfrom() returned 36 bytes
-output: | kernel_ops_policy_add()   XFRM_MSG_UPDPOLICY for flow %hold(block) (out) had A policy
+output: | kernel_ops_policy_add()   XFRM_MSG_UPDPOLICY for flow %hold(block) 192.0.1.0/24===192.0.2.0/24 had A policy
 output: | "west-east" #3: routing:   ... yes
 output: | "west-east" #3: routing: stop INITIATED, ROUTED_ONDEMAND->ROUTED_NEGOTIATION, PERMANENT; ok=yes; routing_sa #0->#3 negotiating_ike_sa #1 established_ike_sa #1 negotiating_child_sa #0->#3 (initiate_ondemand() +158 programs/pluto/acquire.c)
 output: | "west-east": delref @0x7f18d5ea1a78(5->4) "west-east" #3:  (dispatch() +2450 programs/pluto/routing.c)

--- a/testing/pluto/impair-install-ipsec-sa-inbound-state-initiator-ikev1/east.console.txt
+++ b/testing/pluto/impair-install-ipsec-sa-inbound-state-initiator-ikev1/east.console.txt
@@ -45,7 +45,7 @@ east #
  ipsec unroute west-east
 "west-east": terminating SAs using this connection
 "west-east" #3: deleting IPsec SA (QUICK_R1) and sending notification using ISAKMP SA #1
-ERROR: "west-east" #3: kernel: xfrm XFRM_MSG_DELPOLICY delete response for flow (out): No such file or directory (errno 2)
+ERROR: "west-east" #3: kernel: xfrm XFRM_MSG_DELPOLICY delete response for flow 192.0.2.0/24===192.0.1.0/24: No such file or directory (errno 2)
 ERROR: "west-east" #3: netlink response for Get SA esp.ESPSPIi@192.1.2.45: No such process (errno 3)
 "west-east" #3: failed to pull traffic counters from outbound IPsec SA
 "west-east" #3: ESP traffic information: in=0B out=0B

--- a/testing/pluto/impair-install-ipsec-sa-inbound-state-initiator-ikev1/west.console.txt
+++ b/testing/pluto/impair-install-ipsec-sa-inbound-state-initiator-ikev1/west.console.txt
@@ -49,7 +49,7 @@ IMPAIR: "west-east" #2: kernel: install_ipsec_sa_inbound_state in setup_half_ker
 "west-east" #2: state transition failed: failed
 "west-east" #2: connection is supposed to remain up; revival attempt 1 scheduled in 0 seconds
 IMPAIR: "west-east" #2: revival: skip scheduling CONNECTION_REVIVAL event in 0 seconds
-ERROR: "west-east" #2: kernel: xfrm XFRM_MSG_DELPOLICY delete response for flow (in): No such file or directory (errno 2)
+ERROR: "west-east" #2: kernel: xfrm XFRM_MSG_DELPOLICY delete response for flow 192.0.2.0/24===192.0.1.0/24: No such file or directory (errno 2)
 "west-east" #2: kernel: replace_ipsec_with_bare_kernel_policy() inbound delete failed
 "west-east" #2: deleting IPsec SA (QUICK_I1) and NOT sending notification
 ERROR: "west-east" #2: netlink response for Del SA esp.ESPSPIi@192.1.2.23: No such process (errno 3)

--- a/testing/pluto/impair-install-ipsec-sa-inbound-state-initiator-ikev2/west.console.txt
+++ b/testing/pluto/impair-install-ipsec-sa-inbound-state-initiator-ikev2/west.console.txt
@@ -49,7 +49,7 @@ IMPAIR: "west-east" #2: kernel: install_ipsec_sa_inbound_state in setup_half_ker
 "west-east" #2: sent INFORMATIONAL request to delete larval Child SA using IKE SA #1
 "west-east" #2: connection is supposed to remain up; revival attempt 1 scheduled in 0 seconds
 IMPAIR: "west-east" #2: revival: skip scheduling CONNECTION_REVIVAL event in 0 seconds
-ERROR: "west-east" #2: kernel: xfrm XFRM_MSG_DELPOLICY delete response for flow (in): No such file or directory (errno 2)
+ERROR: "west-east" #2: kernel: xfrm XFRM_MSG_DELPOLICY delete response for flow 192.0.2.0/24===192.0.1.0/24: No such file or directory (errno 2)
 "west-east" #2: kernel: replace_ipsec_with_bare_kernel_policy() inbound delete failed
 ERROR: "west-east" #2: netlink response for Del SA esp.ESPSPIi@192.1.2.23: No such process (errno 3)
 ERROR: "west-east" #2: netlink response for Del SA esp.ESPSPIi@192.1.2.45: No such process (errno 3)

--- a/testing/pluto/impair-install-ipsec-sa-inbound-state-responder-ikev1/west.console.txt
+++ b/testing/pluto/impair-install-ipsec-sa-inbound-state-responder-ikev1/west.console.txt
@@ -692,7 +692,7 @@ output: | kernel_xfrm_policy_add() IPsec SA SPD priority set to 1757393
 output: | kernel_xfrm_policy_add() adding xfrm_user_tmpl reqid=0 id.proto=50 optional=0 family=2 mode=0 saddr=<unset-address> daddr=<unset-address>
 output: | sendrecv_xfrm_msg() sending 25 policy %trap(allow)
 output: | sendrecv_xfrm_msg() recvfrom() returned 36 bytes
-output: | kernel_ops_policy_add()   XFRM_MSG_UPDPOLICY for flow %trap(allow) (out) had A policy
+output: | kernel_ops_policy_add()   XFRM_MSG_UPDPOLICY for flow %trap(allow) 192.0.1.0/24===192.0.2.0/24 had A policy
 output: | "west-east" #2: routing:   ... yes
 output: | "west-east" #2: .st_on_delete.skip_send_delete no->true (delete_child_sa() +758 programs/pluto/state.c)
 output: | "west-east" #2: delete_state() skipping log_message:no
@@ -817,7 +817,7 @@ output: | kernel_xfrm_policy_add() adding xfrm_user_tmpl reqid=0 id.proto=50 opt
 output: | sendrecv_xfrm_msg() sending 25 policy %hold(block)
 output: | job 4 helper 1 #3 quick_outI1 (dh): started
 output: | sendrecv_xfrm_msg() recvfrom() returned 36 bytes
-output: | kernel_ops_policy_add()   XFRM_MSG_UPDPOLICY for flow %hold(block) (out) had A policy
+output: | kernel_ops_policy_add()   XFRM_MSG_UPDPOLICY for flow %hold(block) 192.0.1.0/24===192.0.2.0/24 had A policy
 output: | "west-east" #3: routing:   ... yes
 output: | "west-east" #3: routing: stop INITIATED, ROUTED_ONDEMAND->ROUTED_NEGOTIATION, PERMANENT; ok=yes; routing_sa #0->#3 negotiating_ike_sa #1 established_ike_sa #1 negotiating_child_sa #0->#3 (initiate_ondemand() +158 programs/pluto/acquire.c)
 output: | "west-east": delref @0x7ff4d1066a78(5->4) "west-east" #3:  (dispatch() +2450 programs/pluto/routing.c)

--- a/testing/pluto/impair-install-ipsec-sa-outbound-policy-initiator-ikev1/east.console.txt
+++ b/testing/pluto/impair-install-ipsec-sa-outbound-policy-initiator-ikev1/east.console.txt
@@ -45,7 +45,7 @@ east #
  ipsec unroute west-east
 "west-east": terminating SAs using this connection
 "west-east" #3: deleting IPsec SA (QUICK_R1) and sending notification using ISAKMP SA #1
-ERROR: "west-east" #3: kernel: xfrm XFRM_MSG_DELPOLICY delete response for flow (out): No such file or directory (errno 2)
+ERROR: "west-east" #3: kernel: xfrm XFRM_MSG_DELPOLICY delete response for flow 192.0.2.0/24===192.0.1.0/24: No such file or directory (errno 2)
 ERROR: "west-east" #3: netlink response for Get SA esp.ESPSPIi@192.1.2.45: No such process (errno 3)
 "west-east" #3: failed to pull traffic counters from outbound IPsec SA
 "west-east" #3: ESP traffic information: in=0B out=0B

--- a/testing/pluto/impair-install-ipsec-sa-outbound-policy-responder-ikev1/west.console.txt
+++ b/testing/pluto/impair-install-ipsec-sa-outbound-policy-responder-ikev1/west.console.txt
@@ -876,11 +876,11 @@ output: | kernel_xfrm_policy_add() IPsec SA SPD priority set to 1757393
 output: | kernel_xfrm_policy_add() adding xfrm_user_tmpl reqid=16389 id.proto=50 optional=0 family=2 mode=1 saddr=192.1.2.23 daddr=192.1.2.45
 output: | sendrecv_xfrm_msg() sending 25 policy IPv4
 output: | sendrecv_xfrm_msg() recvfrom() returned 36 bytes
-output: | kernel_ops_policy_add()   XFRM_MSG_UPDPOLICY for flow IPv4 (in) had A policy
+output: | kernel_ops_policy_add()   XFRM_MSG_UPDPOLICY for flow IPv4 192.0.2.0/24===192.0.1.0/24 had A policy
 output: | kernel_xfrm_policy_add() adding policy forward (suspect a tunnel)
 output: | sendrecv_xfrm_msg() sending 25 policy IPv4
 output: | sendrecv_xfrm_msg() recvfrom() returned 36 bytes
-output: | kernel_ops_policy_add()   XFRM_MSG_UPDPOLICY for flow IPv4 (fwd) had A policy
+output: | kernel_ops_policy_add()   XFRM_MSG_UPDPOLICY for flow IPv4 192.0.2.0/24===192.0.1.0/24 had A policy
 output: | "west-east" #2: routing:   ... yes
 output: | "west-east" #2: routing: stop ESTABLISH_INBOUND, ROUTED_NEGOTIATION->ROUTED_INBOUND_NEGOTIATION, PERMANENT; ok=yes; routing_sa #2 negotiating_ike_sa #1 established_ike_sa #1 negotiating_child_sa #2 (quick_inR1_outI2_tail() +1791 programs/pluto/ikev1_quick.c)
 output: | "west-east": delref @0x7f1c931a1a78(4->3) "west-east" #2:  (dispatch() +2450 programs/pluto/routing.c)
@@ -928,7 +928,7 @@ output: | kernel_xfrm_policy_add() IPsec SA SPD priority set to 1757393
 output: | kernel_xfrm_policy_add() adding xfrm_user_tmpl reqid=16389 id.proto=50 optional=0 family=2 mode=1 saddr=192.1.2.45 daddr=192.1.2.23
 output: | sendrecv_xfrm_msg() sending 25 policy IPv4
 output: | sendrecv_xfrm_msg() recvfrom() returned 36 bytes
-output: | kernel_ops_policy_add()   XFRM_MSG_UPDPOLICY for flow IPv4 (out) had A policy
+output: | kernel_ops_policy_add()   XFRM_MSG_UPDPOLICY for flow IPv4 192.0.1.0/24===192.0.2.0/24 had A policy
 output: | "west-east" #2: routing:   ... yes
 output: | kernel: running updown command "ipsec _updown" for verb prepare 
 output: | kernel: command executing prepare-client

--- a/testing/pluto/impair-install-ipsec-sa-outbound-state-initiator-ikev1/east.console.txt
+++ b/testing/pluto/impair-install-ipsec-sa-outbound-state-initiator-ikev1/east.console.txt
@@ -45,7 +45,7 @@ east #
  ipsec unroute west-east
 "west-east": terminating SAs using this connection
 "west-east" #3: deleting IPsec SA (QUICK_R1) and sending notification using ISAKMP SA #1
-ERROR: "west-east" #3: kernel: xfrm XFRM_MSG_DELPOLICY delete response for flow (out): No such file or directory (errno 2)
+ERROR: "west-east" #3: kernel: xfrm XFRM_MSG_DELPOLICY delete response for flow 192.0.2.0/24===192.0.1.0/24: No such file or directory (errno 2)
 ERROR: "west-east" #3: netlink response for Get SA esp.ESPSPIi@192.1.2.45: No such process (errno 3)
 "west-east" #3: failed to pull traffic counters from outbound IPsec SA
 "west-east" #3: ESP traffic information: in=0B out=0B

--- a/testing/pluto/impair-install-ipsec-sa-outbound-state-responder-ikev1/west.console.txt
+++ b/testing/pluto/impair-install-ipsec-sa-outbound-state-responder-ikev1/west.console.txt
@@ -876,11 +876,11 @@ output: | kernel_xfrm_policy_add() IPsec SA SPD priority set to 1757393
 output: | kernel_xfrm_policy_add() adding xfrm_user_tmpl reqid=16389 id.proto=50 optional=0 family=2 mode=1 saddr=192.1.2.23 daddr=192.1.2.45
 output: | sendrecv_xfrm_msg() sending 25 policy IPv4
 output: | sendrecv_xfrm_msg() recvfrom() returned 36 bytes
-output: | kernel_ops_policy_add()   XFRM_MSG_UPDPOLICY for flow IPv4 (in) had A policy
+output: | kernel_ops_policy_add()   XFRM_MSG_UPDPOLICY for flow IPv4 192.0.2.0/24===192.0.1.0/24 had A policy
 output: | kernel_xfrm_policy_add() adding policy forward (suspect a tunnel)
 output: | sendrecv_xfrm_msg() sending 25 policy IPv4
 output: | sendrecv_xfrm_msg() recvfrom() returned 36 bytes
-output: | kernel_ops_policy_add()   XFRM_MSG_UPDPOLICY for flow IPv4 (fwd) had A policy
+output: | kernel_ops_policy_add()   XFRM_MSG_UPDPOLICY for flow IPv4 192.0.2.0/24===192.0.1.0/24 had A policy
 output: | "west-east" #2: routing:   ... yes
 output: | "west-east" #2: routing: stop ESTABLISH_INBOUND, ROUTED_NEGOTIATION->ROUTED_INBOUND_NEGOTIATION, PERMANENT; ok=yes; routing_sa #2 negotiating_ike_sa #1 established_ike_sa #1 negotiating_child_sa #2 (quick_inR1_outI2_tail() +1791 programs/pluto/ikev1_quick.c)
 output: | "west-east": delref @0x7f97e9c50a78(4->3) "west-east" #2:  (dispatch() +2450 programs/pluto/routing.c)
@@ -928,7 +928,7 @@ output: | kernel_xfrm_policy_add() IPsec SA SPD priority set to 1757393
 output: | kernel_xfrm_policy_add() adding xfrm_user_tmpl reqid=16389 id.proto=50 optional=0 family=2 mode=1 saddr=192.1.2.45 daddr=192.1.2.23
 output: | sendrecv_xfrm_msg() sending 25 policy IPv4
 output: | sendrecv_xfrm_msg() recvfrom() returned 36 bytes
-output: | kernel_ops_policy_add()   XFRM_MSG_UPDPOLICY for flow IPv4 (out) had A policy
+output: | kernel_ops_policy_add()   XFRM_MSG_UPDPOLICY for flow IPv4 192.0.1.0/24===192.0.2.0/24 had A policy
 output: | "west-east" #2: routing:   ... yes
 output: | kernel: running updown command "ipsec _updown" for verb prepare 
 output: | kernel: command executing prepare-client

--- a/testing/pluto/whack-delete-04-ikev1-quick-responder/east.console.txt
+++ b/testing/pluto/whack-delete-04-ikev1-quick-responder/east.console.txt
@@ -20,7 +20,7 @@ east #
  ipsec delete west-to-east
 "west-to-east": terminating SAs using this connection
 "west-to-east" #2: deleting IPsec SA (QUICK_R1) and sending notification using ISAKMP SA #1
-ERROR: "west-to-east" #2: kernel: xfrm XFRM_MSG_DELPOLICY delete response for flow (out): No such file or directory (errno 2)
+ERROR: "west-to-east" #2: kernel: xfrm XFRM_MSG_DELPOLICY delete response for flow 192.1.2.23/32===192.1.2.45/32: No such file or directory (errno 2)
 ERROR: "west-to-east" #2: netlink response for Get SA esp.ESPSPIi@192.1.2.45: No such process (errno 3)
 "west-to-east" #2: failed to pull traffic counters from outbound IPsec SA
 "west-to-east" #2: ESP traffic information: in=0B out=0B

--- a/testing/pluto/whack-down-10-ikev1-quick-responder/east.console.txt
+++ b/testing/pluto/whack-down-10-ikev1-quick-responder/east.console.txt
@@ -20,7 +20,7 @@ east #
  ipsec down west-to-east
 "west-to-east": initiating delete of connection's IPsec SA #2 and ISAKMP SA #1
 "west-to-east" #2: deleting IPsec SA (QUICK_R1) and sending notification using ISAKMP SA #1
-ERROR: "west-to-east" #2: kernel: xfrm XFRM_MSG_DELPOLICY delete response for flow (out): No such file or directory (errno 2)
+ERROR: "west-to-east" #2: kernel: xfrm XFRM_MSG_DELPOLICY delete response for flow 192.1.2.23/32===192.1.2.45/32: No such file or directory (errno 2)
 ERROR: "west-to-east" #2: netlink response for Get SA esp.ESPSPIi@192.1.2.45: No such process (errno 3)
 "west-to-east" #2: failed to pull traffic counters from outbound IPsec SA
 "west-to-east" #2: ESP traffic information: in=0B out=0B

--- a/testing/pluto/whack-unroute-01-ikev1-quick-responder/east.console.txt
+++ b/testing/pluto/whack-unroute-01-ikev1-quick-responder/east.console.txt
@@ -20,7 +20,7 @@ east #
  ipsec unroute west-to-east
 "west-to-east": terminating SAs using this connection
 "west-to-east" #2: deleting IPsec SA (QUICK_R1) and sending notification using ISAKMP SA #1
-ERROR: "west-to-east" #2: kernel: xfrm XFRM_MSG_DELPOLICY delete response for flow (out): No such file or directory (errno 2)
+ERROR: "west-to-east" #2: kernel: xfrm XFRM_MSG_DELPOLICY delete response for flow 192.1.2.23/32===192.1.2.45/32: No such file or directory (errno 2)
 ERROR: "west-to-east" #2: netlink response for Get SA esp.ESPSPIi@192.1.2.45: No such process (errno 3)
 "west-to-east" #2: failed to pull traffic counters from outbound IPsec SA
 "west-to-east" #2: ESP traffic information: in=0B out=0B


### PR DESCRIPTION
Fixes #1544

Policy deletion errors like xfrm XFRM_MSG_DELPOLICY delete response for flow (out) only showed direction, making them useless for debugging
SA deletion errors already included the full identifier (e.g = esp.ESPSPIi@192.1.2.23). This formats the src/dst selectors via str_selector_pair() into both  kernel_xfrm_policy_add()  and  kernel_xfrm_policy_del() error messages, producing output like response for flow 192.0.2.0/24===192.0.1.0/24

**`Testing`**

Updated expected output in 14 test files across impair-install-ipsec-sa, connalias, whack-down, whack-unroute, and whack-delete tests
