### PR TITLE
kernel: remove story parameter from kernel_ops_get_ipsec_spi()

### DIFF
--- a/programs/pluto/kernel.c
+++ b/programs/pluto/kernel.c
@@ -406,7 +406,7 @@ ipsec_spi_t get_ipsec_spi(const struct connection *c,
 					proto,
 					get_proto_reqid(c->child.reqid, proto, logger),
 					IPSEC_DOI_SPI_OUR_MIN, 0xffffffffU,
-					"SPI", logger);
+					logger);
 }
 
 /* Generate Unique CPI numbers.
@@ -426,7 +426,7 @@ ipsec_spi_t get_ipsec_cpi(const struct connection *c, struct logger *logger)
 					get_proto_reqid(c->child.reqid, &ip_protocol_ipcomp, logger),
 					IPCOMP_FIRST_NEGOTIATED,
 					IPCOMP_LAST_NEGOTIATED,
-					"CPI", logger);
+					logger);
 }
 
 /*

--- a/programs/pluto/kernel.h
+++ b/programs/pluto/kernel.h
@@ -289,7 +289,6 @@ struct kernel_ops {
 				     const struct ip_protocol *proto,
 				     reqid_t reqid,
 				     uintmax_t min, uintmax_t max,
-				     const char *story,	/* often SAID string */
 				     struct logger *logger);
 	bool (*del_ipsec_spi)(ipsec_spi_t spi,
 			      const struct ip_protocol *proto,

--- a/programs/pluto/kernel_ops.c
+++ b/programs/pluto/kernel_ops.c
@@ -431,7 +431,6 @@ ipsec_spi_t kernel_ops_get_ipsec_spi(ipsec_spi_t avoid,
 				     const struct ip_protocol *proto,
 				     reqid_t reqid,
 				     uintmax_t min, uintmax_t max,
-				     const char *story,	/* often SAID string */
 				     struct logger *logger)
 {
 	if (LDBGP(DBG_ROUTING, logger)) {
@@ -446,18 +445,17 @@ ipsec_spi_t kernel_ops_get_ipsec_spi(ipsec_spi_t avoid,
 			jam_address(buf, dst);
 			jam(buf, " reqid=%x", reqid);
 			jam(buf, " [%jx,%jx]", min, max);
-			jam(buf, " for %s ...", story);
 		}
 	}
 
 	passert(kernel_ops->get_ipsec_spi != NULL);
 	ipsec_spi_t spi = kernel_ops->get_ipsec_spi(avoid, src, dst, proto,
-						    reqid, min, max, story, logger);
+						    reqid, min, max, logger);
 
 	if (LDBGP(DBG_ROUTING, logger)) {
 		LLOG_JAMBUF(DEBUG_STREAM, logger, buf) {
-			jam(buf, "routing:   ... allocated "PRI_IPSEC_SPI" for %s",
-			    pri_ipsec_spi(spi), story);
+			jam(buf, "routing:   ... allocated "PRI_IPSEC_SPI,
+			    pri_ipsec_spi(spi));
 		}
 	}
 

--- a/programs/pluto/kernel_ops.h
+++ b/programs/pluto/kernel_ops.h
@@ -47,7 +47,6 @@ ipsec_spi_t kernel_ops_get_ipsec_spi(ipsec_spi_t avoid,
 				     const struct ip_protocol *proto,
 				     reqid_t reqid,
 				     uintmax_t min, uintmax_t max,
-				     const char *story,	/* often SAID string */
 				     struct logger *logger);
 
 bool kernel_ops_del_ipsec_spi(ipsec_spi_t spi, const struct ip_protocol *proto,

--- a/programs/pluto/kernel_pfkeyv2.c
+++ b/programs/pluto/kernel_pfkeyv2.c
@@ -709,7 +709,6 @@ static ipsec_spi_t pfkeyv2_get_ipsec_spi(ipsec_spi_t avoid UNUSED,
 					 const struct ip_protocol *protocol,
 					 reqid_t reqid,
 					 uintmax_t min, uintmax_t max,
-					 const char *story UNUSED,	/* often SAID string */
 					 struct logger *logger)
 {
 	struct verbose verbose = VERBOSE(DEBUG_STREAM, logger, NULL);

--- a/programs/pluto/kernel_xfrm.c
+++ b/programs/pluto/kernel_xfrm.c
@@ -2747,7 +2747,6 @@ static ipsec_spi_t xfrm_get_ipsec_spi(ipsec_spi_t avoid UNUSED,
 				      const struct ip_protocol *proto,
 				      reqid_t reqid,
 				      uintmax_t min, uintmax_t max,
-				      const char *story,
 				      struct logger *logger)
 {
 	struct {
@@ -2779,7 +2778,7 @@ static ipsec_spi_t xfrm_get_ipsec_spi(ipsec_spi_t avoid UNUSED,
 
 	int recv_errno;
 	if (!sendrecv_xfrm_msg(&req.n, XFRM_MSG_NEWSA, &rsp,
-			       "Get SPI", story,
+			       "Get SPI", "",
 			       &recv_errno, logger)) {
 		return 0;
 	}

--- a/programs/pluto/kernel_xfrm.c
+++ b/programs/pluto/kernel_xfrm.c
@@ -2778,7 +2778,7 @@ static ipsec_spi_t xfrm_get_ipsec_spi(ipsec_spi_t avoid UNUSED,
 
 	int recv_errno;
 	if (!sendrecv_xfrm_msg(&req.n, XFRM_MSG_NEWSA, &rsp,
-			       "Get SPI", "",
+			       "Get SPI", proto->name,
 			       &recv_errno, logger)) {
 		return 0;
 	}

--- a/testing/pluto/impair-install-ipsec-sa-inbound-policy-responder-ikev1/west.console.txt
+++ b/testing/pluto/impair-install-ipsec-sa-inbound-policy-responder-ikev1/west.console.txt
@@ -440,10 +440,10 @@ output: |    protocol ID: PROTO_IPSEC_ESP (0x3)
 output: |    SPI size: 4 (04)
 output: |    number of transforms: 2 (02)
 output: | last substructure: saving location 'ISAKMP Security Association Payload'.'ISAKMP Proposal Payload'.'next payload type'
-output: | "west-east" #2: routing:  kernel_ops_get_ipsec_spi() 192.1.2.23-ESP->192.1.2.45 reqid=4005 [1000,ffffffff] for SPI ...
+output: | "west-east" #2: routing:  kernel_ops_get_ipsec_spi() 192.1.2.23-ESP->192.1.2.45 reqid=4005 [1000,ffffffff]
 output: | sendrecv_xfrm_msg() sending 22 Get SPI SPI
 output: | sendrecv_xfrm_msg() recvfrom() returned 256 bytes
-output: | "west-east" #2: routing:   ... allocated 575ad026 for SPI
+output: | "west-east" #2: routing:   ... allocated 575ad026
 output: | emitting 4 raw bytes of SPI SPISPI ISAKMP Proposal Payload
 output: | SPI: 57 5a d0 26
 output: | *****emit ISAKMP Transform Payload (ESP):
@@ -869,10 +869,10 @@ output: |    protocol ID: PROTO_IPSEC_ESP (0x3)
 output: |    SPI size: 4 (04)
 output: |    number of transforms: 2 (02)
 output: | last substructure: saving location 'ISAKMP Security Association Payload'.'ISAKMP Proposal Payload'.'next payload type'
-output: | "west-east" #3: routing:  kernel_ops_get_ipsec_spi() 192.1.2.23-ESP->192.1.2.45 reqid=4005 [1000,ffffffff] for SPI ...
+output: | "west-east" #3: routing:  kernel_ops_get_ipsec_spi() 192.1.2.23-ESP->192.1.2.45 reqid=4005 [1000,ffffffff]
 output: | sendrecv_xfrm_msg() sending 22 Get SPI SPI
 output: | sendrecv_xfrm_msg() recvfrom() returned 256 bytes
-output: | "west-east" #3: routing:   ... allocated a5fd303f for SPI
+output: | "west-east" #3: routing:   ... allocated a5fd303f
 output: | emitting 4 raw bytes of SPI SPISPI ISAKMP Proposal Payload
 output: | SPI: a5 fd 30 3f
 output: | *****emit ISAKMP Transform Payload (ESP):

--- a/testing/pluto/impair-install-ipsec-sa-inbound-state-responder-ikev1/west.console.txt
+++ b/testing/pluto/impair-install-ipsec-sa-inbound-state-responder-ikev1/west.console.txt
@@ -440,10 +440,10 @@ output: |    protocol ID: PROTO_IPSEC_ESP (0x3)
 output: |    SPI size: 4 (04)
 output: |    number of transforms: 2 (02)
 output: | last substructure: saving location 'ISAKMP Security Association Payload'.'ISAKMP Proposal Payload'.'next payload type'
-output: | "west-east" #2: routing:  kernel_ops_get_ipsec_spi() 192.1.2.23-ESP->192.1.2.45 reqid=4005 [1000,ffffffff] for SPI ...
+output: | "west-east" #2: routing:  kernel_ops_get_ipsec_spi() 192.1.2.23-ESP->192.1.2.45 reqid=4005 [1000,ffffffff]
 output: | sendrecv_xfrm_msg() sending 22 Get SPI SPI
 output: | sendrecv_xfrm_msg() recvfrom() returned 256 bytes
-output: | "west-east" #2: routing:   ... allocated e2929ca3 for SPI
+output: | "west-east" #2: routing:   ... allocated e2929ca3
 output: | emitting 4 raw bytes of SPI SPISPI ISAKMP Proposal Payload
 output: | SPI: e2 92 9c a3
 output: | *****emit ISAKMP Transform Payload (ESP):
@@ -869,10 +869,10 @@ output: |    protocol ID: PROTO_IPSEC_ESP (0x3)
 output: |    SPI size: 4 (04)
 output: |    number of transforms: 2 (02)
 output: | last substructure: saving location 'ISAKMP Security Association Payload'.'ISAKMP Proposal Payload'.'next payload type'
-output: | "west-east" #3: routing:  kernel_ops_get_ipsec_spi() 192.1.2.23-ESP->192.1.2.45 reqid=4005 [1000,ffffffff] for SPI ...
+output: | "west-east" #3: routing:  kernel_ops_get_ipsec_spi() 192.1.2.23-ESP->192.1.2.45 reqid=4005 [1000,ffffffff]
 output: | sendrecv_xfrm_msg() sending 22 Get SPI SPI
 output: | sendrecv_xfrm_msg() recvfrom() returned 256 bytes
-output: | "west-east" #3: routing:   ... allocated f484df86 for SPI
+output: | "west-east" #3: routing:   ... allocated f484df86
 output: | emitting 4 raw bytes of SPI SPISPI ISAKMP Proposal Payload
 output: | SPI: f4 84 df 86
 output: | *****emit ISAKMP Transform Payload (ESP):

--- a/testing/pluto/impair-install-ipsec-sa-outbound-policy-responder-ikev1/west.console.txt
+++ b/testing/pluto/impair-install-ipsec-sa-outbound-policy-responder-ikev1/west.console.txt
@@ -448,10 +448,10 @@ output: |    protocol ID: PROTO_IPSEC_ESP (0x3)
 output: |    SPI size: 4 (04)
 output: |    number of transforms: 2 (02)
 output: | last substructure: saving location 'ISAKMP Security Association Payload'.'ISAKMP Proposal Payload'.'next payload type'
-output: | "west-east" #2: routing:  kernel_ops_get_ipsec_spi() 192.1.2.23-ESP->192.1.2.45 reqid=4005 [1000,ffffffff] for SPI ...
+output: | "west-east" #2: routing:  kernel_ops_get_ipsec_spi() 192.1.2.23-ESP->192.1.2.45 reqid=4005 [1000,ffffffff]
 output: | sendrecv_xfrm_msg() sending 22 Get SPI SPI
 output: | sendrecv_xfrm_msg() recvfrom() returned 256 bytes
-output: | "west-east" #2: routing:   ... allocated 665b5b22 for SPI
+output: | "west-east" #2: routing:   ... allocated 665b5b22
 output: | emitting 4 raw bytes of SPI SPISPI ISAKMP Proposal Payload
 output: | SPI: 66 5b 5b 22
 output: | *****emit ISAKMP Transform Payload (ESP):

--- a/testing/pluto/impair-install-ipsec-sa-outbound-state-responder-ikev1/west.console.txt
+++ b/testing/pluto/impair-install-ipsec-sa-outbound-state-responder-ikev1/west.console.txt
@@ -448,10 +448,10 @@ output: |    protocol ID: PROTO_IPSEC_ESP (0x3)
 output: |    SPI size: 4 (04)
 output: |    number of transforms: 2 (02)
 output: | last substructure: saving location 'ISAKMP Security Association Payload'.'ISAKMP Proposal Payload'.'next payload type'
-output: | "west-east" #2: routing:  kernel_ops_get_ipsec_spi() 192.1.2.23-ESP->192.1.2.45 reqid=4005 [1000,ffffffff] for SPI ...
+output: | "west-east" #2: routing:  kernel_ops_get_ipsec_spi() 192.1.2.23-ESP->192.1.2.45 reqid=4005 [1000,ffffffff]
 output: | sendrecv_xfrm_msg() sending 22 Get SPI SPI
 output: | sendrecv_xfrm_msg() recvfrom() returned 256 bytes
-output: | "west-east" #2: routing:   ... allocated fe237aa7 for SPI
+output: | "west-east" #2: routing:   ... allocated fe237aa7
 output: | emitting 4 raw bytes of SPI SPISPI ISAKMP Proposal Payload
 output: | SPI: fe 23 7a a7
 output: | *****emit ISAKMP Transform Payload (ESP):


### PR DESCRIPTION
fixes #2654

Removed the 'story' parameter from kernel_ops_get_ipsec_spi() and related internal calls.
This parameter was only used for debug logging.

Updated 4 impair-install-ipsec-sa golden files to reflect the removal.
No functional behavior was changed. Tested compilation and key unit tests.

Sample output from east.pluto.log:

| iface:   allocated 2560 buffer for SIOCGIFCONF
| routing:   ... allocated 7d2d7fd3