### PR TITLE
Fixes #2628

### DIFF
--- a/programs/pluto/updown.c
+++ b/programs/pluto/updown.c
@@ -41,6 +41,8 @@
 #include "secrets.h"		/* for struct pubkey_list */
 #include "server_run.h"
 #include "server_fork.h"
+#include <string.h>
+#include <stdlib.h>
 
 static server_fork_cb updown_async_callback;
 const char *pluto_dns_resolver;
@@ -95,10 +97,16 @@ static void jam_clean_xauth_username(struct jambuf *buf,
  * note: this mutates *st by calling get_sa_bundle_info().
  */
 
+// struct updown_exec {
+// 	char buffer[2048];
+// 	const char *env[100];
+// 	const char *arg[4];
+// };
+
 struct updown_exec {
-	char buffer[2048];
-	const char *env[100];
-	const char *arg[4];
+    char buffer[2048];
+    const char *env[100];
+    const char *arg[16];  // increased size
 };
 
 static bool build_updown_exec(struct updown_exec *exec,
@@ -112,16 +120,60 @@ static bool build_updown_exec(struct updown_exec *exec,
 	/*
 	 * Build argv[]
 	 */
-	const char **argv = exec->arg;
-	if (c->local->config->child.updown.updown_config_exec) {
-		(*argv++) = c->local->config->child.updown.command;
-	} else {
-		(*argv++) = "/bin/sh";
-		(*argv++) = "-c";
-		(*argv++) = c->local->config->child.updown.command;
-	}
-	(*argv++) = NULL;
-	vassert(argv <= exec->arg + elemsof(exec->arg));
+	// const char **argv = exec->arg;
+	// if (c->local->config->child.updown.updown_config_exec) {
+	// 	(*argv++) = c->local->config->child.updown.command;
+	// } else {
+	// 	(*argv++) = "/bin/sh";
+	// 	(*argv++) = "-c";
+	// 	(*argv++) = c->local->config->child.updown.command;
+
+
+	// }
+	// (*argv++) = NULL;
+	// vassert(argv <= exec->arg + elemsof(exec->arg));
+
+
+const char **argv = exec->arg;
+
+const char *cmd = c->local->config->child.updown.command;
+
+/* copy command into local buffer */
+char buf[1024];
+snprintf(buf, sizeof(buf), "%s", cmd);
+
+/* simple whitespace splitting */
+char *p = buf;
+while (*p != '\0' && argv < exec->arg + elemsof(exec->arg) - 1) {
+
+    /* skip leading spaces */
+    while (*p == ' ') {
+        p++;
+    }
+
+    if (*p == '\0') {
+        break;
+    }
+
+    (*argv++) = p;
+
+    /* find next space */
+    while (*p != '\0' && *p != ' ') {
+        p++;
+    }
+
+    if (*p == ' ') {
+        *p = '\0';
+        p++;
+    }
+}
+
+(*argv++) = NULL;
+
+vassert(argv <= exec->arg + elemsof(exec->arg));
+
+
+
 
 	/*
 	 * Build envp[]


### PR DESCRIPTION
This PR removes the use of `/bin/sh -c` for executing updown commands
in pluto and replaces it with direct argv[] execution.



