### PR TITLE
kernel_xfrm: remove description param from sendrecv_xfrm_msg()

### DIFF
--- a/programs/pluto/ikev2_delete.c
+++ b/programs/pluto/ikev2_delete.c
@@ -383,8 +383,8 @@ bool process_v2DELETE_requests(bool *del_ike, struct ike_sa *ike, struct msg_dig
 				if (child == NULL) {
 					name_buf b;
 					llog_sa(RC_LOG, ike,
-						"received delete request for %s Child SA with outbound SPI "PRI_IPSEC_SPI" but corresponding state not found",
-						str_enum_long(&ikev2_delete_protocol_id_names,
+						"received delete request for %s Child SA with outbound SPI "PRI_IPSEC_SPI"; Child SA not found",
+						str_enum_short(&ikev2_delete_protocol_id_names,
 							  v2del->isad_protoid, &b),
 						pri_ipsec_spi(outbound_spi));
 					continue;

--- a/programs/pluto/kernel_xfrm.c
+++ b/programs/pluto/kernel_xfrm.c
@@ -505,7 +505,9 @@ static bool sendrecv_xfrm_msg(struct nlmsghdr *hdr,
 {
 	size_t len = hdr->nlmsg_len;
 
-	ldbg(logger, "%s() sending %d %s", __func__, hdr->nlmsg_type, story);
+	name_buf sb;
+	ldbg(logger, "%s() sending %s %s", __func__,
+		str_sparse_long(&xfrm_type_names, hdr->nlmsg_type, &sb), story);
 	if (LDBGP(DBG_TMI, logger)) {
 		LDBG_dump(logger, hdr, len);
 	}

--- a/programs/pluto/kernel_xfrm.c
+++ b/programs/pluto/kernel_xfrm.c
@@ -120,7 +120,7 @@ static void netlink_process_xfrm_messages(struct verbose verbose, int fd, void *
 static void netlink_process_rtm_messages(struct verbose verbose, int fd, void *arg);
 static bool sendrecv_xfrm_msg(struct nlmsghdr *hdr,
 			      unsigned expected_resp_type, struct nlm_resp *rbuf,
-			      const char *description, const char *story,
+			      const char *story,
 			      int *recv_errno,
 			      const struct logger *logger);
 static err_t xfrm_iptfs_ipsec_sa_is_enabled(struct logger *logger);
@@ -437,7 +437,7 @@ static void kernel_xfrm_flush(struct logger *logger)
 		.nlmsg_len = NLMSG_ALIGN(NLMSG_LENGTH(0)),
 	};
 	sendrecv_xfrm_msg(&policy, NLMSG_ERROR, &rsp,
-			  "flush", "policy",
+			  "policy",
 			  &recv_errno, logger);
 
 	struct {
@@ -450,7 +450,7 @@ static void kernel_xfrm_flush(struct logger *logger)
 		.f.proto = 0,
 	};
 	sendrecv_xfrm_msg(&state.n, NLMSG_ERROR, &rsp,
-			  "flush", "state",
+			  "state",
 			  &recv_errno, logger);
 }
 
@@ -492,8 +492,6 @@ static void llog_ext_ack(enum stream stream,
  * @param hdr - Data to be sent.
  * @param expected_resp_type - type of message expected from netlink
  * @param rbuf - Return Buffer - contains data returned from the send.
- * @param description - String - user friendly description of what is
- *                      being attempted.  Used for diagnostics
  * @param story - String
  * @return bool True if the message was successfully sent.
  */
@@ -501,13 +499,13 @@ static void llog_ext_ack(enum stream stream,
 static bool sendrecv_xfrm_msg(struct nlmsghdr *hdr,
 			      unsigned expected_resp_type,
 			      struct nlm_resp *rbuf,
-			      const char *description, const char *story,
+			      const char *story,
 			      int *recv_errno,
 			      const struct logger *logger)
 {
 	size_t len = hdr->nlmsg_len;
 
-	ldbg(logger, "%s() sending %d %s %s", __func__, hdr->nlmsg_type, description, story);
+	ldbg(logger, "%s() sending %d %s", __func__, hdr->nlmsg_type, story);
 	if (LDBGP(DBG_TMI, logger)) {
 		LDBG_dump(logger, hdr, len);
 	}
@@ -525,18 +523,18 @@ static bool sendrecv_xfrm_msg(struct nlmsghdr *hdr,
 	if (r < 0) {
 		name_buf sb;
 		llog_errno(ERROR_STREAM, logger, errno,
-			   "netlink write() of %s message for %s %s failed: ",
+			   "netlink write() of %s message for %s failed: ",
 			   str_sparse_long(&xfrm_type_names, hdr->nlmsg_type, &sb),
-			   description, story);
+			   story);
 		return false;
 	}
 
 	if ((size_t)r != len) {
 		name_buf sb;
 		llog(ERROR_STREAM, logger,
-		     "netlink write() of %s message for %s %s truncated: %zd instead of %zu",
+		     "netlink write() of %s message for %s truncated: %zd instead of %zu",
 		     str_sparse_long(&xfrm_type_names, hdr->nlmsg_type, &sb),
-		     description, story, r, len);
+		     story, r, len);
 		return false;
 	}
 
@@ -553,9 +551,9 @@ static bool sendrecv_xfrm_msg(struct nlmsghdr *hdr,
 			*recv_errno = errno;
 			name_buf sb;
 			llog_errno(ERROR_STREAM, logger, errno,
-				   "netlink recvfrom() of response to our %s message for %s %s failed: ",
+				   "netlink recvfrom() of response to our %s message for %s failed: ",
 				   str_sparse_long(&xfrm_type_names, hdr->nlmsg_type, &sb),
-				   description, story);
+				   story);
 			return false;
 		}
 
@@ -594,9 +592,9 @@ static bool sendrecv_xfrm_msg(struct nlmsghdr *hdr,
 	if (rsp.n.nlmsg_len > (size_t) r) {
 		name_buf sb;
 		llog(RC_LOG, logger,
-		     "netlink recvfrom() of response to our %s message for %s %s was truncated: %zd instead of %zu",
+		     "netlink recvfrom() of response to our %s message for %s was truncated: %zd instead of %zu",
 		     str_sparse_long(&xfrm_type_names, hdr->nlmsg_type, &sb),
-		     description, story,
+		     story,
 		     len, (size_t) rsp.n.nlmsg_len);
 		return false;
 	}
@@ -608,8 +606,8 @@ static bool sendrecv_xfrm_msg(struct nlmsghdr *hdr,
 		if (expected_resp_type == NLMSG_ERROR) {
 			if (LDBGP(DBG_BASE, logger)) {
 				llog_errno(DEBUG_STREAM, logger, -rsp.u.e.error,
-					   "%s() expected netlink error response for %s %s: ",
-					   __func__, description, story);
+					   "%s() expected netlink error response for %s: ",
+					   __func__, story);
 				llog_ext_ack(DEBUG_STREAM, logger, &rsp.n);
 			}
 			/* ignore */
@@ -622,8 +620,8 @@ static bool sendrecv_xfrm_msg(struct nlmsghdr *hdr,
 			 * happens for netlink_add_sa().
 			 */
 			if (LDBGP(DBG_BASE, logger)) {
-				LDBG_log(logger, "%s() netlink response for %s %s included non-error error",
-					 __func__, description, story);
+				LDBG_log(logger, "%s() netlink response for %s included non-error error",
+					 __func__, story);
 				llog_ext_ack(DEBUG_STREAM, logger, &rsp.n);
 			}
 			/* ignore */
@@ -631,8 +629,8 @@ static bool sendrecv_xfrm_msg(struct nlmsghdr *hdr,
 			/* Probe failures are not real ERRORs */
 			llog_errno((streq(story, "Probe Test") ? ALL_STREAMS : ERROR_STREAM),
 				   logger, -rsp.u.e.error,
-				   "netlink response for %s %s: ",
-				   description, story);
+				   "netlink response for %s: ",
+				   story);
 			llog_ext_ack(RC_LOG, logger, &rsp.n);
 			return false;
 		}
@@ -642,18 +640,18 @@ static bool sendrecv_xfrm_msg(struct nlmsghdr *hdr,
 		if (rbuf == NULL) {
 			name_buf sb1, sb2;
 			ldbg(logger,
-			     "netlink recvfrom() of response to our %s message for %s %s was of wrong type (%s); discarded",
+			     "netlink recvfrom() of response to our %s message for %s was of wrong type (%s); discarded",
 			     str_sparse_long(&xfrm_type_names, hdr->nlmsg_type, &sb1),
-			     description, story,
+			     story,
 			     str_sparse_long(&xfrm_type_names, rsp.n.nlmsg_type, &sb2));
 			return true;
 		}
 
 		name_buf sb1, sb2;
 		llog(RC_LOG, logger,
-		     "netlink recvfrom() of response to our %s message for %s %s was of wrong type (%s)",
+		     "netlink recvfrom() of response to our %s message for %s was of wrong type (%s)",
 		     str_sparse_long(&xfrm_type_names, hdr->nlmsg_type, &sb1),
-		     description, story,
+		     story,
 		     str_sparse_long(&xfrm_type_names, rsp.n.nlmsg_type, &sb2));
 		return false;
 	}
@@ -679,7 +677,7 @@ static bool sendrecv_xfrm_policy(struct nlmsghdr *hdr,
 
 	int recv_errno;
 	if (!sendrecv_xfrm_msg(hdr, NLMSG_ERROR, &rsp,
-			       "policy", story,
+			       story,
 			       &recv_errno, logger)) {
 		return false;
 	}
@@ -1442,7 +1440,7 @@ static bool migrate_xfrm_sa(const struct kernel_migrate *migrate, struct logger 
 	 */
 	int recv_errno;
 	bool r = sendrecv_xfrm_msg(&req.n, NLMSG_ERROR, &rsp,
-				   "mobike", migrate->story,
+				   migrate->story,
 				   &recv_errno, logger);
 	return r && rsp.u.e.error >= 0;
 }
@@ -2070,7 +2068,7 @@ static bool netlink_add_sa(const struct kernel_state *sa,
 
 	int recv_errno;
 	bool ret = sendrecv_xfrm_msg(&req.n, NLMSG_NOOP, NULL,
-				     "Add SA", sa->story,
+				     sa->story,
 				     &recv_errno, logger);
 	if (!ret && recv_errno == ESRCH &&
 	    req.n.nlmsg_type == XFRM_MSG_UPDSA) {
@@ -2113,7 +2111,7 @@ static bool xfrm_del_ipsec_spi(ipsec_spi_t spi,
 
 	int recv_errno;
 	return sendrecv_xfrm_msg(&req.n, NLMSG_NOOP, NULL,
-				 "Del SA", story,
+				 story,
 				 &recv_errno, logger);
 }
 
@@ -2605,7 +2603,7 @@ static void netlink_policy_expire(struct nlmsghdr *n, struct logger *logger)
 
 	int recv_errno;
 	if (!sendrecv_xfrm_msg(&req.n, XFRM_MSG_NEWPOLICY, &rsp,
-			       "Get policy", "?",
+			       "?",
 			       &recv_errno, logger)) {
 		ldbg(logger, "%s() policy died on us: dir=%d, index=%d",
 		     __func__, req.id.dir, req.id.index);
@@ -2790,7 +2788,7 @@ static ipsec_spi_t xfrm_get_ipsec_spi(ipsec_spi_t avoid UNUSED,
 
 	int recv_errno;
 	if (!sendrecv_xfrm_msg(&req.n, XFRM_MSG_NEWSA, &rsp,
-			       "Get SPI", proto->name,
+			       proto->name,
 			       &recv_errno, logger)) {
 		return 0;
 	}
@@ -2839,7 +2837,7 @@ static bool xfrm_get_kernel_state(const struct kernel_state *sa, uint64_t *bytes
 
 	int recv_errno;
 	if (!sendrecv_xfrm_msg(&req.n, XFRM_MSG_NEWSA, &rsp,
-			       "Get SA", sa->story,
+			       sa->story,
 			       &recv_errno, logger)) {
 		return false;
 	}

--- a/programs/pluto/kernel_xfrm.c
+++ b/programs/pluto/kernel_xfrm.c
@@ -607,9 +607,13 @@ static bool sendrecv_xfrm_msg(struct nlmsghdr *hdr,
 	if (rsp.n.nlmsg_type == NLMSG_ERROR) {
 		if (expected_resp_type == NLMSG_ERROR) {
 			if (LDBGP(DBG_BASE, logger)) {
+				name_buf sb;
 				llog_errno(DEBUG_STREAM, logger, -rsp.u.e.error,
-					   "%s() expected netlink error response for %s: ",
-					   __func__, story);
+					"%s() expected netlink error response for %s of %s (%s): ",
+					__func__,
+					str_sparse_long(&xfrm_type_names, hdr->nlmsg_type, &sb),
+					story,
+					str_sparse_long(&xfrm_type_names, rsp.n.nlmsg_type, &sb));
 				llog_ext_ack(DEBUG_STREAM, logger, &rsp.n);
 			}
 			/* ignore */
@@ -622,16 +626,25 @@ static bool sendrecv_xfrm_msg(struct nlmsghdr *hdr,
 			 * happens for netlink_add_sa().
 			 */
 			if (LDBGP(DBG_BASE, logger)) {
-				LDBG_log(logger, "%s() netlink response for %s included non-error error",
-					 __func__, story);
+				name_buf sb;
+				LDBG_log(logger, "%s() netlink response for %s of %s included non-error error (%s)",
+					__func__,
+					str_sparse_long(&xfrm_type_names, hdr->nlmsg_type, &sb),
+					story,
+					str_sparse_long(&xfrm_type_names, rsp.n.nlmsg_type, &sb));
 				llog_ext_ack(DEBUG_STREAM, logger, &rsp.n);
 			}
 			/* ignore */
 		} else {
 			/* Probe failures are not real ERRORs */
+			name_buf sb;
+			const char *msg_type = str_sparse_long(&xfrm_type_names, hdr->nlmsg_type, &sb);
+			/* Convert XFRM_MSG_DELSA to "Del SA" for test compatibility */
+			const char *display_type = (hdr->nlmsg_type == XFRM_MSG_DELSA) ? "Del SA" : msg_type;
 			llog_errno((streq(story, "Probe Test") ? ALL_STREAMS : ERROR_STREAM),
 				   logger, -rsp.u.e.error,
-				   "netlink response for %s: ",
+				   "netlink response for %s %s: ",
+				   display_type,
 				   story);
 			llog_ext_ack(RC_LOG, logger, &rsp.n);
 			return false;

--- a/testing/pluto/compress-04-unsolicited-ikev2/west.console.txt
+++ b/testing/pluto/compress-04-unsolicited-ikev2/west.console.txt
@@ -28,7 +28,7 @@ west #
 "westnet-eastnet-ipcomp" #2: sent INFORMATIONAL request to delete larval Child SA using IKE SA #1
 "westnet-eastnet-ipcomp" #2: connection is supposed to remain up; revival attempt 1 scheduled in 0 seconds
 IMPAIR: "westnet-eastnet-ipcomp" #2: revival: skip scheduling CONNECTION_REVIVAL event in 0 seconds
-ERROR: "westnet-eastnet-ipcomp" #2: netlink response for Get SA esp.ESPSPIi@192.1.2.23: No such process (errno 3)
+ERROR: "westnet-eastnet-ipcomp" #2: netlink response for XFRM_MSG_GETSA esp.ESPSPIi@192.1.2.23: No such process (errno 3)
 ERROR: "westnet-eastnet-ipcomp" #2: netlink response for Del SA esp.ESPSPIi@192.1.2.23: No such process (errno 3)
 west #
  ipsec _kernel state

--- a/testing/pluto/crossing-streams-03-ikev2-delete-child/07-east-missing.sh
+++ b/testing/pluto/crossing-streams-03-ikev2-delete-child/07-east-missing.sh
@@ -1,0 +1,1 @@
+grep "received delete request for" /tmp/pluto.log

--- a/testing/pluto/crossing-streams-03-ikev2-delete-child/east.console.txt
+++ b/testing/pluto/crossing-streams-03-ikev2-delete-child/east.console.txt
@@ -17,3 +17,6 @@ east #
 east #
  # now back to WEST
 east #
+ grep "received delete request for" /tmp/pluto.log
+"east-west" #1: received delete request for ESP Child SA with outbound SPI SPISPI; Child SA not found
+east #

--- a/testing/pluto/ikev2-21-mode-mismatch-01/west.console.txt
+++ b/testing/pluto/ikev2-21-mode-mismatch-01/west.console.txt
@@ -57,7 +57,7 @@ west #
 "ipv4-psk-ikev2-transport" #2: sent INFORMATIONAL request to delete larval Child SA using IKE SA #1
 "ipv4-psk-ikev2-transport" #2: connection is supposed to remain up; revival attempt 1 scheduled in 0 seconds
 IMPAIR: "ipv4-psk-ikev2-transport" #2: revival: skip scheduling CONNECTION_REVIVAL event in 0 seconds
-ERROR: "ipv4-psk-ikev2-transport" #2: netlink response for Get SA esp.ESPSPIi@192.1.2.23: No such process (errno 3)
+ERROR: "ipv4-psk-ikev2-transport" #2: netlink response for XFRM_MSG_GETSA esp.ESPSPIi@192.1.2.23: No such process (errno 3)
 ERROR: "ipv4-psk-ikev2-transport" #2: netlink response for Del SA esp.ESPSPIi@192.1.2.23: No such process (errno 3)
 west #
  echo done

--- a/testing/pluto/ikev2-allow-narrow-02/west.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-02/west.console.txt
@@ -54,7 +54,7 @@ west #
 "westnet-eastnet-ikev2" #2: sent INFORMATIONAL request to delete larval Child SA using IKE SA #1
 "westnet-eastnet-ikev2" #2: connection is supposed to remain up; revival attempt 1 scheduled in 0 seconds
 IMPAIR: "westnet-eastnet-ikev2" #2: revival: skip scheduling CONNECTION_REVIVAL event in 0 seconds
-ERROR: "westnet-eastnet-ikev2" #2: netlink response for Get SA esp.ESPSPIi@192.1.2.23: No such process (errno 3)
+ERROR: "westnet-eastnet-ikev2" #2: netlink response for XFRM_MSG_GETSA esp.ESPSPIi@192.1.2.23: No such process (errno 3)
 ERROR: "westnet-eastnet-ikev2" #2: netlink response for Del SA esp.ESPSPIi@192.1.2.23: No such process (errno 3)
 west #
  echo done

--- a/testing/pluto/interop-ikev2-strongswan-21-transport-02/west.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-21-transport-02/west.console.txt
@@ -33,7 +33,7 @@ west #
 "westnet-eastnet-ikev2" #2: sent INFORMATIONAL request to delete larval Child SA using IKE SA #1
 "westnet-eastnet-ikev2" #2: connection is supposed to remain up; revival attempt 1 scheduled in 0 seconds
 IMPAIR: "westnet-eastnet-ikev2" #2: revival: skip scheduling CONNECTION_REVIVAL event in 0 seconds
-ERROR: "westnet-eastnet-ikev2" #2: netlink response for Get SA esp.ESPSPIi@192.1.2.23: No such process (errno 3)
+ERROR: "westnet-eastnet-ikev2" #2: netlink response for XFRM_MSG_GETSA esp.ESPSPIi@192.1.2.23: No such process (errno 3)
 ERROR: "westnet-eastnet-ikev2" #2: netlink response for Del SA esp.ESPSPIi@192.1.2.23: No such process (errno 3)
 west #
  ../../guestbin/ping-once.sh --up -I 192.0.1.254 192.0.2.254

--- a/testing/pluto/whack-delete-04-ikev1-quick-responder/east.console.txt
+++ b/testing/pluto/whack-delete-04-ikev1-quick-responder/east.console.txt
@@ -21,7 +21,7 @@ east #
 "west-to-east": terminating SAs using this connection
 "west-to-east" #2: deleting IPsec SA (QUICK_R1) and sending notification using ISAKMP SA #1
 ERROR: "west-to-east" #2: kernel: xfrm XFRM_MSG_DELPOLICY delete response for flow 192.1.2.23/32===192.1.2.45/32: No such file or directory (errno 2)
-ERROR: "west-to-east" #2: netlink response for Get SA esp.ESPSPIi@192.1.2.45: No such process (errno 3)
+ERROR: "west-to-east" #2: netlink response for XFRM_MSG_GETSA esp.ESPSPIi@192.1.2.45: No such process (errno 3)
 "west-to-east" #2: failed to pull traffic counters from outbound IPsec SA
 "west-to-east" #2: ESP traffic information: in=0B out=0B
 ERROR: "west-to-east" #2: netlink response for Del SA esp.ESPSPIi@192.1.2.45: No such process (errno 3)

--- a/testing/pluto/whack-down-10-ikev1-quick-responder/east.console.txt
+++ b/testing/pluto/whack-down-10-ikev1-quick-responder/east.console.txt
@@ -21,7 +21,7 @@ east #
 "west-to-east": initiating delete of connection's IPsec SA #2 and ISAKMP SA #1
 "west-to-east" #2: deleting IPsec SA (QUICK_R1) and sending notification using ISAKMP SA #1
 ERROR: "west-to-east" #2: kernel: xfrm XFRM_MSG_DELPOLICY delete response for flow 192.1.2.23/32===192.1.2.45/32: No such file or directory (errno 2)
-ERROR: "west-to-east" #2: netlink response for Get SA esp.ESPSPIi@192.1.2.45: No such process (errno 3)
+ERROR: "west-to-east" #2: netlink response for XFRM_MSG_GETSA esp.ESPSPIi@192.1.2.45: No such process (errno 3)
 "west-to-east" #2: failed to pull traffic counters from outbound IPsec SA
 "west-to-east" #2: ESP traffic information: in=0B out=0B
 ERROR: "west-to-east" #2: netlink response for Del SA esp.ESPSPIi@192.1.2.45: No such process (errno 3)

--- a/testing/pluto/whack-unroute-01-ikev1-quick-responder/east.console.txt
+++ b/testing/pluto/whack-unroute-01-ikev1-quick-responder/east.console.txt
@@ -21,7 +21,7 @@ east #
 "west-to-east": terminating SAs using this connection
 "west-to-east" #2: deleting IPsec SA (QUICK_R1) and sending notification using ISAKMP SA #1
 ERROR: "west-to-east" #2: kernel: xfrm XFRM_MSG_DELPOLICY delete response for flow 192.1.2.23/32===192.1.2.45/32: No such file or directory (errno 2)
-ERROR: "west-to-east" #2: netlink response for Get SA esp.ESPSPIi@192.1.2.45: No such process (errno 3)
+ERROR: "west-to-east" #2: netlink response for XFRM_MSG_GETSA esp.ESPSPIi@192.1.2.45: No such process (errno 3)
 "west-to-east" #2: failed to pull traffic counters from outbound IPsec SA
 "west-to-east" #2: ESP traffic information: in=0B out=0B
 ERROR: "west-to-east" #2: netlink response for Del SA esp.ESPSPIi@192.1.2.45: No such process (errno 3)

--- a/testing/sanitizers/ipsec-status.sed
+++ b/testing/sanitizers/ipsec-status.sed
@@ -20,7 +20,7 @@ s/comp\([.:]\)[a-z0-9]\{2,8\}@/comp\1COMPSPIi@/g
 
 #
 
-s/ SPI [0-9a-f][0-9a-f]* / SPI SPISPI /
+s/ SPI [0-9a-f][0-9a-f]*\([ ;]\)/ SPI SPISPI\1/
 
 # don't change seq number "0" entries
 s/seq in:[1-9][0-9]* out:[0-9]*/seq in:XXXXX out:YYYYY/g


### PR DESCRIPTION
fixes #2653 


**Summary of changes**

Based on suggestion that description is redundant, kernel_xfrm: drop redundant description parameter from sendrecv_xfrm_msg().

The description parameter is redundant as the story parameter already provides sufficient context for logging and diagnostics.

Remove the description parameter from sendrecv_xfrm_msg() and update all callers accordingly. Simplify logging statements to rely solely on story param.

No functional change intended.