### PR TITLE
Add .dir-locals.el for Emacs

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,2 @@
+((c-mode . ((c-file-style . "linux")))
+ (yaml-mode . ((indent-tabs-mode . nil))))


### PR DESCRIPTION
Inspired by 099fce41ba57904a745a6391894972ace9868db0, it's probably good idea to have an indentation setup for Emacs in .dir-locals.el.

- [x] have you seen our [Programming Conventions](https://github.com/libreswan/libreswan/wiki/Hacking:-Programming-Conventions) guideline
- [x] have you seen our [Git, GitHub, and Pull Requests](https://github.com/libreswan/libreswan/wiki/Hacking:-Git,-GitHub,-and-Pull-Requests) guideline