### PR TITLE
Solution for GitHub Task #2652

### DIFF
--- a/include/ip_said.h
+++ b/include/ip_said.h
@@ -109,6 +109,8 @@ typedef struct {
 
 size_t jam_said(struct jambuf *buf, const ip_said *said);
 const char *str_said(const ip_said *said, said_buf *buf);
+size_t jam_said_sensitive(struct jambuf *buf, const ip_said *said);
+const char *str_said_sensitive(const ip_said *said, said_buf *buf);
 
 /*
  * Details.

--- a/lib/libswan/ip_said.c
+++ b/lib/libswan/ip_said.c
@@ -93,11 +93,29 @@ size_t jam_said(struct jambuf *buf, const ip_said *said)
 	return s;
 }
 
+size_t jam_said_sensitive(struct jambuf *buf, const ip_said *said)
+{
+        const struct ip_info *afi;
+        size_t s = jam_sensitive_ip(buf, "said", said, &afi);
+        if (s > 0) {
+                return s;
+        }
+
+        return jam_said(buf, said);
+}
+
 const char *str_said(const ip_said *said, said_buf *buf)
 {
 	struct jambuf b = ARRAY_AS_JAMBUF(buf->buf);
 	jam_said(&b, said);
 	return buf->buf;
+}
+
+const char *str_said_sensitive(const ip_said *said, said_buf *buf)
+{
+        struct jambuf b = ARRAY_AS_JAMBUF(buf->buf);
+        jam_said_sensitive(&b, said);
+        return buf->buf;
 }
 
 const struct ip_info *said_type(const ip_said *said)

--- a/programs/pluto/kernel_ops.c
+++ b/programs/pluto/kernel_ops.c
@@ -470,7 +470,6 @@ bool kernel_ops_del_ipsec_spi(ipsec_spi_t spi, const struct ip_protocol *proto,
 {
 	ip_said said = said_from_address_protocol_spi(*dst, proto, spi);
 	said_buf sbuf;
-	const char *said_story = (log_ip ? str_said(&said, &sbuf) : "<said>");
 
 	if (LDBGP(DBG_ROUTING, logger)) {
 		LLOG_JAMBUF(DEBUG_STREAM, logger, buf) {
@@ -481,13 +480,13 @@ bool kernel_ops_del_ipsec_spi(ipsec_spi_t spi, const struct ip_protocol *proto,
 			    proto == NULL ? "<NULL>" : proto->name,
 			    pri_ipsec_spi(spi),
 			    str_address(dst, &db),
-			    said_story);
+			    str_said(&said, &sbuf));
 		}
 	}
 
 	passert(kernel_ops->del_ipsec_spi != NULL);
 
-	bool ok = kernel_ops->del_ipsec_spi(spi, proto, src, dst, said_story, logger);
+	bool ok = kernel_ops->del_ipsec_spi(spi, proto, src, dst, str_said_sensitive(&said, &sbuf), logger);
 
 	if (LDBGP(DBG_ROUTING, logger)) {
 		LLOG_JAMBUF(DEBUG_STREAM, logger, buf) {


### PR DESCRIPTION
added str_said_sensitive() and jam_said_sensitive() to lib/include/ip_said.[h/c]
they hide the ip based on log_ip
then modified kernel_ops_del_ipsec_spi() in programs/pluto/kernel_ops.c, making use of str_said() and str_said_sensitive()
