### PR TITLE
ikev2: reword Child SA not found log for received delete request

### DIFF
--- a/programs/pluto/ikev2_delete.c
+++ b/programs/pluto/ikev2_delete.c
@@ -383,8 +383,8 @@ bool process_v2DELETE_requests(bool *del_ike, struct ike_sa *ike, struct msg_dig
 				if (child == NULL) {
 					name_buf b;
 					llog_sa(RC_LOG, ike,
-						"received delete request for %s Child SA with outbound SPI "PRI_IPSEC_SPI" but corresponding state not found",
-						str_enum_long(&ikev2_delete_protocol_id_names,
+						"received delete request for %s Child SA with outbound SPI "PRI_IPSEC_SPI"; Child SA not found",
+						str_enum_short(&ikev2_delete_protocol_id_names,
 							  v2del->isad_protoid, &b),
 						pri_ipsec_spi(outbound_spi));
 					continue;

--- a/testing/pluto/crossing-streams-03-ikev2-delete-child/07-east-missing.sh
+++ b/testing/pluto/crossing-streams-03-ikev2-delete-child/07-east-missing.sh
@@ -1,0 +1,1 @@
+grep "received delete request for" /tmp/pluto.log

--- a/testing/pluto/crossing-streams-03-ikev2-delete-child/east.console.txt
+++ b/testing/pluto/crossing-streams-03-ikev2-delete-child/east.console.txt
@@ -17,3 +17,6 @@ east #
 east #
  # now back to WEST
 east #
+ grep "received delete request for" /tmp/pluto.log
+"east-west" #1: received delete request for ESP Child SA with outbound SPI SPISPI; Child SA not found
+east #

--- a/testing/sanitizers/ipsec-status.sed
+++ b/testing/sanitizers/ipsec-status.sed
@@ -20,7 +20,7 @@ s/comp\([.:]\)[a-z0-9]\{2,8\}@/comp\1COMPSPIi@/g
 
 #
 
-s/ SPI [0-9a-f][0-9a-f]* / SPI SPISPI /
+s/ SPI [0-9a-f][0-9a-f]*\([ ;]\)/ SPI SPISPI\1/
 
 # don't change seq number "0" entries
 s/seq in:[1-9][0-9]* out:[0-9]*/seq in:XXXXX out:YYYYY/g


### PR DESCRIPTION
Fixes #1585 

Rewording:
`received delete request for IKEv2_SEC_PROTO_ESP Child SA with outbound SPI 4dd368fb but corresponding state not found`

to:
`received delete request for ESP Child SA with outbound SPI 4dd368fb; Child SA not found`