### PR TITLE
pluto: log SKF[n fragments] prefix for reassembled IKEv2 messages

### DIFF
--- a/programs/pluto/ikev2.c
+++ b/programs/pluto/ikev2.c
@@ -2057,9 +2057,12 @@ void llog_transition_start(enum stream stream, struct logger *logger,
 			   const struct v2_transition *svm,
 			   const struct msg_digest *md)
 {
+	bool reassembled = (v2_msg_role(md) == MESSAGE_REQUEST &&
+			    md->v2_frags_total > 0);
+
 	LLOG_JAMBUF(stream, logger, buf) {
 
-		jam_string(buf, "processing ");
+		jam_string(buf, reassembled ? "processing reassembled " : "processing ");
 
 		PEXPECT(logger, svm->exchange->type == md->hdr.isa_xchg);
 		jam_string(buf, svm->exchange->name);
@@ -2074,6 +2077,11 @@ void llog_transition_start(enum stream stream, struct logger *logger,
 		jam_endpoint_address_protocol_port_sensitive(buf, &md->sender);
 
 		jam_string(buf, " containing ");
+		if (reassembled) {
+			jam(buf, "SKF[%u fragment%s] -> ",
+			    md->v2_frags_total,
+			    md->v2_frags_total == 1 ? "" : "s");
+		}
 		jam_msg_digest_payloads(buf, md);
 	}
 }

--- a/programs/pluto/ikev2.c
+++ b/programs/pluto/ikev2.c
@@ -2057,12 +2057,9 @@ void llog_transition_start(enum stream stream, struct logger *logger,
 			   const struct v2_transition *svm,
 			   const struct msg_digest *md)
 {
-	bool reassembled = (v2_msg_role(md) == MESSAGE_REQUEST &&
-			    md->v2_frags_total > 0);
-
 	LLOG_JAMBUF(stream, logger, buf) {
 
-		jam_string(buf, reassembled ? "processing reassembled " : "processing ");
+		jam_string(buf, "processing ");
 
 		PEXPECT(logger, svm->exchange->type == md->hdr.isa_xchg);
 		jam_string(buf, svm->exchange->name);
@@ -2077,11 +2074,12 @@ void llog_transition_start(enum stream stream, struct logger *logger,
 		jam_endpoint_address_protocol_port_sensitive(buf, &md->sender);
 
 		jam_string(buf, " containing ");
-		if (reassembled) {
-			jam(buf, "SKF[%u fragment%s] -> ",
+		jam_msg_digest_payloads(buf, md);
+
+		if (md->v2_frags_total > 0) {
+			jam(buf, " reassembled from %u fragment%s",
 			    md->v2_frags_total,
 			    md->v2_frags_total == 1 ? "" : "s");
 		}
-		jam_msg_digest_payloads(buf, md);
 	}
 }

--- a/testing/pluto/addresspool-4in4-in-use-ikev2-ikev1/north.console.txt
+++ b/testing/pluto/addresspool-4in4-in-use-ikev2-ikev1/north.console.txt
@@ -23,7 +23,7 @@ north #
 "north-east" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "north-east" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "north-east" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.3.33/32===192.0.2.0/24]
-"north-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"north-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "north-east" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "north-east" #2: received INTERNAL_IP4_ADDRESS 192.0.2.101
 "north-east" #2: received INTERNAL_IP4_DNS server address 1.2.3.4

--- a/testing/pluto/addresspool-4in4-reserved-ikev2-ikev1/north.console.txt
+++ b/testing/pluto/addresspool-4in4-reserved-ikev2-ikev1/north.console.txt
@@ -23,7 +23,7 @@ north #
 "north-east" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "north-east" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "north-east" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.3.33/32===192.0.2.0/24]
-"north-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"north-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "north-east" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "north-east" #2: received INTERNAL_IP4_ADDRESS 192.0.2.101
 "north-east" #2: received INTERNAL_IP4_DNS server address 1.2.3.4

--- a/testing/pluto/addresspool-6in6-defaultroute-dual-dns-ikev2/road.console.txt
+++ b/testing/pluto/addresspool-6in6-defaultroute-dual-dns-ikev2/road.console.txt
@@ -103,7 +103,7 @@ road #
 "road"[1] 2001:db8:1:2::23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road"[1] 2001:db8:1:2::23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road"[1] 2001:db8:1:2::23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"road"[1] 2001:db8:1:2::23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"road"[1] 2001:db8:1:2::23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road"[1] 2001:db8:1:2::23 #1: initiator established IKE SA; authenticated peer certificate '@east.testing.libreswan.org' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road"[1] 2001:db8:1:2::23 #2: received INTERNAL_IP6_ADDRESS 2001:db8:0:3:1::
 "road"[1] 2001:db8:1:2::23 #2: initiator established Child SA using #1; IPsec tunnel [2001:db8:0:3:1::/128===::/0] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}

--- a/testing/pluto/certoe-01-whack/west.console.txt
+++ b/testing/pluto/certoe-01-whack/west.console.txt
@@ -26,7 +26,7 @@ west #
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/certoe-03-cop-whack/road.console.txt
+++ b/testing/pluto/certoe-03-cop-whack/road.console.txt
@@ -37,7 +37,7 @@ road #
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with null and NULL 'ID_NULL'; Child SA #2 {ESP <0xESPESP} [192.1.3.209/32===192.1.2.23/32]
-"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.1.3.209/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 road #

--- a/testing/pluto/certoe-03-poc-whack/road.console.txt
+++ b/testing/pluto/certoe-03-poc-whack/road.console.txt
@@ -37,7 +37,7 @@ road #
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with null and NULL 'ID_NULL'; Child SA #2 {ESP <0xESPESP} [192.1.3.209/32===192.1.2.23/32]
-"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.1.3.209/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 road #

--- a/testing/pluto/certoe-06-nat-packet-cop/road.console.txt
+++ b/testing/pluto/certoe-06-nat-packet-cop/road.console.txt
@@ -187,6 +187,6 @@ road #
 | parsing 2 raw bytes of IKEv2 Notify Payload into hash algorithm identifier (network ordered)
 |    auth method: IKEv2_AUTH_NULL (0xd)
 |    auth method: IKEv2_AUTH_DIGITAL_SIGNATURE (0xe)
-"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 road #

--- a/testing/pluto/certoe-07-nat-2-clients/north.console.txt
+++ b/testing/pluto/certoe-07-nat-2-clients/north.console.txt
@@ -274,6 +274,6 @@ north #
 | parsing 2 raw bytes of IKEv2 Notify Payload into hash algorithm identifier (network ordered)
 |    auth method: IKEv2_AUTH_NULL (0xd)
 |    auth method: IKEv2_AUTH_DIGITAL_SIGNATURE (0xe)
-"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 north #

--- a/testing/pluto/certoe-07-nat-2-clients/road.console.txt
+++ b/testing/pluto/certoe-07-nat-2-clients/road.console.txt
@@ -278,6 +278,6 @@ road #
 | parsing 2 raw bytes of IKEv2 Notify Payload into hash algorithm identifier (network ordered)
 |    auth method: IKEv2_AUTH_NULL (0xd)
 |    auth method: IKEv2_AUTH_DIGITAL_SIGNATURE (0xe)
-"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 road #

--- a/testing/pluto/certoe-08-nat-packet-cop-restart/road.console.txt
+++ b/testing/pluto/certoe-08-nat-packet-cop-restart/road.console.txt
@@ -338,6 +338,6 @@ road #
 | parsing 2 raw bytes of IKEv2 Notify Payload into hash algorithm identifier (network ordered)
 |    auth method: IKEv2_AUTH_NULL (0xd)
 |    auth method: IKEv2_AUTH_DIGITAL_SIGNATURE (0xe)
-"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 road #

--- a/testing/pluto/certoe-10-symmetric-cert-whack/road.console.txt
+++ b/testing/pluto/certoe-10-symmetric-cert-whack/road.console.txt
@@ -33,7 +33,7 @@ road #
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.3.209/32===192.1.2.23/32]
-"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.1.3.209/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 road #

--- a/testing/pluto/certoe-11-symmetric-cert-nat/road.console.txt
+++ b/testing/pluto/certoe-11-symmetric-cert-nat/road.console.txt
@@ -31,7 +31,7 @@ road #
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESPinUDP <0xESPESP} [192.1.3.209/32===192.1.2.23/32]
-"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 10.0.10.1
 "private-or-clear#192.1.2.0/24"[1] 10.0.10.1/32=== ...192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [10.0.10.1/32===192.1.2.23/32] {ESPinUDP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 NATD=192.1.2.23:4500 DPD=passive}

--- a/testing/pluto/certoe-17-asymmetric-cert-nat/road.console.txt
+++ b/testing/pluto/certoe-17-asymmetric-cert-nat/road.console.txt
@@ -28,7 +28,7 @@ road #
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500 with null and NULL 'ID_NULL'; Child SA #2 {ESPinUDP <0xESPESP} [192.1.3.209/32===192.1.2.23/32]
-"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 10.0.10.1
 "private-or-clear#192.1.2.0/24"[1] 10.0.10.1/32=== ...192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [10.0.10.1/32===192.1.2.23/32] {ESPinUDP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 NATD=192.1.2.23:4500 DPD=passive}

--- a/testing/pluto/crossing-streams-04-ikev2-initiator-ike-rekey-responder-child-up/west.console.txt
+++ b/testing/pluto/crossing-streams-04-ikev2-initiator-ike-rekey-responder-child-up/west.console.txt
@@ -26,7 +26,7 @@ west #
 "west-cuckold" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-cuckold" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-cuckold" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"west-cuckold" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"west-cuckold" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-cuckold" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "west-cuckold" #2: initiator established Child SA using #1; IPsec tunnel [192.0.3.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/dnsoe-01/road.console.txt
+++ b/testing/pluto/dnsoe-01/road.console.txt
@@ -29,7 +29,7 @@ road #
  ipsec whack --oppohere 192.1.3.209 --oppothere 192.1.2.23
 initiate on-demand for packet 192.1.3.209:8-ICMP->192.1.2.23:0 by whack
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: initiating IKEv2 connection to 192.1.2.23 using UDP
-"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: initiator established IKE SA; authenticated peer using preloaded certificate '192.1.2.23' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.1.3.209/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 road #
@@ -75,6 +75,6 @@ road #
 | parsing 2 raw bytes of IKEv2 Notify Payload into hash algorithm identifier (network ordered)
 |    auth method: IKEv2_AUTH_NULL (0xd)
 |    auth method: IKEv2_AUTH_DIGITAL_SIGNATURE (0xe)
-"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: initiator established IKE SA; authenticated peer using preloaded certificate '192.1.2.23' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature
 road #

--- a/testing/pluto/dnsoe-02/road.console.txt
+++ b/testing/pluto/dnsoe-02/road.console.txt
@@ -29,7 +29,7 @@ road #
  ipsec whack --oppohere 192.1.3.209 --oppothere east.testing.libreswan.org
 initiate on-demand for packet 192.1.3.209:8-ICMP->192.1.2.23:0 by whack
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: initiating IKEv2 connection to 192.1.2.23 using UDP
-"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: initiator established IKE SA; authenticated peer using preloaded certificate '192.1.2.23' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.1.3.209/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 road #
@@ -79,6 +79,6 @@ road #
 | parsing 2 raw bytes of IKEv2 Notify Payload into hash algorithm identifier (network ordered)
 |    auth method: IKEv2_AUTH_NULL (0xd)
 |    auth method: IKEv2_AUTH_DIGITAL_SIGNATURE (0xe)
-"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: initiator established IKE SA; authenticated peer using preloaded certificate '192.1.2.23' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature
 road #

--- a/testing/pluto/dnsoe-03/road.console.txt
+++ b/testing/pluto/dnsoe-03/road.console.txt
@@ -40,7 +40,7 @@ road #
  ipsec whack --oppohere 192.1.3.209 --oppothere 192.1.2.23
 initiate on-demand for packet 192.1.3.209:8-ICMP->192.1.2.23:0 by whack
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: initiating IKEv2 connection to 192.1.2.23 using UDP
-"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: initiator established IKE SA; authenticated peer using preloaded certificate '192.1.2.23' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.1.3.209/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 road #
@@ -84,6 +84,6 @@ road #
 | parsing 2 raw bytes of IKEv2 Notify Payload into hash algorithm identifier (network ordered)
 |    auth method: IKEv2_AUTH_NULL (0xd)
 |    auth method: IKEv2_AUTH_DIGITAL_SIGNATURE (0xe)
-"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: initiator established IKE SA; authenticated peer using preloaded certificate '192.1.2.23' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature
 road #

--- a/testing/pluto/dnsoe-04/road.console.txt
+++ b/testing/pluto/dnsoe-04/road.console.txt
@@ -46,7 +46,7 @@ road #
  ipsec whack --oppohere 192.1.3.209 --oppothere 192.1.2.23
 initiate on-demand for packet 192.1.3.209:8-ICMP->192.1.2.23:0 by whack
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: initiating IKEv2 connection to 192.1.2.23 using UDP
-"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: initiator established IKE SA; authenticated peer using preloaded certificate '192.1.2.23' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.1.3.209/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 road #
@@ -95,6 +95,6 @@ road #
 | parsing 2 raw bytes of IKEv2 Notify Payload into hash algorithm identifier (network ordered)
 |    auth method: IKEv2_AUTH_NULL (0xd)
 |    auth method: IKEv2_AUTH_DIGITAL_SIGNATURE (0xe)
-"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23 #1: initiator established IKE SA; authenticated peer using preloaded certificate '192.1.2.23' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature
 road #

--- a/testing/pluto/dnsoe-05/road.console.txt
+++ b/testing/pluto/dnsoe-05/road.console.txt
@@ -31,7 +31,7 @@ road #
  ipsec whack --oppohere 192.1.3.209 --oppothere 192.1.2.66
 initiate on-demand for packet 192.1.3.209:8-ICMP->192.1.2.66:0 by whack
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.66 #1: initiating IKEv2 connection to 192.1.2.23 using UDP
-"private-or-clear#192.1.2.0/24"[1] ...192.1.2.66 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"private-or-clear#192.1.2.0/24"[1] ...192.1.2.66 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.66 #1: initiator established IKE SA; authenticated peer using preloaded certificate '192.1.2.66' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.66 #2: initiator established Child SA using #1; IPsec tunnel [192.1.3.209/32===192.1.2.66-192.1.2.66:0-65535 0] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 road #
@@ -97,6 +97,6 @@ road #
 | parsing 2 raw bytes of IKEv2 Notify Payload into hash algorithm identifier (network ordered)
 |    auth method: IKEv2_AUTH_NULL (0xd)
 |    auth method: IKEv2_AUTH_DIGITAL_SIGNATURE (0xe)
-"private-or-clear#192.1.2.0/24"[1] ...192.1.2.66 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"private-or-clear#192.1.2.0/24"[1] ...192.1.2.66 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "private-or-clear#192.1.2.0/24"[1] ...192.1.2.66 #1: initiator established IKE SA; authenticated peer using preloaded certificate '192.1.2.66' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature
 road #

--- a/testing/pluto/fips-08-ikev2-x509/west.console.txt
+++ b/testing/pluto/fips-08-ikev2-x509/west.console.txt
@@ -35,7 +35,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/fips-14-ikev2-x509-ecdsa/west.console.txt
+++ b/testing/pluto/fips-14-ikev2-x509-ecdsa/west.console.txt
@@ -29,7 +29,7 @@ west #
 "west" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature ECDSA with SHA2_384 and DER_ASN1_DN 'E=user-west@testing.libreswan.org, CN=west.testing.libreswan.org, OU=Test Department, O=Libreswan, L=Toronto, ST=Ontario, C=CA'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and P-384 ECDSA with SHA2_384 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainec, E=testing@libreswan.org'
 "west" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-03-basic-rawrsa-pem/west.console.txt
+++ b/testing/pluto/ikev2-03-basic-rawrsa-pem/west.console.txt
@@ -77,7 +77,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and IPV4_ADDR '192.1.2.45'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: no Certificate Authority in NSS Certificate DB! certificate payloads discarded
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer using preloaded certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'CN=east'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}

--- a/testing/pluto/ikev2-04-basic-x509-ckaid/west.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-ckaid/west.console.txt
@@ -77,7 +77,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-04-basic-x509-nhelpers0/west.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-nhelpers0/west.console.txt
@@ -59,7 +59,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-04-basic-x509-no-ca-02/west.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-no-ca-02/west.console.txt
@@ -96,7 +96,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and IPV4_ADDR '192.1.2.45'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-04-basic-x509-no-ca/west.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-no-ca/west.console.txt
@@ -72,7 +72,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and IPV4_ADDR '192.1.2.45'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: no Certificate Authority in NSS Certificate DB! certificate payloads discarded
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer using preloaded certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}

--- a/testing/pluto/ikev2-04-basic-x509-nsspw/west.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-nsspw/west.console.txt
@@ -60,7 +60,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-04-basic-x509/west.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509/west.console.txt
@@ -59,7 +59,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-10-2behind-nat/north.console.txt
+++ b/testing/pluto/ikev2-10-2behind-nat/north.console.txt
@@ -16,7 +16,7 @@ north #
 "north"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "north"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "north"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org'; Child SA #2 {ESPinUDP <0xESPESP} [0.0.0.0/0===0.0.0.0/0]
-"north"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"north"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "north"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "north"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 192.0.2.100
 "north"[1] 192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.0.2.100/32===0.0.0.0/0] {ESPinUDP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 NATD=192.1.2.23:4500 DPD=passive}

--- a/testing/pluto/ikev2-10-2behind-nat/road.console.txt
+++ b/testing/pluto/ikev2-10-2behind-nat/road.console.txt
@@ -16,7 +16,7 @@ road #
 "road"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESPinUDP <0xESPESP} [0.0.0.0/0===0.0.0.0/0]
-"road"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"road"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "road"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 192.0.2.101
 "road"[1] 192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.0.2.101/32===0.0.0.0/0] {ESPinUDP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 NATD=192.1.2.23:4500 DPD=passive}

--- a/testing/pluto/ikev2-16-alias-whack-start/north.console.txt
+++ b/testing/pluto/ikev2-16-alias-whack-start/north.console.txt
@@ -21,7 +21,7 @@ north #
 "northnet-eastnets/0x1" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "northnet-eastnets/0x1" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "northnet-eastnets/0x1" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.3.0/24===192.0.2.0/24]
-"northnet-eastnets/0x1" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"northnet-eastnets/0x1" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "northnet-eastnets/0x1" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "northnet-eastnets/0x1" #2: initiator established Child SA using #1; IPsec tunnel [192.0.3.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 "northnet-eastnets/0x2" #3: initiating Child SA using IKE SA #1

--- a/testing/pluto/ikev2-16-alias-whack-up/north.console.txt
+++ b/testing/pluto/ikev2-16-alias-whack-up/north.console.txt
@@ -21,7 +21,7 @@ north #
 "northnet-eastnets/0x1" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "northnet-eastnets/0x1" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "northnet-eastnets/0x1" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.3.0/24===192.0.2.0/24]
-"northnet-eastnets/0x1" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"northnet-eastnets/0x1" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "northnet-eastnets/0x1" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "northnet-eastnets/0x1" #2: initiator established Child SA using #1; IPsec tunnel [192.0.3.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 "northnet-eastnets/0x2" #3: initiating Child SA using IKE SA #1

--- a/testing/pluto/ikev2-20-ikesa-reauth/west.console.txt
+++ b/testing/pluto/ikev2-20-ikesa-reauth/west.console.txt
@@ -25,7 +25,7 @@ west #
 "west" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "west" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-27-uniqueid/north.console.txt
+++ b/testing/pluto/ikev2-27-uniqueid/north.console.txt
@@ -19,7 +19,7 @@ north #
 "road-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.3.111/32===192.1.2.23/32]
-"road-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"road-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.1.3.111/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 north #
@@ -50,7 +50,7 @@ north #
 "road-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.3.111/32===192.1.2.23/32]
-"road-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"road-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.1.3.111/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 north #

--- a/testing/pluto/ikev2-30-rw-no-rekey/road.console.txt
+++ b/testing/pluto/ikev2-30-rw-no-rekey/road.console.txt
@@ -26,7 +26,7 @@ road #
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [0.0.0.0/0===0.0.0.0/0]
-"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 192.0.2.100
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.0.2.100/32===0.0.0.0/0] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}

--- a/testing/pluto/ikev2-31-nat-rw-no-rekey/road.console.txt
+++ b/testing/pluto/ikev2-31-nat-rw-no-rekey/road.console.txt
@@ -24,7 +24,7 @@ road #
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESPinUDP <0xESPESP} [0.0.0.0/0===0.0.0.0/0]
-"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 192.0.2.100
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.0.2.100/32===0.0.0.0/0] {ESPinUDP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 NATD=192.1.2.23:4500 DPD=passive}

--- a/testing/pluto/ikev2-32-nat-rw-rekey/road.console.txt
+++ b/testing/pluto/ikev2-32-nat-rw-rekey/road.console.txt
@@ -22,7 +22,7 @@ road #
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 192.0.2.100
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.0.2.100/32===0.0.0.0/0] {ESPinUDP=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 NATD=192.1.2.23:4500 DPD=passive}

--- a/testing/pluto/ikev2-37-docker-rw/road.console.txt
+++ b/testing/pluto/ikev2-37-docker-rw/road.console.txt
@@ -130,7 +130,7 @@ ipsec auto --up road-eastnet-nonat
 "road-eastnet-nonat" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=aes_gcm_16_256 integ=n/a prf=sha2_512 group=DH19}, initiating IKE_AUTH
 "road-eastnet-nonat" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
 "road-eastnet-nonat" #2: negotiated connection [192.0.2.219/32->192.0.2.0/24]
-"road-eastnet-nonat" #2: ESTABLISHED_IKE_SA: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"road-eastnet-nonat" #2: ESTABLISHED_IKE_SA: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road-eastnet-nonat" #2: ESTABLISHED_IKE_SA: initiator established IKE SA tunnel mode {ESP=>0xESPESP<0xESPESP xfrm=AES_128-HMAC_SHA1 DPD=passive}
 road #
 ping -n -c 4 -I 192.0.2.219  192.0.2.254

--- a/testing/pluto/ikev2-41-rw-replace/road.console.txt
+++ b/testing/pluto/ikev2-41-rw-replace/road.console.txt
@@ -22,7 +22,7 @@ road #
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [0.0.0.0/0===0.0.0.0/0]
-"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 192.0.2.100
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.0.2.100/32===0.0.0.0/0] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}

--- a/testing/pluto/ikev2-42-rw-replace-responder/road.console.txt
+++ b/testing/pluto/ikev2-42-rw-replace-responder/road.console.txt
@@ -22,7 +22,7 @@ road #
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [0.0.0.0/0===0.0.0.0/0]
-"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 192.0.2.100
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.0.2.100/32===0.0.0.0/0] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}

--- a/testing/pluto/ikev2-44-switch-initiator-strongswan/west.console.txt
+++ b/testing/pluto/ikev2-44-switch-initiator-strongswan/west.console.txt
@@ -19,7 +19,7 @@ west #
 "one" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "one" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_128 integ=HMAC_SHA1_96 prf=HMAC_SHA1 group=DH19}, initiating IKE_AUTH
 "one" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"one" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"one" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "one" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "one" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0-192.0.1.255:80-80 6===192.0.2.0/24/TCP] {ESP=>0xESPESP <0xESPESP xfrm=AES_CBC_128-HMAC_SHA1_96 DPD=passive}
 west #

--- a/testing/pluto/ikev2-48-nat-cp-nondefault/road.console.txt
+++ b/testing/pluto/ikev2-48-nat-cp-nondefault/road.console.txt
@@ -31,7 +31,7 @@ road #
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESPinUDP <0xESPESP} [0.0.0.0/0===0.0.0.0/0]
-"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 192.0.2.100
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.0.2.100/32===192.0.2.0/24] {ESPinUDP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 NATD=192.1.2.23:4500 DPD=passive}

--- a/testing/pluto/ikev2-48-nat-cp-two-servers-same/road.console.txt
+++ b/testing/pluto/ikev2-48-nat-cp-two-servers-same/road.console.txt
@@ -34,7 +34,7 @@ road #
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESPinUDP <0xESPESP} [0.0.0.0/0===0.0.0.0/0]
-"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 192.0.2.100
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.0.2.100/32===192.0.2.0/24] {ESPinUDP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 NATD=192.1.2.23:4500 DPD=passive}
@@ -57,7 +57,7 @@ road #
 "road-west-x509-ipv4"[1] 192.1.2.45 #3: sent IKE_SA_INIT request to 192.1.2.45:UDP/500
 "road-west-x509-ipv4"[1] 192.1.2.45 #3: processed IKE_SA_INIT response from 192.1.2.45:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road-west-x509-ipv4"[1] 192.1.2.45 #3: sent IKE_AUTH request to 192.1.2.45:UDP/4500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #4 {ESPinUDP <0xESPESP} [0.0.0.0/0===0.0.0.0/0]
-"road-west-x509-ipv4"[1] 192.1.2.45 #3: processing IKE_AUTH response from 192.1.2.45:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"road-west-x509-ipv4"[1] 192.1.2.45 #3: processing IKE_AUTH response from 192.1.2.45:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "road-west-x509-ipv4"[1] 192.1.2.45 #3: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road-west-x509-ipv4"[1] 192.1.2.45 #4: received INTERNAL_IP4_ADDRESS 192.0.2.100
 "road-west-x509-ipv4"[1] 192.1.2.45 #4: initiator established Child SA using #3; IPsec tunnel [192.0.2.100/32===192.0.1.0/24] {ESPinUDP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 NATD=192.1.2.45:4500 DPD=passive}

--- a/testing/pluto/ikev2-48-nat-cp-two-servers/road.console.txt
+++ b/testing/pluto/ikev2-48-nat-cp-two-servers/road.console.txt
@@ -34,7 +34,7 @@ road #
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESPinUDP <0xESPESP} [0.0.0.0/0===0.0.0.0/0]
-"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 192.0.2.100
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.0.2.100/32===192.0.2.0/24] {ESPinUDP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 NATD=192.1.2.23:4500 DPD=passive}
@@ -57,7 +57,7 @@ road #
 "road-west-x509-ipv4"[1] 192.1.2.45 #3: sent IKE_SA_INIT request to 192.1.2.45:UDP/500
 "road-west-x509-ipv4"[1] 192.1.2.45 #3: processed IKE_SA_INIT response from 192.1.2.45:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road-west-x509-ipv4"[1] 192.1.2.45 #3: sent IKE_AUTH request to 192.1.2.45:UDP/4500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #4 {ESPinUDP <0xESPESP} [0.0.0.0/0===0.0.0.0/0]
-"road-west-x509-ipv4"[1] 192.1.2.45 #3: processing IKE_AUTH response from 192.1.2.45:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"road-west-x509-ipv4"[1] 192.1.2.45 #3: processing IKE_AUTH response from 192.1.2.45:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "road-west-x509-ipv4"[1] 192.1.2.45 #3: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road-west-x509-ipv4"[1] 192.1.2.45 #4: received INTERNAL_IP4_ADDRESS 192.0.1.100
 "road-west-x509-ipv4"[1] 192.1.2.45 #4: initiator established Child SA using #3; IPsec tunnel [192.0.1.100/32===192.0.1.0/24] {ESPinUDP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 NATD=192.1.2.45:4500 DPD=passive}

--- a/testing/pluto/ikev2-55-ipseckey-10/road.console.txt
+++ b/testing/pluto/ikev2-55-ipseckey-10/road.console.txt
@@ -30,7 +30,7 @@ road #
 "road-east-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road-east-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road-east-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"road-east-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"road-east-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road-east-ikev2" #1: initiator established IKE SA; authenticated peer RSA
 "road-east-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.1.3.209/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 road #

--- a/testing/pluto/ikev2-59-multiple-acquires-alias/north.console.txt
+++ b/testing/pluto/ikev2-59-multiple-acquires-alias/north.console.txt
@@ -32,7 +32,7 @@ initiating all connections with alias "north-eastnets"
 "north-eastnets/0x1" #2: Child SA initiating pending connection using IKE SA #1's IKE_AUTH exchange
 "north-eastnets/0x2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA2_256_128 prf=HMAC_SHA2_256 group=DH19}, initiating IKE_AUTH
 "north-eastnets/0x2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"north-eastnets/0x2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"north-eastnets/0x2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "north-eastnets/0x2" #1: initiator established IKE SA; authenticated peer using preloaded certificate '@east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature
 "north-eastnets/0x1" #2: initiator established Child SA using #1; IPsec tunnel [192.0.3.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_CBC_128-HMAC_SHA2_512_256 DPD=passive}
 "north-eastnets/0x2" #3: initiating Child SA using IKE SA #1

--- a/testing/pluto/ikev2-67-parallel-sa/north.console.txt
+++ b/testing/pluto/ikev2-67-parallel-sa/north.console.txt
@@ -24,7 +24,7 @@ initiating 2 connections
 "northnet-eastnet/0x1" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "northnet-eastnet/0x1" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "northnet-eastnet/0x1" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"northnet-eastnet/0x1" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"northnet-eastnet/0x1" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "northnet-eastnet/0x1" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "northnet-eastnet/0x1" #2: initiator established Child SA using #1; IPsec tunnel [192.0.3.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 "northnet-eastnet/0x2" #3: initiating Child SA using IKE SA #1

--- a/testing/pluto/ikev2-71-cp-resolve-name/road.console.txt
+++ b/testing/pluto/ikev2-71-cp-resolve-name/road.console.txt
@@ -34,7 +34,7 @@ road #
 "road"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [0.0.0.0/0===192.0.2.128/25]
-"road"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"road"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "road"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate '@east.testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 192.0.2.1
 "road"[1] 192.1.2.23 #2: received INTERNAL_IP4_DNS server address 1.2.3.4

--- a/testing/pluto/ikev2-72-cp-resolve-both/road.console.txt
+++ b/testing/pluto/ikev2-72-cp-resolve-both/road.console.txt
@@ -34,7 +34,7 @@ road #
 "road"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [0.0.0.0/0===192.0.2.128/25]
-"road"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"road"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "road"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate '@east.testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 192.0.2.1
 "road"[1] 192.1.2.23 #2: received INTERNAL_IP4_DNS server address 1.2.3.4

--- a/testing/pluto/ikev2-algo-esn-09-replay-zero/west.console.txt
+++ b/testing/pluto/ikev2-algo-esn-09-replay-zero/west.console.txt
@@ -37,7 +37,7 @@ west #
 "west" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west" #1: initiator established IKE SA; authenticated peer using preloaded certificate '@east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature
 "west" #2: IKE_AUTH response rejected Child SA with TS_UNACCEPTABLE
 west #

--- a/testing/pluto/ikev2-asymmetric-08-psk-rsacert/west.console.txt
+++ b/testing/pluto/ikev2-asymmetric-08-psk-rsacert/west.console.txt
@@ -71,7 +71,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with shared-key-mac and FQDN '@west'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-asymmetric-11-rsaraw-rsacert/west.console.txt
+++ b/testing/pluto/ikev2-asymmetric-11-rsaraw-rsacert/west.console.txt
@@ -43,7 +43,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and FQDN '@west'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: no Certificate Authority in NSS Certificate DB! certificate payloads discarded
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer using preloaded certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}

--- a/testing/pluto/ikev2-child-rekey-05/west.console.txt
+++ b/testing/pluto/ikev2-child-rekey-05/west.console.txt
@@ -22,7 +22,7 @@ west #
 "west" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "west" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-child-rekey-08-deadlock/west.console.txt
+++ b/testing/pluto/ikev2-child-rekey-08-deadlock/west.console.txt
@@ -29,7 +29,7 @@ initiating all connections with alias "west-east"
 "west-east/4x0" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-east/4x0" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-east/4x0" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"west-east/4x0" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"west-east/4x0" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-east/4x0" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "west-east/1x0" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.254/32===192.0.2.254/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 "west-east/2x0" #3: sent IPsec Child req wait response

--- a/testing/pluto/ikev2-child-rekey-09-windows/road.console.txt
+++ b/testing/pluto/ikev2-child-rekey-09-windows/road.console.txt
@@ -24,7 +24,7 @@ road #
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 192.0.2.100
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.0.2.100/32===0.0.0.0/0] {ESPinUDP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 NATD=192.1.2.23:4500 DPD=passive}

--- a/testing/pluto/ikev2-child-rekey-10-impair-rekey-initiate-subnet/road.console.txt
+++ b/testing/pluto/ikev2-child-rekey-10-impair-rekey-initiate-subnet/road.console.txt
@@ -26,7 +26,7 @@ road #
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESPinUDP <0xESPESP} [0.0.0.0/0===0.0.0.0/0]
-"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 192.0.2.100
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.0.2.100/32===0.0.0.0/0] {ESPinUDP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 NATD=192.1.2.23:4500 DPD=passive}

--- a/testing/pluto/ikev2-child-rekey-10-impair-rekey-respond-subnet/road.console.txt
+++ b/testing/pluto/ikev2-child-rekey-10-impair-rekey-respond-subnet/road.console.txt
@@ -24,7 +24,7 @@ road #
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESPinUDP <0xESPESP} [0.0.0.0/0===0.0.0.0/0]
-"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 192.0.2.100
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.0.2.100/32===0.0.0.0/0] {ESPinUDP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 NATD=192.1.2.23:4500 DPD=passive}

--- a/testing/pluto/ikev2-child-rekey-10-impair-rekey-respond-supernet/road.console.txt
+++ b/testing/pluto/ikev2-child-rekey-10-impair-rekey-respond-supernet/road.console.txt
@@ -26,7 +26,7 @@ road #
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESPinUDP <0xESPESP} [0.0.0.0/0===0.0.0.0/0]
-"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 192.0.2.100
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.0.2.100/32===0.0.0.0/0] {ESPinUDP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 NATD=192.1.2.23:4500 DPD=passive}

--- a/testing/pluto/ikev2-connswitch-01/west.console.txt
+++ b/testing/pluto/ikev2-connswitch-01/west.console.txt
@@ -52,7 +52,7 @@ west #
 "westnet-eastnet-ikev1" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev1" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev1" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"westnet-eastnet-ikev1" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev1" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev1" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ikev1" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-cp-rekey-01/road.console.txt
+++ b/testing/pluto/ikev2-cp-rekey-01/road.console.txt
@@ -22,7 +22,7 @@ road #
 "eastnet-any"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "eastnet-any"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "eastnet-any"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"eastnet-any"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"eastnet-any"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "eastnet-any"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "eastnet-any"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 100.64.13.2
 "eastnet-any"[1] 192.1.2.23 #2: received INTERNAL_IP4_DNS 1.2.3.4

--- a/testing/pluto/ikev2-cp-rekey-02-up-up/road.console.txt
+++ b/testing/pluto/ikev2-cp-rekey-02-up-up/road.console.txt
@@ -22,7 +22,7 @@ road #
 "eastnet-any"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "eastnet-any"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "eastnet-any"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"eastnet-any"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"eastnet-any"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "eastnet-any"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "eastnet-any"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 100.64.13.2
 "eastnet-any"[1] 192.1.2.23 #2: received INTERNAL_IP4_DNS 1.2.3.4

--- a/testing/pluto/ikev2-digsig-01-defaults/west.console.txt
+++ b/testing/pluto/ikev2-digsig-01-defaults/west.console.txt
@@ -39,7 +39,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-digsig-02-legacy/west.console.txt
+++ b/testing/pluto/ikev2-digsig-02-legacy/west.console.txt
@@ -35,7 +35,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with rsa-digital-signature and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3072-bit PKCS#1 1.5 RSA with SHA1 signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-digsig-03-rsa-sha2/west.console.txt
+++ b/testing/pluto/ikev2-digsig-03-rsa-sha2/west.console.txt
@@ -39,7 +39,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-digsig-05-rsasig-rsa1/west.console.txt
+++ b/testing/pluto/ikev2-digsig-05-rsasig-rsa1/west.console.txt
@@ -35,7 +35,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with rsa-digital-signature and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3072-bit PKCS#1 1.5 RSA with SHA1 signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-frag-01/west.console.txt
+++ b/testing/pluto/ikev2-frag-01/west.console.txt
@@ -33,7 +33,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-frag-02-ipv6/west.console.txt
+++ b/testing/pluto/ikev2-frag-02-ipv6/west.console.txt
@@ -33,7 +33,7 @@ west #
 "v6-tunnel" #1: sent IKE_SA_INIT request to [2001:db8:1:2::23]:UDP/500
 "v6-tunnel" #1: processed IKE_SA_INIT response from [2001:db8:1:2::23]:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_256 group=MODP2048}, initiating IKE_AUTH
 "v6-tunnel" #1: sent IKE_AUTH request to [2001:db8:1:2::23]:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=key4096.testing.libreswan.org, E=user-key4096@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [2001:111:1111::/48===2001:2222:222:2200::/56]
-"v6-tunnel" #1: processing IKE_AUTH response from [2001:db8:1:2::23]:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"v6-tunnel" #1: processing IKE_AUTH response from [2001:db8:1:2::23]:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "v6-tunnel" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "v6-tunnel" #2: initiator established Child SA using #1; IPsec tunnel [2001:111:1111::/48===2001:2222:222:2200::/56] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-frag-03-retrans/west.console.txt
+++ b/testing/pluto/ikev2-frag-03-retrans/west.console.txt
@@ -40,7 +40,7 @@ west #
 "westnet-eastnet-ikev2" #1: dropping IKE_SA_INIT response with duplicate Message ID 0, IKE SA in state IKE_AUTH_I has already processed response
 "westnet-eastnet-ikev2" #1: dropping IKE_SA_INIT response with duplicate Message ID 0, IKE SA in state IKE_AUTH_I has already processed response
 "westnet-eastnet-ikev2" #1: dropping IKE_SA_INIT response with duplicate Message ID 0, IKE SA in state IKE_AUTH_I has already processed response
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 up

--- a/testing/pluto/ikev2-hostpair-01/road.console.txt
+++ b/testing/pluto/ikev2-hostpair-01/road.console.txt
@@ -22,7 +22,7 @@ road #
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: sending INITIAL_CONTACT
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESPinUDP <0xESPESP} [192.1.3.209/32===192.1.2.23/32]
-"westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 192.0.2.1
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #2: received INTERNAL_IP4_DNS server address 1.2.3.4
@@ -63,7 +63,7 @@ road #
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: sending INITIAL_CONTACT
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESPinUDP <0xESPESP} [192.1.3.210/32===192.1.2.23/32]
-"westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 192.0.2.1
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #2: received INTERNAL_IP4_DNS server address 1.2.3.4

--- a/testing/pluto/ikev2-hostpair-02/road.console.txt
+++ b/testing/pluto/ikev2-hostpair-02/road.console.txt
@@ -19,7 +19,7 @@ road #
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/4500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500; Child SA #2 {ESPinUDP <0xESPESP}
-"westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 192.0.2.1
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #2: received INTERNAL_IP4_DNS 1.2.3.4
@@ -52,7 +52,7 @@ road #
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #3: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #3: processed IKE_SA_INIT response from 192.1.2.23:UDP/4500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #3: sent IKE_AUTH request to 192.1.2.23:UDP/4500; Child SA #4 {ESPinUDP <0xESPESP}
-"westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #3: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #4: received INTERNAL_IP4_ADDRESS 192.0.2.1
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #4: received INTERNAL_IP4_DNS 1.2.3.4
@@ -75,7 +75,7 @@ road #
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #5: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #5: processed IKE_SA_INIT response from 192.1.2.23:UDP/4500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #5: sent IKE_AUTH request to 192.1.2.23:UDP/4500; Child SA #6 {ESPinUDP <0xESPESP}
-"westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #5: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #5: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #5: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #6: received INTERNAL_IP4_ADDRESS 192.0.2.1
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #6: received INTERNAL_IP4_DNS 1.2.3.4
@@ -98,7 +98,7 @@ road #
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #7: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #7: processed IKE_SA_INIT response from 192.1.2.23:UDP/4500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #7: sent IKE_AUTH request to 192.1.2.23:UDP/4500; Child SA #8 {ESPinUDP <0xESPESP}
-"westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #7: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #7: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #7: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #8: received INTERNAL_IP4_ADDRESS 192.0.2.1
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #8: received INTERNAL_IP4_DNS 1.2.3.4

--- a/testing/pluto/ikev2-hostpair-03-initial-contact/road.console.txt
+++ b/testing/pluto/ikev2-hostpair-03-initial-contact/road.console.txt
@@ -20,7 +20,7 @@ road #
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: sending INITIAL_CONTACT
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESPinUDP <0xESPESP} [192.1.3.209/32===192.1.2.23/32]
-"westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 192.0.2.1
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #2: received INTERNAL_IP4_DNS server address 1.2.3.4
@@ -54,7 +54,7 @@ road #
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #3: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #3: sending INITIAL_CONTACT
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #3: sent IKE_AUTH request to 192.1.2.23:UDP/4500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #4 {ESPinUDP <0xESPESP} [192.1.3.209/32===192.1.2.23/32]
-"westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #3: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #3: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #3: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #4: received INTERNAL_IP4_ADDRESS 192.0.2.1
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #4: received INTERNAL_IP4_DNS server address 1.2.3.4
@@ -78,7 +78,7 @@ road #
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #5: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #5: sending INITIAL_CONTACT
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #5: sent IKE_AUTH request to 192.1.2.23:UDP/4500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #6 {ESPinUDP <0xESPESP} [192.1.3.209/32===192.1.2.23/32]
-"westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #5: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #5: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #5: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #6: received INTERNAL_IP4_ADDRESS 192.0.2.1
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #6: received INTERNAL_IP4_DNS server address 1.2.3.4
@@ -102,7 +102,7 @@ road #
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #7: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #7: sending INITIAL_CONTACT
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #7: sent IKE_AUTH request to 192.1.2.23:UDP/4500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #8 {ESPinUDP <0xESPESP} [192.1.3.209/32===192.1.2.23/32]
-"westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #7: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #7: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #7: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #8: received INTERNAL_IP4_ADDRESS 192.0.2.1
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #8: received INTERNAL_IP4_DNS server address 1.2.3.4

--- a/testing/pluto/ikev2-intermediate-01-addke-connswitch/west.console.txt
+++ b/testing/pluto/ikev2-intermediate-01-addke-connswitch/west.console.txt
@@ -49,7 +49,7 @@ west #
 "rsa-west" #3: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE}
 "rsa-west" #3: initiator processed IKE_INTERMEDIATE, initiating IKE_AUTH
 "rsa-west" #3: sent IKE_AUTH request to 192.1.2.23:UDP/500 with rsa-digital-signature and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #4 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"rsa-west" #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"rsa-west" #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "rsa-west" #3: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3072-bit PKCS#1 1.5 RSA with SHA1 signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "rsa-west" #4: initiator established Child SA using #3; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-intermediate-04-addke-ml-kem-768/west.console.txt
+++ b/testing/pluto/ikev2-intermediate-04-addke-ml-kem-768/west.console.txt
@@ -44,10 +44,10 @@ west #
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_128 integ=HMAC_SHA2_256_128 prf=HMAC_SHA2_256 group=DH31}, initiating IKE_INTERMEDIATE
 IMPAIR: "westnet-eastnet-ikev2" #1: adding an unknown payload of type 255 to unencrypted IKE_INTERMEDIATE message
 "westnet-eastnet-ikev2" #1: sent IKE_INTERMEDIATE request to 192.1.2.23:UDP/500 {addke1=ML_KEM_768}
-"westnet-eastnet-ikev2" #1: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE}
+"westnet-eastnet-ikev2" #1: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator processed IKE_INTERMEDIATE, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with rsa-digital-signature and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3072-bit PKCS#1 1.5 RSA with SHA1 signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-intermediate-05-addke-duplicate/west.console.txt
+++ b/testing/pluto/ikev2-intermediate-05-addke-duplicate/west.console.txt
@@ -31,7 +31,7 @@ Redirecting to: [initsystem]
 "algo" #1: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE}
 "algo" #1: initiator processed IKE_INTERMEDIATE, initiating IKE_AUTH
 "algo" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with rsa-digital-signature and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"algo" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"algo" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "algo" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3072-bit PKCS#1 1.5 RSA with SHA1 signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "algo" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
  ../../guestbin/wait-until-alive -I 192.0.1.254 192.0.2.254
@@ -57,7 +57,7 @@ Redirecting to: [initsystem]
 "algo" #1: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE}
 "algo" #1: initiator processed IKE_INTERMEDIATE, initiating IKE_AUTH
 "algo" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with rsa-digital-signature and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"algo" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"algo" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "algo" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3072-bit PKCS#1 1.5 RSA with SHA1 signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "algo" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
  ../../guestbin/wait-until-alive -I 192.0.1.254 192.0.2.254
@@ -81,7 +81,7 @@ Redirecting to: [initsystem]
 "algo" #1: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE}
 "algo" #1: initiator processed IKE_INTERMEDIATE, initiating IKE_AUTH
 "algo" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with rsa-digital-signature and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"algo" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"algo" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "algo" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3072-bit PKCS#1 1.5 RSA with SHA1 signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "algo" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
  ../../guestbin/wait-until-alive -I 192.0.1.254 192.0.2.254

--- a/testing/pluto/ikev2-intermediate-06-addke2-dh19-addke4-none-addke6-dh20/west.console.txt
+++ b/testing/pluto/ikev2-intermediate-06-addke2-dh19-addke4-none-addke6-dh20/west.console.txt
@@ -45,7 +45,7 @@ west #
 "west" #1: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE}
 "west" #1: initiator processed IKE_INTERMEDIATE, initiating IKE_AUTH
 "west" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with rsa-digital-signature and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3072-bit PKCS#1 1.5 RSA with SHA1 signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "west" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-invalid-ke-08-rekey-child/west.console.txt
+++ b/testing/pluto/ikev2-invalid-ke-08-rekey-child/west.console.txt
@@ -24,7 +24,7 @@ west #
 "west" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA1_96 prf=HMAC_SHA1 group=MODP8192}, initiating IKE_AUTH
 "west" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "west" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_CBC_128-HMAC_SHA1_96 DPD=passive}
 west #

--- a/testing/pluto/ikev2-invalid-ke-09-preference-ecp/west.console.txt
+++ b/testing/pluto/ikev2-invalid-ke-09-preference-ecp/west.console.txt
@@ -37,7 +37,7 @@ west #
 "westnet-eastnet-ipv4-psk-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ipv4-psk-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA2_256_128 prf=HMAC_SHA2_256 group=MODP8192}, initiating IKE_AUTH
 "westnet-eastnet-ipv4-psk-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"westnet-eastnet-ipv4-psk-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ipv4-psk-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ipv4-psk-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "westnet-eastnet-ipv4-psk-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-iptfs-01/west.console.txt
+++ b/testing/pluto/ikev2-iptfs-01/west.console.txt
@@ -26,7 +26,7 @@ west #
 "ipv4-psk-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "ipv4-psk-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "ipv4-psk-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with shared-key-mac and FQDN '@west'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"ipv4-psk-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr,N(USE_AGGFRAG)}
+"ipv4-psk-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr,N(USE_AGGFRAG)} reassembled from N fragments
 "ipv4-psk-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "ipv4-psk-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN/IPTFS=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #
@@ -83,5 +83,5 @@ kernel: IPTFS SA supported by kernel
 "ipv4-psk-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN/IPTFS=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #
  grep -e '^[^|].*USE_AGGFRAG' /tmp/pluto.log
-"ipv4-psk-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr,N(USE_AGGFRAG)}
+"ipv4-psk-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr,N(USE_AGGFRAG)} reassembled from N fragments
 west #

--- a/testing/pluto/ikev2-iptfs-02-mismatch/west.console.txt
+++ b/testing/pluto/ikev2-iptfs-02-mismatch/west.console.txt
@@ -26,7 +26,7 @@ west #
 "ipv4-psk-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "ipv4-psk-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "ipv4-psk-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with shared-key-mac and FQDN '@west'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"ipv4-psk-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"ipv4-psk-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "ipv4-psk-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "ipv4-psk-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-iptfs-03-on-demand/west.console.txt
+++ b/testing/pluto/ikev2-iptfs-03-on-demand/west.console.txt
@@ -83,5 +83,5 @@ kernel: IPTFS SA supported by kernel
 "ipv4-psk-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN/IPTFS=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #
  grep -e '^[^|].*USE_AGGFRAG' /tmp/pluto.log
-"ipv4-psk-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr,N(USE_AGGFRAG)}
+"ipv4-psk-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr,N(USE_AGGFRAG)} reassembled from N fragments
 west #

--- a/testing/pluto/ikev2-labeled-ipsec-01-ike-childless-enforcing/west.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-01-ike-childless-enforcing/west.console.txt
@@ -27,7 +27,7 @@ west #
 "labeled"[1] 192.1.2.23 #1: omitting CHILD SA payloads
 "labeled"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "labeled"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"labeled"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"labeled"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "labeled"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer using preloaded certificate '@east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature
 west #
  ipsec _kernel state

--- a/testing/pluto/ikev2-labeled-ipsec-03-multi-acquires-enforcing/west.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-03-multi-acquires-enforcing/west.console.txt
@@ -29,7 +29,7 @@ west #
 "labeled"[1] 192.1.2.23 #1: omitting CHILD SA payloads
 "labeled"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "labeled"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"labeled"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"labeled"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "labeled"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer using preloaded certificate '@east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature
 west #
  # expect policy but no states

--- a/testing/pluto/ikev2-labeled-ipsec-03-multi-acquires-permissive/west.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-03-multi-acquires-permissive/west.console.txt
@@ -27,7 +27,7 @@ west #
 "labeled"[1] 192.1.2.23 #1: omitting CHILD SA payloads
 "labeled"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "labeled"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"labeled"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"labeled"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "labeled"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer using preloaded certificate '@east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature
 west #
  # expect policy but no states

--- a/testing/pluto/ikev2-labeled-ipsec-03-multi-acquires-rekey/west.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-03-multi-acquires-rekey/west.console.txt
@@ -27,7 +27,7 @@ west #
 "labeled"[1] 192.1.2.23 #1: omitting CHILD SA payloads
 "labeled"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "labeled"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"labeled"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"labeled"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "labeled"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer using preloaded certificate '@east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature
 west #
  # expect policy but no states

--- a/testing/pluto/ikev2-labeled-ipsec-06-reauth-ike-acquire/west.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-06-reauth-ike-acquire/west.console.txt
@@ -27,7 +27,7 @@ west #
 "labeled"[1] 192.1.2.23 #1: omitting CHILD SA payloads
 "labeled"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "labeled"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"labeled"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"labeled"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "labeled"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer using preloaded certificate '@east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature
 west #
  ipsec _kernel state

--- a/testing/pluto/ikev2-labeled-ipsec-07-connswitch-ike-childless/west.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-07-connswitch-ike-childless/west.console.txt
@@ -19,7 +19,7 @@ west #
 "west-to-east" #1: omitting CHILD SA payloads
 "west-to-east" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-to-east" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"west-to-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"west-to-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-to-east" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 west #
  ../../guestbin/ipsec-look.sh

--- a/testing/pluto/ikev2-labeled-ipsec-08-narrow-ike-childless/west.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-08-narrow-ike-childless/west.console.txt
@@ -28,7 +28,7 @@ west #
 "labeled"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "labeled"[1] 192.1.2.23 #1: omitting CHILD SA payloads
 "labeled"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'
-"labeled"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH}
+"labeled"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH} reassembled from N fragments
 "labeled"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 west #
  ipsec _kernel state

--- a/testing/pluto/ikev2-liveness-01-east-active-clear/west.console.txt
+++ b/testing/pluto/ikev2-liveness-01-east-active-clear/west.console.txt
@@ -32,7 +32,7 @@ west #
 "westnet-eastnet-ipv4-psk-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ipv4-psk-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ipv4-psk-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"westnet-eastnet-ipv4-psk-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ipv4-psk-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ipv4-psk-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "westnet-eastnet-ipv4-psk-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-liveness-02-east-active-restart/west.console.txt
+++ b/testing/pluto/ikev2-liveness-02-east-active-restart/west.console.txt
@@ -34,7 +34,7 @@ west #
 "westnet-eastnet-ipv4-psk-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ipv4-psk-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ipv4-psk-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ipv4-psk-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ipv4-psk-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ipv4-psk-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "westnet-eastnet-ipv4-psk-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-liveness-03-both-active-clear/west.console.txt
+++ b/testing/pluto/ikev2-liveness-03-both-active-clear/west.console.txt
@@ -32,7 +32,7 @@ west #
 "westnet-eastnet-ipv4-psk-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ipv4-psk-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ipv4-psk-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ipv4-psk-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ipv4-psk-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ipv4-psk-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "westnet-eastnet-ipv4-psk-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=active}
 west #

--- a/testing/pluto/ikev2-liveness-04-west-aggr-clear/west.console.txt
+++ b/testing/pluto/ikev2-liveness-04-west-aggr-clear/west.console.txt
@@ -32,7 +32,7 @@ west #
 "westnet-eastnet-ipv4-psk-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ipv4-psk-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ipv4-psk-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ipv4-psk-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ipv4-psk-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ipv4-psk-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "westnet-eastnet-ipv4-psk-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=active}
 west #

--- a/testing/pluto/ikev2-liveness-05/west.console.txt
+++ b/testing/pluto/ikev2-liveness-05/west.console.txt
@@ -33,7 +33,7 @@ west #
 "westnet-eastnet-ikev2"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"westnet-eastnet-ikev2"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer using preloaded certificate '@east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature
 "westnet-eastnet-ikev2"[1] 192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=active}
 west #

--- a/testing/pluto/ikev2-liveness-06-both-active-clear-clear/road.console.txt
+++ b/testing/pluto/ikev2-liveness-06-both-active-clear-clear/road.console.txt
@@ -24,7 +24,7 @@ road #
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 192.0.2.100
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.0.2.100/32===0.0.0.0/0] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=active}

--- a/testing/pluto/ikev2-liveness-07/road.console.txt
+++ b/testing/pluto/ikev2-liveness-07/road.console.txt
@@ -22,7 +22,7 @@ road #
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 192.0.2.100
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.0.2.100/32===0.0.0.0/0] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=active}

--- a/testing/pluto/ikev2-liveness-12-clear-rw-restart/road.console.txt
+++ b/testing/pluto/ikev2-liveness-12-clear-rw-restart/road.console.txt
@@ -14,7 +14,7 @@ road #
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 192.0.2.100
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.0.2.100/32===0.0.0.0/0] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
@@ -43,7 +43,7 @@ road #
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"road-east-x509-ipv4"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road-east-x509-ipv4"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 192.0.2.100
 "road-east-x509-ipv4"[1] 192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.0.2.100/32===0.0.0.0/0] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}

--- a/testing/pluto/ikev2-mobike-08-nat-expire-liveness-east/road.console.txt
+++ b/testing/pluto/ikev2-mobike-08-nat-expire-liveness-east/road.console.txt
@@ -18,7 +18,7 @@ road #
 "road"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESPinUDP <0xESPESP} [0.0.0.0/0===192.0.2.0/24]
-"road"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"road"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "road"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate '@east.testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 100.64.0.1
 "road"[1] 192.1.2.23 #2: received INTERNAL_IP4_DNS server address 1.2.3.4

--- a/testing/pluto/ikev2-mobike-08-nat-expire-liveness-road-mobike-nat/road.console.txt
+++ b/testing/pluto/ikev2-mobike-08-nat-expire-liveness-road-mobike-nat/road.console.txt
@@ -19,7 +19,7 @@ road #
 "road"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/4500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500; Child SA #2 {ESPinUDP <0xESPESP}
-"road"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"road"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate '@east.testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 100.64.0.1
 "road"[1] 192.1.2.23 #2: received INTERNAL_IP4_DNS 1.2.3.4

--- a/testing/pluto/ikev2-mobike-08-nat-expire-liveness-road-mobike-no/road.console.txt
+++ b/testing/pluto/ikev2-mobike-08-nat-expire-liveness-road-mobike-no/road.console.txt
@@ -18,7 +18,7 @@ road #
 "road"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESPinUDP <0xESPESP} [0.0.0.0/0===192.0.2.0/24]
-"road"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"road"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "road"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate '@east.testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 100.64.0.1
 "road"[1] 192.1.2.23 #2: received INTERNAL_IP4_DNS server address 1.2.3.4

--- a/testing/pluto/ikev2-mobike-08-nat-expire-liveness-road-mobike-yes/road.console.txt
+++ b/testing/pluto/ikev2-mobike-08-nat-expire-liveness-road-mobike-yes/road.console.txt
@@ -18,7 +18,7 @@ road #
 "road"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/4500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500; Child SA #2 {ESPinUDP <0xESPESP}
-"road"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"road"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate '@east.testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 100.64.0.1
 "road"[1] 192.1.2.23 #2: received INTERNAL_IP4_DNS 1.2.3.4

--- a/testing/pluto/ikev2-nss-cert-08-mismatch/west.console.txt
+++ b/testing/pluto/ikev2-nss-cert-08-mismatch/west.console.txt
@@ -32,7 +32,7 @@ west #
 "nss-cert-correct" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "nss-cert-correct" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "nss-cert-correct" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.254/32===192.0.2.254/32]
-"nss-cert-correct" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"nss-cert-correct" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "nss-cert-correct" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "nss-cert-correct" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.254/32===192.0.2.254/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #
@@ -49,7 +49,7 @@ west #
 "nss-cert-incorrect" #3: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "nss-cert-incorrect" #3: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "nss-cert-incorrect" #3: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #4 {ESP <0xESPESP} [192.0.1.254/32===192.0.2.254/32]
-"nss-cert-incorrect" #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"nss-cert-incorrect" #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "nss-cert-incorrect" #3: X509: authentication failed; peer ID DER_ASN1_DN 'E=user-east@testing.libreswan.org,CN=east.testing.libreswan.org,OU=Test Department,O=Libreswan,L=Toronto,ST=Ontario,C=CA' does not match expected 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'
 "nss-cert-incorrect" #3: deleting IKE SA (IKE_AUTH_I) and sending notification
 "nss-cert-incorrect" #4: connection is supposed to remain up; revival attempt 1 scheduled in 0 seconds

--- a/testing/pluto/ikev2-nss-cert-pkcs11-uri-01/west.console.txt
+++ b/testing/pluto/ikev2-nss-cert-pkcs11-uri-01/west.console.txt
@@ -26,7 +26,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-redirect-01-global-load-balancer/north.console.txt
+++ b/testing/pluto/ikev2-redirect-01-global-load-balancer/north.console.txt
@@ -96,7 +96,7 @@ IMPAIR: "north-east": dispatch REVIVAL; redirect attempt 1 from 192.1.2.23 to 19
 "north-east" #6: sent IKE_SA_INIT request to 192.1.2.45:UDP/500
 "north-east" #6: processed IKE_SA_INIT response from 192.1.2.45:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "north-east" #6: sent IKE_AUTH request to 192.1.2.45:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org'; Child SA #7 {ESP <0xESPESP} [192.1.3.33/32===0.0.0.0/0]
-"north-east" #6: processing IKE_AUTH response from 192.1.2.45:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"north-east" #6: processing IKE_AUTH response from 192.1.2.45:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "north-east" #6: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "north-east" #7: received INTERNAL_IP4_ADDRESS 192.0.2.101
 "north-east" #7: received INTERNAL_IP4_DNS server address 1.2.3.4

--- a/testing/pluto/ikev2-redirect-01-global-load-balancer/road.console.txt
+++ b/testing/pluto/ikev2-redirect-01-global-load-balancer/road.console.txt
@@ -40,7 +40,7 @@ IMPAIR: "road-east": dispatch REVIVAL; redirect attempt 1 from 192.1.2.23 to 192
 "road-east" #2: sent IKE_SA_INIT request to 192.1.2.45:UDP/500
 "road-east" #2: processed IKE_SA_INIT response from 192.1.2.45:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road-east" #2: sent IKE_AUTH request to 192.1.2.45:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #3 {ESP <0xESPESP} [192.1.3.209/32===0.0.0.0/0]
-"road-east" #2: processing IKE_AUTH response from 192.1.2.45:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"road-east" #2: processing IKE_AUTH response from 192.1.2.45:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "road-east" #2: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road-east" #3: received INTERNAL_IP4_ADDRESS 192.0.2.101
 "road-east" #3: received INTERNAL_IP4_DNS server address 1.2.3.4

--- a/testing/pluto/ikev2-redirect-06-roadwarriors-reverse/north.console.txt
+++ b/testing/pluto/ikev2-redirect-06-roadwarriors-reverse/north.console.txt
@@ -19,7 +19,7 @@ north #
 "north-east" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "north-east" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "north-east" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"north-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"north-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "north-east" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "north-east" #2: received INTERNAL_IP4_ADDRESS 192.0.2.102
 "north-east" #2: received INTERNAL_IP4_DNS 1.2.3.4
@@ -47,7 +47,7 @@ IMPAIR: "north-east": dispatch REVIVAL; redirect attempt 1 from 192.1.2.23 to 19
 "north-east" #3: sent IKE_SA_INIT request to 192.1.2.45:UDP/500
 "north-east" #3: processed IKE_SA_INIT response from 192.1.2.45:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "north-east" #3: sent IKE_AUTH request to 192.1.2.45:UDP/500; Child SA #4 {ESP <0xESPESP}
-"north-east" #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"north-east" #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "north-east" #3: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "north-east" #4: received INTERNAL_IP4_ADDRESS 192.0.2.101
 "north-east" #4: received INTERNAL_IP4_DNS 1.2.3.4

--- a/testing/pluto/ikev2-redirect-06-roadwarriors-reverse/road.console.txt
+++ b/testing/pluto/ikev2-redirect-06-roadwarriors-reverse/road.console.txt
@@ -19,7 +19,7 @@ road #
 "road-east" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road-east" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road-east" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"road-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"road-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road-east" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road-east" #2: received INTERNAL_IP4_ADDRESS 192.0.2.101
 "road-east" #2: received INTERNAL_IP4_DNS 1.2.3.4
@@ -47,7 +47,7 @@ IMPAIR: "road-east": dispatch REVIVAL; redirect attempt 1 from 192.1.2.23 to 192
 "road-east" #3: sent IKE_SA_INIT request to 192.1.2.45:UDP/500
 "road-east" #3: processed IKE_SA_INIT response from 192.1.2.45:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road-east" #3: sent IKE_AUTH request to 192.1.2.45:UDP/500; Child SA #4 {ESP <0xESPESP}
-"road-east" #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"road-east" #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road-east" #3: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road-east" #4: received INTERNAL_IP4_ADDRESS 192.0.2.102
 "road-east" #4: received INTERNAL_IP4_DNS 1.2.3.4

--- a/testing/pluto/ikev2-redirect-06-roadwarriors/north.console.txt
+++ b/testing/pluto/ikev2-redirect-06-roadwarriors/north.console.txt
@@ -29,7 +29,7 @@ north #
 "north-east" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "north-east" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "north-east" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.3.33/32===0.0.0.0/0]
-"north-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"north-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "north-east" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "north-east" #2: received INTERNAL_IP4_ADDRESS 192.0.2.102
 "north-east" #2: received INTERNAL_IP4_DNS server address 1.2.3.4
@@ -57,7 +57,7 @@ IMPAIR: "north-east": dispatch REVIVAL; redirect attempt 1 from 192.1.2.23 to 19
 "north-east" #3: sent IKE_SA_INIT request to 192.1.2.45:UDP/500
 "north-east" #3: processed IKE_SA_INIT response from 192.1.2.45:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "north-east" #3: sent IKE_AUTH request to 192.1.2.45:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org'; Child SA #4 {ESP <0xESPESP} [192.0.2.102/32===0.0.0.0/0]
-"north-east" #3: processing IKE_AUTH response from 192.1.2.45:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"north-east" #3: processing IKE_AUTH response from 192.1.2.45:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "north-east" #3: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "north-east" #4: received INTERNAL_IP4_ADDRESS 192.0.2.102
 "north-east" #4: received INTERNAL_IP4_DNS server address 1.2.3.4

--- a/testing/pluto/ikev2-redirect-06-roadwarriors/road.console.txt
+++ b/testing/pluto/ikev2-redirect-06-roadwarriors/road.console.txt
@@ -29,7 +29,7 @@ road #
 "road-east" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road-east" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road-east" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.3.209/32===0.0.0.0/0]
-"road-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"road-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "road-east" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road-east" #2: received INTERNAL_IP4_ADDRESS 192.0.2.101
 "road-east" #2: received INTERNAL_IP4_DNS server address 1.2.3.4
@@ -57,7 +57,7 @@ IMPAIR: "road-east": dispatch REVIVAL; redirect attempt 1 from 192.1.2.23 to 192
 "road-east" #3: sent IKE_SA_INIT request to 192.1.2.45:UDP/500
 "road-east" #3: processed IKE_SA_INIT response from 192.1.2.45:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road-east" #3: sent IKE_AUTH request to 192.1.2.45:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #4 {ESP <0xESPESP} [192.0.2.101/32===0.0.0.0/0]
-"road-east" #3: processing IKE_AUTH response from 192.1.2.45:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"road-east" #3: processing IKE_AUTH response from 192.1.2.45:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "road-east" #3: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road-east" #4: received INTERNAL_IP4_ADDRESS 192.0.2.101
 "road-east" #4: received INTERNAL_IP4_DNS server address 1.2.3.4

--- a/testing/pluto/ikev2-resume-01-psk/west.console.txt
+++ b/testing/pluto/ikev2-resume-01-psk/west.console.txt
@@ -24,7 +24,7 @@ west #
 "west-east" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-east" #1: asking for session resume ticket
 "west-east" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with shared-key-mac and FQDN '@west'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"west-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{N(TICKET_LT_OPAQUE),IDr,AUTH,SA,TSi,TSr}
+"west-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{N(TICKET_LT_OPAQUE),IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-east" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "west-east" #1: received v2N_TICKET_LT_OPAQUE
 "west-east" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}

--- a/testing/pluto/ikev2-resume-02-x509/west.console.txt
+++ b/testing/pluto/ikev2-resume-02-x509/west.console.txt
@@ -24,7 +24,7 @@ west #
 "west-east" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-east" #1: asking for session resume ticket
 "west-east" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"west-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{N(TICKET_LT_OPAQUE),IDr,CERT,AUTH,SA,TSi,TSr}
+"west-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{N(TICKET_LT_OPAQUE),IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-east" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "west-east" #1: received v2N_TICKET_LT_OPAQUE
 "west-east" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}

--- a/testing/pluto/ikev2-resume-03-rollover/west.console.txt
+++ b/testing/pluto/ikev2-resume-03-rollover/west.console.txt
@@ -19,7 +19,7 @@ west #
 "west-east" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-east" #1: asking for session resume ticket
 "west-east" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with shared-key-mac and FQDN '@west'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"west-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{N(TICKET_LT_OPAQUE),IDr,AUTH,SA,TSi,TSr}
+"west-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{N(TICKET_LT_OPAQUE),IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-east" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "west-east" #1: received v2N_TICKET_LT_OPAQUE
 "west-east" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
@@ -67,7 +67,7 @@ west #
 "west-east" #6: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-east" #6: asking for session resume ticket
 "west-east" #6: sent IKE_AUTH request to 192.1.2.23:UDP/500 with shared-key-mac and FQDN '@west'; Child SA #7 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"west-east" #6: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{N(TICKET_LT_OPAQUE),IDr,AUTH,SA,TSi,TSr}
+"west-east" #6: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{N(TICKET_LT_OPAQUE),IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-east" #6: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "west-east" #6: received v2N_TICKET_LT_OPAQUE
 "west-east" #7: initiator established Child SA using #6; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}

--- a/testing/pluto/ikev2-resume-04-instance/west.console.txt
+++ b/testing/pluto/ikev2-resume-04-instance/west.console.txt
@@ -22,7 +22,7 @@ west #
 "west-east" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-east" #1: asking for session resume ticket
 "west-east" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"west-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{N(TICKET_LT_OPAQUE),IDr,CERT,AUTH,SA,TSi,TSr}
+"west-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{N(TICKET_LT_OPAQUE),IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-east" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "west-east" #1: received v2N_TICKET_LT_OPAQUE
 "west-east" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}

--- a/testing/pluto/ikev2-routes-subnets-plural/road.console.txt
+++ b/testing/pluto/ikev2-routes-subnets-plural/road.console.txt
@@ -25,7 +25,7 @@ initiating 4 connections
 "road/1x1" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road/1x1" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road/1x1" #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESPinUDP <0xESPESP} [192.0.3.0/24===192.0.2.0/24]
-"road/1x1" #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"road/1x1" #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road/1x1" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road/1x1" #2: initiator established Child SA using #1; IPsec tunnel [192.0.3.0/24===192.0.2.0/24] {ESPinUDP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 NATD=192.1.2.23:4500 DPD=passive}
 "road/1x2" #3: initiating Child SA using IKE SA #1

--- a/testing/pluto/ikev2-routes-subnets-singular/road.console.txt
+++ b/testing/pluto/ikev2-routes-subnets-singular/road.console.txt
@@ -18,7 +18,7 @@ road #
 "road" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road" #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESPinUDP <0xESPESP} [192.0.3.0/24===192.0.2.0/24] [192.0.3.0/24===192.0.20.0/24] [192.0.30.0/24===192.0.2.0/24] [192.0.30.0/24===192.0.20.0/24]
-"road" #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"road" #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road" #2: accepted selectors [192.0.3.0/24 192.0.30.0/24]->[192.0.2.0/24 192.0.20.0/24]
 "road" #2: running updown prepare 192.0.3.0/24===192.0.2.0/24

--- a/testing/pluto/ikev2-rw-multiple-rw-by-id/north.console.txt
+++ b/testing/pluto/ikev2-rw-multiple-rw-by-id/north.console.txt
@@ -19,7 +19,7 @@ north #
 "rw"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "rw"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "rw"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"rw"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"rw"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "rw"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate '@east.testing.libreswan.org' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "rw"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 100.64.0.2
 "rw"[1] 192.1.2.23 #2: received INTERNAL_IP4_DNS 1.2.3.4

--- a/testing/pluto/ikev2-rw-multiple-rw-by-id/road.console.txt
+++ b/testing/pluto/ikev2-rw-multiple-rw-by-id/road.console.txt
@@ -19,7 +19,7 @@ road #
 "rw"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "rw"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "rw"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"rw"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"rw"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "rw"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate '@east.testing.libreswan.org' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "rw"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 100.64.0.1
 "rw"[1] 192.1.2.23 #2: received INTERNAL_IP4_DNS 1.2.3.4

--- a/testing/pluto/ikev2-rw-multiple-subnets-4-mismatch-split-up/road.console.txt
+++ b/testing/pluto/ikev2-rw-multiple-subnets-4-mismatch-split-up/road.console.txt
@@ -26,7 +26,7 @@ road #
 "road/0x1" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road/0x1" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road/0x1" #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESPinUDP <0xESPESP} [192.0.3.0/24===192.0.2.0/24]
-"road/0x1" #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"road/0x1" #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road/0x1" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road/0x1" #2: initiator established Child SA using #1; IPsec tunnel [192.0.3.0/24===192.0.2.0/24] {ESPinUDP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 NATD=192.1.2.23:4500 DPD=passive}
 road #

--- a/testing/pluto/ikev2-rw-multiple-subnets-4-mismatch/road.console.txt
+++ b/testing/pluto/ikev2-rw-multiple-subnets-4-mismatch/road.console.txt
@@ -35,7 +35,7 @@ initiating 8 connections
 "road/0x1" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road/0x1" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road/0x1" #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESPinUDP <0xESPESP} [192.0.3.0/24===192.0.2.0/24]
-"road/0x1" #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"road/0x1" #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road/0x1" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road/0x1" #2: initiator established Child SA using #1; IPsec tunnel [192.0.3.0/24===192.0.2.0/24] {ESPinUDP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 NATD=192.1.2.23:4500 DPD=passive}
 "road/0x2" #3: initiating Child SA using IKE SA #1

--- a/testing/pluto/ikev2-rw-multiple-subnets-5-mismatch-frst/road.console.txt
+++ b/testing/pluto/ikev2-rw-multiple-subnets-5-mismatch-frst/road.console.txt
@@ -27,7 +27,7 @@ initiating 4 connections
 "road/0x1" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road/0x1" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road/0x1" #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESPinUDP <0xESPESP} [192.0.3.0/24===192.0.4.0/24]
-"road/0x1" #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,N(TS_UNACCEPTABLE)}
+"road/0x1" #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,N(TS_UNACCEPTABLE)} reassembled from N fragments
 "road/0x1" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road/0x1" #2: IKE_AUTH response rejected Child SA with TS_UNACCEPTABLE
 "road/0x2" #3: initiating Child SA using IKE SA #1

--- a/testing/pluto/ikev2-selectors-44in4-rw-alias-mismatch-01/road.console.txt
+++ b/testing/pluto/ikev2-selectors-44in4-rw-alias-mismatch-01/road.console.txt
@@ -25,7 +25,7 @@ initiating all connections with alias "road"
 "road/0x1" #2: Child SA initiating pending connection using IKE SA #1's IKE_AUTH exchange
 "road/0x2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road/0x2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"road/0x2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"road/0x2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road/0x2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "road/0x1" #2: initiator established Child SA using #1; IPsec tunnel [192.0.3.0/24===192.0.2.0/24] {ESPinUDP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 NATD=192.1.2.23:4500 DPD=passive}
 "road/0x2" #3: initiating Child SA using IKE SA #1

--- a/testing/pluto/ikev2-selectors-44in4-rw-alias-mismatch-02/road.console.txt
+++ b/testing/pluto/ikev2-selectors-44in4-rw-alias-mismatch-02/road.console.txt
@@ -27,7 +27,7 @@ initiating all connections with alias "road"
 "road/0x1" #2: Child SA initiating pending connection using IKE SA #1's IKE_AUTH exchange
 "road/0x3" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road/0x3" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"road/0x3" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"road/0x3" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road/0x3" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "road/0x1" #2: initiator established Child SA using #1; IPsec tunnel [192.0.3.0/24===192.0.2.0/24] {ESPinUDP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 NATD=192.1.2.23:4500 DPD=passive}
 "road/0x2" #3: initiating Child SA using IKE SA #1

--- a/testing/pluto/ikev2-selectors-44in4-rw-ike-mismatch-01/road.console.txt
+++ b/testing/pluto/ikev2-selectors-44in4-rw-ike-mismatch-01/road.console.txt
@@ -22,7 +22,7 @@ road #
 "road" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"road" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"road" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "road" #2: accepted selectors [192.0.3.0/24]->[192.0.2.0/24 192.0.20.0/24]
 "road" #2: running updown up 192.0.3.0/24===192.0.2.0/24

--- a/testing/pluto/ikev2-selectors-44in4-rw-ike-mismatch-02/road.console.txt
+++ b/testing/pluto/ikev2-selectors-44in4-rw-ike-mismatch-02/road.console.txt
@@ -22,7 +22,7 @@ road #
 "road" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"road" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"road" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "road" #2: accepted selectors [192.0.3.0/24]->[192.0.2.0/24 192.0.20.0/24 192.0.30.0/24(block)]
 "road" #2: state spd requires a block

--- a/testing/pluto/ikev2-selectors-66in4-rw-alias-nonat/road.console.txt
+++ b/testing/pluto/ikev2-selectors-66in4-rw-alias-nonat/road.console.txt
@@ -25,7 +25,7 @@ initiating all connections with alias "road"
 "road/0x1" #2: Child SA initiating pending connection using IKE SA #1's IKE_AUTH exchange
 "road/0x2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road/0x2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"road/0x2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"road/0x2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road/0x2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "road/0x1" #2: initiator established Child SA using #1; IPsec tunnel [2001:db8:0:3::/64===2001:db8:0:2::/64] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 "road/0x2" #3: initiating Child SA using IKE SA #1

--- a/testing/pluto/ikev2-switchnat-01/road.console.txt
+++ b/testing/pluto/ikev2-switchnat-01/road.console.txt
@@ -21,7 +21,7 @@ road #
 "road1" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road1" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road1" #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESPinUDP <0xESPESP} [1.2.3.4/32===192.0.2.0/24]
-"road1" #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"road1" #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road1" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road1" #2: initiator established Child SA using #1; IPsec tunnel [1.2.3.4/32===192.0.2.0/24] {ESPinUDP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 NATD=192.1.2.23:4500 DPD=passive}
 road #
@@ -42,7 +42,7 @@ road #
 "road2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESPinUDP <0xESPESP} [1.2.3.4/32===192.0.2.0/24]
-"road2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"road2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/4500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road2" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road2" #2: initiator established Child SA using #1; IPsec tunnel [1.2.3.4/32===192.0.2.0/24] {ESPinUDP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 NATD=192.1.2.23:4500 DPD=passive}
 road #

--- a/testing/pluto/ikev2-systemrole-03-certs/west.console.txt
+++ b/testing/pluto/ikev2-systemrole-03-certs/west.console.txt
@@ -78,7 +78,7 @@ west #
 "192.1.2.45-to-192.1.2.23" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "192.1.2.45-to-192.1.2.23" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "192.1.2.45-to-192.1.2.23" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and IPV4_ADDR '192.1.2.45'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"192.1.2.45-to-192.1.2.23" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"192.1.2.45-to-192.1.2.23" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "192.1.2.45-to-192.1.2.23" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "192.1.2.45-to-192.1.2.23" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-tcp-03-basic-rawrsa-blocking/west.console.txt
+++ b/testing/pluto/ikev2-tcp-03-basic-rawrsa-blocking/west.console.txt
@@ -44,7 +44,7 @@ IMPAIR: "westnet-eastnet-ikev2" #1: IKETCP ENABLED: socket XX: switching off NON
 IMPAIR: "westnet-eastnet-ikev2" #1: IKETCP ENABLED: socket XX: restoring flags 04002 after write
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer using preloaded certificate '@east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESPinTCP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 up

--- a/testing/pluto/ikev2-tcp-03-basic-rawrsa-nonblocking/west.console.txt
+++ b/testing/pluto/ikev2-tcp-03-basic-rawrsa-nonblocking/west.console.txt
@@ -44,7 +44,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer using preloaded certificate '@east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESPinTCP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 up

--- a/testing/pluto/ikev2-tcp-04-ikeport-500/west.console.txt
+++ b/testing/pluto/ikev2-tcp-04-ikeport-500/west.console.txt
@@ -32,7 +32,7 @@ west #
 "west" #1: sent IKE_SA_INIT request to 192.1.2.23:TCP/500
 "west" #1: processed IKE_SA_INIT response from 192.1.2.23:TCP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west" #1: sent IKE_AUTH request to 192.1.2.23:TCP/500; Child SA #2 {ESP <0xESPESP}
-"west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "west" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESPinTCP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-tcp-05-transport-mode/west.console.txt
+++ b/testing/pluto/ikev2-tcp-05-transport-mode/west.console.txt
@@ -18,7 +18,7 @@ west #
 "ikev2-west-east" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/4500
 "ikev2-west-east" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/4500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "ikev2-west-east" #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500; Child SA #2 {ESPinUDP <0xESPESP}
-"ikev2-west-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"ikev2-west-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "ikev2-west-east" #1: initiator established IKE SA; authenticated peer using preloaded certificate '@east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature
 "ikev2-west-east" #2: initiator established Child SA using #1; IPsec transport [192.1.2.45/32===192.1.2.23/32] {ESPinTCP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-x509-01/west.console.txt
+++ b/testing/pluto/ikev2-x509-01/west.console.txt
@@ -37,7 +37,7 @@ west #
 "ikev2-westnet-eastnet-x509-cr" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "ikev2-westnet-eastnet-x509-cr" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "ikev2-westnet-eastnet-x509-cr" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"ikev2-westnet-eastnet-x509-cr" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"ikev2-westnet-eastnet-x509-cr" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "ikev2-westnet-eastnet-x509-cr" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "ikev2-westnet-eastnet-x509-cr" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-x509-03/west.console.txt
+++ b/testing/pluto/ikev2-x509-03/west.console.txt
@@ -37,7 +37,7 @@ west #
 "ikev2-westnet-eastnet-x509-cr" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "ikev2-westnet-eastnet-x509-cr" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "ikev2-westnet-eastnet-x509-cr" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"ikev2-westnet-eastnet-x509-cr" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"ikev2-westnet-eastnet-x509-cr" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "ikev2-westnet-eastnet-x509-cr" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "ikev2-westnet-eastnet-x509-cr" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-x509-05-san-firstemail-match/west.console.txt
+++ b/testing/pluto/ikev2-x509-05-san-firstemail-match/west.console.txt
@@ -25,7 +25,7 @@ west #
 "san" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "san" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "san" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and USER_FQDN 'user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"san" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"san" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "san" #1: X509: authentication failed; peer certificate subjectAltName extension does not match USER_FQDN 'user-east@testing.libreswan.org'
 "san" #1: deleting IKE SA (IKE_AUTH_I) and sending notification
 "san" #2: connection is supposed to remain up; revival attempt 1 scheduled in 0 seconds

--- a/testing/pluto/ikev2-x509-06-san-email-mismatch/west.console.txt
+++ b/testing/pluto/ikev2-x509-06-san-email-mismatch/west.console.txt
@@ -23,7 +23,7 @@ west #
 "san" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "san" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "san" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and USER_FQDN 'west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"san" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"san" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "san" #1: X509: authentication failed; peer certificate subjectAltName extension does not match USER_FQDN 'NOTeast@testing.libreswan.org'
 "san" #1: deleting IKE SA (IKE_AUTH_I) and sending notification
 "san" #2: connection is supposed to remain up; revival attempt 1 scheduled in 0 seconds

--- a/testing/pluto/ikev2-x509-08-san-dns-mismatch/west.console.txt
+++ b/testing/pluto/ikev2-x509-08-san-dns-mismatch/west.console.txt
@@ -23,7 +23,7 @@ west #
 "san" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "san" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "san" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and FQDN '@west.testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"san" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"san" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "san" #1: X509: authentication failed; peer certificate subjectAltName extension does not match FQDN 'NOTeast.testing.libreswan.org'
 "san" #1: deleting IKE SA (IKE_AUTH_I) and sending notification
 "san" #2: connection is supposed to remain up; revival attempt 1 scheduled in 0 seconds

--- a/testing/pluto/ikev2-x509-09-san-email-match/west.console.txt
+++ b/testing/pluto/ikev2-x509-09-san-email-match/west.console.txt
@@ -23,7 +23,7 @@ west #
 "san" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "san" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "san" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and USER_FQDN 'west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"san" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"san" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "san" #1: initiator established IKE SA; authenticated peer certificate 'east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "san" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-x509-10-san-ip-match/west.console.txt
+++ b/testing/pluto/ikev2-x509-10-san-ip-match/west.console.txt
@@ -23,7 +23,7 @@ west #
 "san" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "san" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "san" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and IPV4_ADDR '192.1.2.45'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"san" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"san" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "san" #1: initiator established IKE SA; authenticated peer certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "san" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-x509-10-san-ipv6-match/west.console.txt
+++ b/testing/pluto/ikev2-x509-10-san-ipv6-match/west.console.txt
@@ -50,7 +50,7 @@ west #
 "san" #1: sent IKE_SA_INIT request to [2001:db8:1:2::23]:UDP/500
 "san" #1: processed IKE_SA_INIT response from [2001:db8:1:2::23]:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "san" #1: sent IKE_AUTH request to [2001:db8:1:2::23]:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and IPV6_ADDR '2001:db8:1:2::45'; Child SA #2 {ESP <0xESPESP} [2001:db8:1:2::45/128===2001:db8:1:2::23/128]
-"san" #1: processing IKE_AUTH response from [2001:db8:1:2::23]:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"san" #1: processing IKE_AUTH response from [2001:db8:1:2::23]:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "san" #1: initiator established IKE SA; authenticated peer certificate '2001:db8:1:2::23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "san" #2: initiator established Child SA using #1; IPsec tunnel [2001:db8:1:2::45/128===2001:db8:1:2::23/128] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-x509-11-san-dns-match/west.console.txt
+++ b/testing/pluto/ikev2-x509-11-san-dns-match/west.console.txt
@@ -23,7 +23,7 @@ west #
 "san" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "san" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "san" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and FQDN '@west.testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"san" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"san" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "san" #1: initiator established IKE SA; authenticated peer certificate '@east.testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "san" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-x509-12-san-dn-fromcert/west.console.txt
+++ b/testing/pluto/ikev2-x509-12-san-dn-fromcert/west.console.txt
@@ -23,7 +23,7 @@ west #
 "san" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "san" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "san" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"san" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"san" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "san" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "san" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-x509-13-san-dn-match/west.console.txt
+++ b/testing/pluto/ikev2-x509-13-san-dn-match/west.console.txt
@@ -23,7 +23,7 @@ west #
 "san" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "san" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "san" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"san" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"san" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "san" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "san" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-x509-14-san-dn-mismatch/west.console.txt
+++ b/testing/pluto/ikev2-x509-14-san-dn-mismatch/west.console.txt
@@ -25,7 +25,7 @@ west #
 "san" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "san" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "san" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"san" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"san" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "san" #1: X509: authentication failed; peer ID DER_ASN1_DN 'E=user-east@testing.libreswan.org,CN=east.testing.libreswan.org,OU=Test Department,O=Libreswan,L=Toronto,ST=Ontario,C=CA' does not match expected 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=NOTeast.testing.libreswan.org, E=user-NOTeast@testing.libreswan.org'
 "san" #1: deleting IKE SA (IKE_AUTH_I) and sending notification
 "san" #2: connection is supposed to remain up; revival attempt 1 scheduled in 0 seconds

--- a/testing/pluto/ikev2-x509-16-multicert/west.console.txt
+++ b/testing/pluto/ikev2-x509-16-multicert/west.console.txt
@@ -48,7 +48,7 @@ west #
 "other" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "other" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "other" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and FQDN '@otherwest.other.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"other" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"other" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "other" #1: initiator established IKE SA; authenticated peer certificate '@othereast.other.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for otherca, E=testing@libreswan.org'
 "other" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-x509-17-multicert-02/west.console.txt
+++ b/testing/pluto/ikev2-x509-17-multicert-02/west.console.txt
@@ -49,7 +49,7 @@ west #
 "main" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "main" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "main" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"main" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"main" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "main" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "main" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-x509-17-multicert-rightid-san-wildcard/west.console.txt
+++ b/testing/pluto/ikev2-x509-17-multicert-rightid-san-wildcard/west.console.txt
@@ -21,7 +21,7 @@ west #
 "main" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "main" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "main" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and FQDN '@west.testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"main" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"main" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "main" #1: initiator established IKE SA; authenticated peer certificate '@east.testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "main" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-x509-18-multicert-rightid/west.console.txt
+++ b/testing/pluto/ikev2-x509-18-multicert-rightid/west.console.txt
@@ -21,7 +21,7 @@ west #
 "main" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "main" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "main" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"main" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"main" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "main" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "main" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-x509-19-multicert-rightid-san/west.console.txt
+++ b/testing/pluto/ikev2-x509-19-multicert-rightid-san/west.console.txt
@@ -21,7 +21,7 @@ west #
 "main" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "main" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "main" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and FQDN '@west.testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"main" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"main" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "main" #1: initiator established IKE SA; authenticated peer certificate '@east.testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "main" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-x509-20-multicert-rightid-san-wildcard/west.console.txt
+++ b/testing/pluto/ikev2-x509-20-multicert-rightid-san-wildcard/west.console.txt
@@ -21,7 +21,7 @@ west #
 "main" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "main" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "main" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and FQDN '@west.testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"main" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"main" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "main" #1: initiator established IKE SA; authenticated peer certificate '@east.testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "main" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-x509-22-pkcs7/west.console.txt
+++ b/testing/pluto/ikev2-x509-22-pkcs7/west.console.txt
@@ -36,7 +36,7 @@ west #
 "ikev2-westnet-eastnet-x509-cr" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 IMPAIR: "ikev2-westnet-eastnet-x509-cr" #1: sending cert as PKCS7 blob
 "ikev2-westnet-eastnet-x509-cr" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"ikev2-westnet-eastnet-x509-cr" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"ikev2-westnet-eastnet-x509-cr" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "ikev2-westnet-eastnet-x509-cr" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "ikev2-westnet-eastnet-x509-cr" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-x509-29-selfsigned/west.console.txt
+++ b/testing/pluto/ikev2-x509-29-selfsigned/west.console.txt
@@ -34,7 +34,7 @@ west #
 "west-x509" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-x509" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-x509" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"west-x509" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"west-x509" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-x509" #1: initiator established IKE SA; authenticated peer using preloaded certificate 'CN=east-selfsigned.testing.libreswan.org' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'CN=east-selfsigned.testing.libreswan.org'
 "west-x509" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-x509-30-mismatch-ignore/west.console.txt
+++ b/testing/pluto/ikev2-x509-30-mismatch-ignore/west.console.txt
@@ -21,7 +21,7 @@ west #
 "san" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "san" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "san" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and FQDN '@ThisShouldAlsoBeIgnored'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"san" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"san" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "san" #1: initiator established IKE SA; authenticated peer certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "san" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-x509-31-wifi-assist-nonat/road.console.txt
+++ b/testing/pluto/ikev2-x509-31-wifi-assist-nonat/road.console.txt
@@ -24,7 +24,7 @@ road #
 "rw-lte"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "rw-lte"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "rw-lte"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [0.0.0.0/0===192.0.2.0/24]
-"rw-lte"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"rw-lte"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "rw-lte"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer certificate '@east.testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "rw-lte"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 100.64.0.1
 "rw-lte"[1] 192.1.2.23 #2: received INTERNAL_IP4_DNS server address 1.2.3.4
@@ -43,7 +43,7 @@ road #
 "rw-wifi"[1] 192.1.2.23 #3: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "rw-wifi"[1] 192.1.2.23 #3: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "rw-wifi"[1] 192.1.2.23 #3: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org'; Child SA #4 {ESP <0xESPESP} [0.0.0.0/0===192.0.2.0/24]
-"rw-wifi"[1] 192.1.2.23 #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"rw-wifi"[1] 192.1.2.23 #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "rw-wifi"[1] 192.1.2.23 #3: initiator established IKE SA; authenticated peer certificate '@east.testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "rw-wifi"[1] 192.1.2.23 #4: received INTERNAL_IP4_ADDRESS 100.64.0.2
 "rw-wifi"[1] 192.1.2.23 #4: received INTERNAL_IP4_DNS server address 1.2.3.4

--- a/testing/pluto/ikev2-x509-32-id-any/west.console.txt
+++ b/testing/pluto/ikev2-x509-32-id-any/west.console.txt
@@ -43,7 +43,7 @@ west #
 "ikev2-westnet-eastnet-x509-cr" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "ikev2-westnet-eastnet-x509-cr" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "ikev2-westnet-eastnet-x509-cr" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and IPV4_ADDR '192.1.2.45'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"ikev2-westnet-eastnet-x509-cr" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"ikev2-westnet-eastnet-x509-cr" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "ikev2-westnet-eastnet-x509-cr" #1: peer certificate contains no subjectAltName extension to match IPV4_ADDR '192.1.2.23'
 "ikev2-westnet-eastnet-x509-cr" #1: X509: connection allows unmatched IKE ID and certificate SAN
 "ikev2-westnet-eastnet-x509-cr" #1: initiator established IKE SA; authenticated peer certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'

--- a/testing/pluto/ikev2-x509-33-id-notany/west.console.txt
+++ b/testing/pluto/ikev2-x509-33-id-notany/west.console.txt
@@ -26,7 +26,7 @@ west #
 "ikev2-westnet-eastnet-x509-cr" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "ikev2-westnet-eastnet-x509-cr" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "ikev2-westnet-eastnet-x509-cr" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and IPV4_ADDR '192.1.2.45'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"ikev2-westnet-eastnet-x509-cr" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"ikev2-westnet-eastnet-x509-cr" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "ikev2-westnet-eastnet-x509-cr" #1: X509: authentication failed; peer certificate contains no subjectAltName extension to match FQDN '@right'
 "ikev2-westnet-eastnet-x509-cr" #1: deleting IKE SA (IKE_AUTH_I) and sending notification
 "ikev2-westnet-eastnet-x509-cr" #2: connection is supposed to remain up; revival attempt 1 scheduled in 0 seconds

--- a/testing/pluto/ikev2-x509-35-id-any-responder/west.console.txt
+++ b/testing/pluto/ikev2-x509-35-id-any-responder/west.console.txt
@@ -30,7 +30,7 @@ west #
 "ikev2-westnet-eastnet-x509-cr" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "ikev2-westnet-eastnet-x509-cr" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "ikev2-westnet-eastnet-x509-cr" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and IPV4_ADDR '192.1.2.45'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"ikev2-westnet-eastnet-x509-cr" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"ikev2-westnet-eastnet-x509-cr" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "ikev2-westnet-eastnet-x509-cr" #1: peer certificate contains no subjectAltName extension to match IPV4_ADDR '192.1.2.23'
 "ikev2-westnet-eastnet-x509-cr" #1: X509: connection allows unmatched IKE ID and certificate SAN
 "ikev2-westnet-eastnet-x509-cr" #1: initiator established IKE SA; authenticated peer certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'

--- a/testing/pluto/ikev2-x509-36-leftrightauth/west.console.txt
+++ b/testing/pluto/ikev2-x509-36-leftrightauth/west.console.txt
@@ -37,7 +37,7 @@ west #
 "ikev2-westnet-eastnet-x509-cr" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "ikev2-westnet-eastnet-x509-cr" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "ikev2-westnet-eastnet-x509-cr" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"ikev2-westnet-eastnet-x509-cr" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"ikev2-westnet-eastnet-x509-cr" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "ikev2-westnet-eastnet-x509-cr" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "ikev2-westnet-eastnet-x509-cr" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-x509-37-fakeeast-westecca/west.console.txt
+++ b/testing/pluto/ikev2-x509-37-fakeeast-westecca/west.console.txt
@@ -60,7 +60,7 @@ west #
 "ikev2-westnet-eastnet-x509-cr" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "ikev2-westnet-eastnet-x509-cr" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "ikev2-westnet-eastnet-x509-cr" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"ikev2-westnet-eastnet-x509-cr" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"ikev2-westnet-eastnet-x509-cr" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "ikev2-westnet-eastnet-x509-cr" #1: NSS: ERROR: IPsec certificate E=user-east@testing.libreswan.org,CN=east.testing.libreswan.org,OU=Test Department,O=Libreswan,L=Toronto,ST=Ontario,C=CA invalid: SEC_ERROR_UNKNOWN_ISSUER: Peer's Certificate issuer is not recognized.
 "ikev2-westnet-eastnet-x509-cr" #1: X509: certificate payload rejected for this connection
 "ikev2-westnet-eastnet-x509-cr" #1: encountered fatal error in state IKE_AUTH_I

--- a/testing/pluto/ikev2-x509-37-fakeeast-westnoca/west.console.txt
+++ b/testing/pluto/ikev2-x509-37-fakeeast-westnoca/west.console.txt
@@ -54,7 +54,7 @@ west #
 "ikev2-westnet-eastnet-x509-cr" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "ikev2-westnet-eastnet-x509-cr" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "ikev2-westnet-eastnet-x509-cr" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"ikev2-westnet-eastnet-x509-cr" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"ikev2-westnet-eastnet-x509-cr" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "ikev2-westnet-eastnet-x509-cr" #1: no Certificate Authority in NSS Certificate DB! certificate payloads discarded
 "ikev2-westnet-eastnet-x509-cr" #1: authentication failed: no certificate matched RSASSA-PSS with SHA2_512 and 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org'
 "ikev2-westnet-eastnet-x509-cr" #1: deleting IKE SA (IKE_AUTH_I) and sending notification

--- a/testing/pluto/ikev2-x509-37-fakeeast-westrsa/west.console.txt
+++ b/testing/pluto/ikev2-x509-37-fakeeast-westrsa/west.console.txt
@@ -55,7 +55,7 @@ west #
 "ikev2-westnet-eastnet-x509-cr" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "ikev2-westnet-eastnet-x509-cr" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "ikev2-westnet-eastnet-x509-cr" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"ikev2-westnet-eastnet-x509-cr" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"ikev2-westnet-eastnet-x509-cr" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "ikev2-westnet-eastnet-x509-cr" #1: NSS: ERROR: IPsec certificate E=testing@libreswan.org,CN=Libreswan test CA for mainca,OU=Test Department,O=Libreswan,L=Toronto,ST=Ontario,C=CA invalid: SEC_ERROR_BAD_SIGNATURE: Peer's certificate has an invalid signature.
 "ikev2-westnet-eastnet-x509-cr" #1: X509: certificate payload rejected for this connection
 "ikev2-westnet-eastnet-x509-cr" #1: encountered fatal error in state IKE_AUTH_I

--- a/testing/pluto/ikev2-x509-40-dn-wildcard/west.console.txt
+++ b/testing/pluto/ikev2-x509-40-dn-wildcard/west.console.txt
@@ -26,7 +26,7 @@ west #
 "san-openssl" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "san-openssl" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "san-openssl" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"san-openssl" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"san-openssl" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "san-openssl" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "san-openssl" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #
@@ -43,7 +43,7 @@ west #
 "san-nss" #3: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "san-nss" #3: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "san-nss" #3: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'E=user-west@testing.libreswan.org, CN=west.testing.libreswan.org, OU=Test Department, O=Libreswan, L=Toronto, ST=Ontario, C=CA'; Child SA #4 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"san-nss" #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"san-nss" #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "san-nss" #3: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "san-nss" #4: initiator established Child SA using #3; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-x509-41-rightid-fromcert-rightid-ip/west.console.txt
+++ b/testing/pluto/ikev2-x509-41-rightid-fromcert-rightid-ip/west.console.txt
@@ -36,7 +36,7 @@ west #
 "ikev2-westnet-eastnet-x509-cr" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "ikev2-westnet-eastnet-x509-cr" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "ikev2-westnet-eastnet-x509-cr" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west-nosan.testing.libreswan.org, E=user-west-nosan@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"ikev2-westnet-eastnet-x509-cr" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"ikev2-westnet-eastnet-x509-cr" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "ikev2-westnet-eastnet-x509-cr" #1: authentication failed: no certificate matched RSASSA-PSS with SHA2_512 and '192.1.2.23'
 "ikev2-westnet-eastnet-x509-cr" #1: deleting IKE SA (IKE_AUTH_I) and sending notification
 "ikev2-westnet-eastnet-x509-cr" #2: connection is supposed to remain up; revival attempt 1 scheduled in 0 seconds

--- a/testing/pluto/ikev2-x509-42-no-rightca/west.console.txt
+++ b/testing/pluto/ikev2-x509-42-no-rightca/west.console.txt
@@ -47,7 +47,7 @@ west #
 "west" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP}
-"west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "west" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-x509-ecdsa-01/west.console.txt
+++ b/testing/pluto/ikev2-x509-ecdsa-01/west.console.txt
@@ -27,7 +27,7 @@ west #
 "west" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature ECDSA with SHA2_384 and DER_ASN1_DN 'E=user-west@testing.libreswan.org, CN=west.testing.libreswan.org, OU=Test Department, O=Libreswan, L=Toronto, ST=Ontario, C=CA'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and P-384 ECDSA with SHA2_384 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainec, E=testing@libreswan.org'
 "west" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-x509-ecdsa-03-legacy-initiator/west.console.txt
+++ b/testing/pluto/ikev2-x509-ecdsa-03-legacy-initiator/west.console.txt
@@ -35,7 +35,7 @@ IMPAIR: "westnet-eastnet-ikev2" #1: forcing auth method IKEv2_AUTH_ECDSA_SHA2_38
 IMPAIR: "westnet-eastnet-ikev2" #1: forcing auth method IKEv2_AUTH_ECDSA_SHA2_384_P384
 IMPAIR: "westnet-eastnet-ikev2" #1: forcing auth method IKEv2_AUTH_ECDSA_SHA2_384_P384
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with ecdsa-sha2-384-p384 and DER_ASN1_DN 'E=user-west@testing.libreswan.org, CN=west.testing.libreswan.org, OU=Test Department, O=Libreswan, L=Toronto, ST=Ontario, C=CA'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and P-384 ECDSA with SHA2_384 signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainec, E=testing@libreswan.org'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-x509-ecdsa-03-legacy-responder/west.console.txt
+++ b/testing/pluto/ikev2-x509-ecdsa-03-legacy-responder/west.console.txt
@@ -27,7 +27,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with ecdsa-sha2-384-p384 and DER_ASN1_DN 'E=user-west@testing.libreswan.org, CN=west.testing.libreswan.org, OU=Test Department, O=Libreswan, L=Toronto, ST=Ontario, C=CA'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and P-384 ECDSA with SHA2_384 signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainec, E=testing@libreswan.org'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-x509-ecdsa-05-rsa-asym/west.console.txt
+++ b/testing/pluto/ikev2-x509-ecdsa-05-rsa-asym/west.console.txt
@@ -46,7 +46,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CH, O=strongSwan, CN=strongEast' and P-384 ECDSA with SHA2_512 digital signature issued by 'C=CH, O=strongSwan, CN=strongSwan CA'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-x509-ecdsa-06-rsa-asym-flip/west.console.txt
+++ b/testing/pluto/ikev2-x509-ecdsa-06-rsa-asym-flip/west.console.txt
@@ -46,7 +46,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-x509-eddsa-01/west.console.txt
+++ b/testing/pluto/ikev2-x509-eddsa-01/west.console.txt
@@ -27,7 +27,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature EDDSA with IDENTITY and DER_ASN1_DN 'C=CH, O=strongSwan, CN=strongWest'; Child SA #2 {ESP <0xESPESP}
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CH, O=strongSwan, CN=strongEast' and P-384 ECDSA with SHA2_512 digital signature issued by 'C=CH, O=strongSwan, CN=strongSwan strong-EC CA'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ikev2-xfrmi-02-responder/road.console.txt
+++ b/testing/pluto/ikev2-xfrmi-02-responder/road.console.txt
@@ -22,7 +22,7 @@ road #
 "road" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"road" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"road" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "road" #2: initiator established Child SA using #1; IPsec tunnel [192.1.3.209/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 road #

--- a/testing/pluto/ikev2-xfrmi-05-remote-access-client/road.console.txt
+++ b/testing/pluto/ikev2-xfrmi-05-remote-access-client/road.console.txt
@@ -23,7 +23,7 @@ road #
 "eastnet-any"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "eastnet-any"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "eastnet-any"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"eastnet-any"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"eastnet-any"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "eastnet-any"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "eastnet-any"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 100.64.13.2
 "eastnet-any"[1] 192.1.2.23 #2: received INTERNAL_IP4_DNS 1.2.3.4

--- a/testing/pluto/ikev2-xfrmi-18-responder-iface-check/road.console.txt
+++ b/testing/pluto/ikev2-xfrmi-18-responder-iface-check/road.console.txt
@@ -18,7 +18,7 @@ road #
 "road" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"road" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"road" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "road" #2: initiator established Child SA using #1; IPsec tunnel [192.1.3.209/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 road #

--- a/testing/pluto/ikev2-xfrmi-20-with-dev/west.console.txt
+++ b/testing/pluto/ikev2-xfrmi-20-with-dev/west.console.txt
@@ -51,7 +51,7 @@ west #
 "west" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "west" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/impair-install-ipsec-sa-inbound-policy-initiator-ikev2/west.console.txt
+++ b/testing/pluto/impair-install-ipsec-sa-inbound-policy-initiator-ikev2/west.console.txt
@@ -41,7 +41,7 @@ west #
 "west-east" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-east" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-east" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"west-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"west-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-east" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 IMPAIR: "west-east" #2: kernel: install_ipsec_sa_inbound_policy in install_inbound_ipsec_kernel_policies()
 "west-east" #2: CHILD SA failed: TEMPORARY_FAILURE

--- a/testing/pluto/impair-install-ipsec-sa-inbound-policy-responder-ikev2/west.console.txt
+++ b/testing/pluto/impair-install-ipsec-sa-inbound-policy-responder-ikev2/west.console.txt
@@ -39,7 +39,7 @@ west #
 "west-east" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-east" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-east" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"west-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"west-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-east" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "west-east" #2: IKE_AUTH response missing v2SA, v2TSi or v2TSr: not attempting to setup CHILD SA
 "west-east" #1: IKE SA established but initiator rejected Child SA response

--- a/testing/pluto/impair-install-ipsec-sa-inbound-state-initiator-ikev2/west.console.txt
+++ b/testing/pluto/impair-install-ipsec-sa-inbound-state-initiator-ikev2/west.console.txt
@@ -41,7 +41,7 @@ west #
 "west-east" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-east" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-east" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"west-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"west-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-east" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 IMPAIR: "west-east" #2: kernel: install_ipsec_sa_inbound_state in setup_half_kernel_state()
 "west-east" #2: CHILD SA failed: TEMPORARY_FAILURE

--- a/testing/pluto/impair-install-ipsec-sa-inbound-state-responder-ikev2/west.console.txt
+++ b/testing/pluto/impair-install-ipsec-sa-inbound-state-responder-ikev2/west.console.txt
@@ -39,7 +39,7 @@ west #
 "west-east" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-east" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-east" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"west-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"west-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-east" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "west-east" #2: IKE_AUTH response missing v2SA, v2TSi or v2TSr: not attempting to setup CHILD SA
 "west-east" #1: IKE SA established but initiator rejected Child SA response

--- a/testing/pluto/impair-install-ipsec-sa-outbound-policy-initiator-ikev2/west.console.txt
+++ b/testing/pluto/impair-install-ipsec-sa-outbound-policy-initiator-ikev2/west.console.txt
@@ -41,7 +41,7 @@ west #
 "west-east" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-east" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-east" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"west-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"west-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-east" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 IMPAIR: "west-east" #2: kernel: install_ipsec_sa_outbound_policy in install_outbound_ipsec_kernel_policies()
 "west-east" #2: CHILD SA failed: TEMPORARY_FAILURE

--- a/testing/pluto/impair-install-ipsec-sa-outbound-policy-responder-ikev2/west.console.txt
+++ b/testing/pluto/impair-install-ipsec-sa-outbound-policy-responder-ikev2/west.console.txt
@@ -39,7 +39,7 @@ west #
 "west-east" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-east" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-east" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"west-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"west-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-east" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "west-east" #2: IKE_AUTH response missing v2SA, v2TSi or v2TSr: not attempting to setup CHILD SA
 "west-east" #1: IKE SA established but initiator rejected Child SA response

--- a/testing/pluto/impair-install-ipsec-sa-outbound-state-initiator-ikev2/west.console.txt
+++ b/testing/pluto/impair-install-ipsec-sa-outbound-state-initiator-ikev2/west.console.txt
@@ -41,7 +41,7 @@ west #
 "west-east" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-east" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-east" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"west-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"west-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-east" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 IMPAIR: "west-east" #2: kernel: install_ipsec_sa_outbound_state in setup_half_kernel_state()
 "west-east" #2: CHILD SA failed: TEMPORARY_FAILURE

--- a/testing/pluto/impair-install-ipsec-sa-outbound-state-responder-ikev2/west.console.txt
+++ b/testing/pluto/impair-install-ipsec-sa-outbound-state-responder-ikev2/west.console.txt
@@ -39,7 +39,7 @@ west #
 "west-east" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-east" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-east" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"west-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"west-east" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-east" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "west-east" #2: IKE_AUTH response missing v2SA, v2TSi or v2TSr: not attempting to setup CHILD SA
 "west-east" #1: IKE SA established but initiator rejected Child SA response

--- a/testing/pluto/interop-ikev2-strongswan-04-x509-responder/west.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-04-x509-responder/west.console.txt
@@ -43,7 +43,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA2_256_128 prf=HMAC_SHA2_256 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_256 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_256 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP=>0xESPESP <0xESPESP xfrm=AES_CBC_256-HMAC_SHA2_256_128 DPD=passive}
 west #

--- a/testing/pluto/interop-ikev2-strongswan-19-x509-res-certreq/west.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-19-x509-res-certreq/west.console.txt
@@ -43,7 +43,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA2_256_128 prf=HMAC_SHA2_256 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP=>0xESPESP <0xESPESP xfrm=AES_CBC_256-HMAC_SHA2_256_128 DPD=passive}
 west #

--- a/testing/pluto/interop-ikev2-strongswan-39-fragmentation-aes-gcm/west.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-39-fragmentation-aes-gcm/west.console.txt
@@ -41,7 +41,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_256 group=MODP2048}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_256 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_256 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP=>0xESPESP <0xESPESP xfrm=AES_CBC_256-HMAC_SHA2_256_128 DPD=passive}
 west #

--- a/testing/pluto/interop-ikev2-strongswan-46-responder-ecdsa-384/west.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-46-responder-ecdsa-384/west.console.txt
@@ -25,7 +25,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA2_256_128 prf=HMAC_SHA2_256 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature ECDSA with SHA2_384 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and P-384 ECDSA with SHA2_384 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainec, E=testing@libreswan.org'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP=>0xESPESP <0xESPESP xfrm=AES_CBC_128-HMAC_SHA2_512_256 DPD=passive}
 west #

--- a/testing/pluto/ipv6-6in4-02-ikev2-ipsec-device/west.console.txt
+++ b/testing/pluto/ipv6-6in4-02-ikev2-ipsec-device/west.console.txt
@@ -65,7 +65,7 @@ west #
 "westnet-eastnet-6in4" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-6in4" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-6in4" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"westnet-eastnet-6in4" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"westnet-eastnet-6in4" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-6in4" #1: initiator established IKE SA; authenticated peer using preloaded certificate '@east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature
 "westnet-eastnet-6in4" #2: initiator established Child SA using #1; IPsec tunnel [2001:db8:0:1::/64===2001:db8:0:2::/64] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/ipv6-6in4-02-ikev2/west.console.txt
+++ b/testing/pluto/ipv6-6in4-02-ikev2/west.console.txt
@@ -59,7 +59,7 @@ west #
 "westnet-eastnet-6in4" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-6in4" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-6in4" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and FQDN '@west'; Child SA #2 {ESP <0xESPESP} [2001:db8:0:1::/64===2001:db8:0:2::/64]
-"westnet-eastnet-6in4" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"westnet-eastnet-6in4" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-6in4" #1: initiator established IKE SA; authenticated peer using preloaded certificate '@east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature
 "westnet-eastnet-6in4" #2: initiator established Child SA using #1; IPsec tunnel [2001:db8:0:1::/64===2001:db8:0:2::/64] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/nss-cert-01-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-01-ikev2/west.console.txt
@@ -45,7 +45,7 @@ west #
 "nss-cert" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "nss-cert" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "nss-cert" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.254/32===192.0.2.254/32]
-"nss-cert" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"nss-cert" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "nss-cert" #1: initiator established IKE SA; authenticated peer using preloaded certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "nss-cert" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.254/32===192.0.2.254/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/nss-cert-02-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-02-ikev1/west.console.txt
@@ -47,7 +47,7 @@ west #
 "nss-cert" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "nss-cert" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "nss-cert" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.254/32===192.0.2.254/32]
-"nss-cert" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"nss-cert" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "nss-cert" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "nss-cert" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.254/32===192.0.2.254/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/nss-cert-02-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-02-ikev2/west.console.txt
@@ -47,7 +47,7 @@ west #
 "nss-cert" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "nss-cert" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "nss-cert" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.254/32===192.0.2.254/32]
-"nss-cert" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"nss-cert" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "nss-cert" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "nss-cert" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.254/32===192.0.2.254/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/nss-cert-03-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-03-ikev2/west.console.txt
@@ -47,7 +47,7 @@ west #
 "nss-cert" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "nss-cert" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "nss-cert" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.254/32===192.0.2.254/32]
-"nss-cert" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"nss-cert" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "nss-cert" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "nss-cert" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.254/32===192.0.2.254/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/nss-cert-06-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-06-ikev2/west.console.txt
@@ -61,7 +61,7 @@ west #
 "nss-cert" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "nss-cert" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "nss-cert" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and FQDN '@west.testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.254/32===192.0.2.254/32]
-"nss-cert" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"nss-cert" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "nss-cert" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "nss-cert" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.254/32===192.0.2.254/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/nss-cert-11-ca-expired-responder-1conn-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-11-ca-expired-responder-1conn-ikev2/west.console.txt
@@ -51,7 +51,7 @@ west #
 "new-west" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "new-west" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "new-west" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'CN=new-west'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"new-west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"new-west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "new-west" #1: initiator established IKE SA; authenticated peer certificate 'CN=east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'CN=west-ca'
 "new-west" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #
@@ -67,7 +67,7 @@ west #
 "old-west" #3: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "old-west" #3: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "old-west" #3: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'CN=old-west'; Child SA #4 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"old-west" #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"old-west" #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "old-west" #3: initiator established IKE SA; authenticated peer certificate 'CN=east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'CN=west-ca'
 "old-west" #4: initiator established Child SA using #3; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/nss-cert-11-ca-expired-responder-3conn-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-11-ca-expired-responder-3conn-ikev2/west.console.txt
@@ -68,7 +68,7 @@ west #
 "new-west" #4: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "new-west" #4: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "new-west" #4: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'CN=new-west'; Child SA #5 {ESP <0xESPESP} [192.0.2.0/24===192.0.2.0/24]
-"new-west" #4: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"new-west" #4: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "new-west" #4: initiator established IKE SA; authenticated peer certificate 'CN=east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'CN=west-ca'
 "new-west" #5: initiator established Child SA using #4; IPsec tunnel [192.0.2.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #
@@ -83,7 +83,7 @@ west #
 "hog-west" #6: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "hog-west" #6: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "hog-west" #6: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'CN=hog-west'; Child SA #7 {ESP <0xESPESP} [192.0.3.0/24===192.0.2.0/24]
-"hog-west" #6: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"hog-west" #6: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "hog-west" #6: initiator established IKE SA; authenticated peer certificate 'CN=east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'CN=west-ca'
 "hog-west" #7: initiator established Child SA using #6; IPsec tunnel [192.0.3.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/nss-cert-11-ca-expiring-responder-perm-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-11-ca-expiring-responder-perm-ikev2/west.console.txt
@@ -47,7 +47,7 @@ west #
 "old-west" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "old-west" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "old-west" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"old-west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"old-west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "old-west" #1: initiator established IKE SA; authenticated peer certificate 'CN=east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'CN=west-ca'
 "old-west" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #
@@ -63,7 +63,7 @@ west #
 "new-west" #3: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #4 {ESP <0xESPESP}
 "new-west" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "new-west" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"new-west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"new-west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "new-west" #1: initiator established IKE SA; authenticated peer certificate 'CN=east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'CN=west-ca'
 "new-west" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/nss-cert-11-ca-expiring-responder-switch-ikev2-overlapip/west.console.txt
+++ b/testing/pluto/nss-cert-11-ca-expiring-responder-switch-ikev2-overlapip/west.console.txt
@@ -47,7 +47,7 @@ west #
 "old-west" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "old-west" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "old-west" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'CN=old-west'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"old-west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"old-west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "old-west" #1: initiator established IKE SA; authenticated peer certificate 'CN=east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'CN=west-ca'
 "old-west" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #
@@ -62,7 +62,7 @@ west #
 "new-west" #3: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "new-west" #3: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "new-west" #3: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'CN=new-west'; Child SA #4 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"new-west" #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"new-west" #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "new-west" #3: initiator established IKE SA; authenticated peer certificate 'CN=east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'CN=west-ca'
 "new-west" #4: initiator established Child SA using #3; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #
@@ -77,7 +77,7 @@ west #
 "old-west" #5: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "old-west" #5: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "old-west" #5: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'CN=old-west'; Child SA #6 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"old-west" #5: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"old-west" #5: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "old-west" #5: initiator established IKE SA; authenticated peer certificate 'CN=east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'CN=west-ca'
 "old-west" #6: initiator established Child SA using #5; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #
@@ -92,7 +92,7 @@ west #
 "new-west" #7: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "new-west" #7: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "new-west" #7: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'CN=new-west'; Child SA #8 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"new-west" #7: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"new-west" #7: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "new-west" #7: initiator established IKE SA; authenticated peer certificate 'CN=east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'CN=west-ca'
 "new-west" #8: initiator established Child SA using #7; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/nss-cert-11-ca-expiring-responder-switch-ikev2-rw/west.console.txt
+++ b/testing/pluto/nss-cert-11-ca-expiring-responder-switch-ikev2-rw/west.console.txt
@@ -49,7 +49,7 @@ west #
 "old-west" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "old-west" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "old-west" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'CN=old-west'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"old-west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"old-west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "old-west" #1: initiator established IKE SA; authenticated peer certificate 'CN=east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'CN=west-ca'
 "old-west" #2: received INTERNAL_IP4_ADDRESS 192.0.1.0
 "old-west" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/32===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
@@ -65,7 +65,7 @@ west #
 "new-west" #3: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "new-west" #3: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "new-west" #3: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'CN=new-west'; Child SA #4 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"new-west" #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"new-west" #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "new-west" #3: initiator established IKE SA; authenticated peer certificate 'CN=east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'CN=west-ca'
 "new-west" #4: received INTERNAL_IP4_ADDRESS 192.0.1.0
 "new-west" #4: initiator established Child SA using #3; IPsec tunnel [192.0.1.0/32===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
@@ -81,7 +81,7 @@ west #
 "old-west" #5: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "old-west" #5: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "old-west" #5: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'CN=old-west'; Child SA #6 {ESP <0xESPESP} [192.0.1.0/32===192.0.2.0/24]
-"old-west" #5: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"old-west" #5: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "old-west" #5: initiator established IKE SA; authenticated peer certificate 'CN=east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'CN=west-ca'
 "old-west" #6: received INTERNAL_IP4_ADDRESS 192.0.1.0
 "old-west" #6: initiator established Child SA using #5; IPsec tunnel [192.0.1.0/32===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
@@ -97,7 +97,7 @@ west #
 "new-west" #7: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "new-west" #7: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "new-west" #7: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'CN=new-west'; Child SA #8 {ESP <0xESPESP} [192.0.1.0/32===192.0.2.0/24]
-"new-west" #7: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr}
+"new-west" #7: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,CP,SA,TSi,TSr} reassembled from N fragments
 "new-west" #7: initiator established IKE SA; authenticated peer certificate 'CN=east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'CN=west-ca'
 "new-west" #8: received INTERNAL_IP4_ADDRESS 192.0.1.0
 "new-west" #8: initiator established Child SA using #7; IPsec tunnel [192.0.1.0/32===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}

--- a/testing/pluto/nss-cert-11-ca-expiring-responder-switch-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-11-ca-expiring-responder-switch-ikev2/west.console.txt
@@ -47,7 +47,7 @@ west #
 "old-west" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "old-west" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "old-west" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'CN=old-west'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"old-west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"old-west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "old-west" #1: initiator established IKE SA; authenticated peer certificate 'CN=east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'CN=west-ca'
 "old-west" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #
@@ -62,7 +62,7 @@ west #
 "new-west" #3: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "new-west" #3: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "new-west" #3: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'CN=new-west'; Child SA #4 {ESP <0xESPESP} [192.0.2.0/24===192.0.2.0/24]
-"new-west" #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"new-west" #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "new-west" #3: initiator established IKE SA; authenticated peer certificate 'CN=east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'CN=west-ca'
 "new-west" #4: initiator established Child SA using #3; IPsec tunnel [192.0.2.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #
@@ -77,7 +77,7 @@ west #
 "old-west" #5: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "old-west" #5: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "old-west" #5: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'CN=old-west'; Child SA #6 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"old-west" #5: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"old-west" #5: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "old-west" #5: initiator established IKE SA; authenticated peer certificate 'CN=east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'CN=west-ca'
 "old-west" #6: initiator established Child SA using #5; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #
@@ -92,7 +92,7 @@ west #
 "new-west" #7: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "new-west" #7: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "new-west" #7: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'CN=new-west'; Child SA #8 {ESP <0xESPESP} [192.0.2.0/24===192.0.2.0/24]
-"new-west" #7: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"new-west" #7: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "new-west" #7: initiator established IKE SA; authenticated peer certificate 'CN=east' and 2nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'CN=west-ca'
 "new-west" #8: initiator established Child SA using #7; IPsec tunnel [192.0.2.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/nss-cert-chain-01-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-chain-01-ikev2/west.console.txt
@@ -55,7 +55,7 @@ west #
 "nss-cert-chain" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "nss-cert-chain" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "nss-cert-chain" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west_chain_endcert.testing.libreswan.org, E=west_chain_endcert@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.254/32===192.0.2.254/32]
-"nss-cert-chain" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,CERT,CERT,AUTH,SA,TSi,TSr}
+"nss-cert-chain" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,CERT,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "nss-cert-chain" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east_chain_endcert.testing.libreswan.org, E=east_chain_endcert@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east_chain_int_2.testing.libreswan.org, E=east_chain_int_2@testing.libreswan.org'
 "nss-cert-chain" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.254/32===192.0.2.254/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/nss-cert-chain-03-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-chain-03-ikev2/west.console.txt
@@ -70,7 +70,7 @@ west #
 "nss-cert-chain" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "nss-cert-chain" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "nss-cert-chain" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west_chain_endcert.testing.libreswan.org, E=west_chain_endcert@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.254/32===192.0.2.254/32]
-"nss-cert-chain" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,CERT,AUTH,SA,TSi,TSr}
+"nss-cert-chain" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "nss-cert-chain" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east_chain_endcert.testing.libreswan.org, E=east_chain_endcert@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east_chain_int_2.testing.libreswan.org, E=east_chain_int_2@testing.libreswan.org'
 "nss-cert-chain" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.254/32===192.0.2.254/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/nss-cert-chain-04-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-chain-04-ikev2/west.console.txt
@@ -73,7 +73,7 @@ west #
 "road-chain-B" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "road-chain-B" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "road-chain-B" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and FQDN '@west_chain_endcert.testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.254/32===192.0.2.254/32]
-"road-chain-B" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"road-chain-B" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "road-chain-B" #1: initiator established IKE SA; authenticated peer certificate '@east.testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "road-chain-B" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.254/32===192.0.2.254/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/nss-cert-ocsp-01-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-01-ikev2/west.console.txt
@@ -51,7 +51,7 @@ west #
 "nss-cert-ocsp" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "nss-cert-ocsp" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "nss-cert-ocsp" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.254/32===192.0.2.254/32]
-"nss-cert-ocsp" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"nss-cert-ocsp" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "nss-cert-ocsp" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "nss-cert-ocsp" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.254/32===192.0.2.254/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/nss-cert-ocsp-03-bogus-uri-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-03-bogus-uri-ikev2/west.console.txt
@@ -51,7 +51,7 @@ west #
 "nss-cert-ocsp" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "nss-cert-ocsp" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "nss-cert-ocsp" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.254/32===192.0.2.254/32]
-"nss-cert-ocsp" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"nss-cert-ocsp" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "nss-cert-ocsp" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "nss-cert-ocsp" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.254/32===192.0.2.254/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/nss-cert-ocsp-05-no-trust-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-05-no-trust-ikev2/west.console.txt
@@ -51,7 +51,7 @@ west #
 "nss-cert-ocsp" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "nss-cert-ocsp" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "nss-cert-ocsp" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.254/32===192.0.2.254/32]
-"nss-cert-ocsp" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"nss-cert-ocsp" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "nss-cert-ocsp" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "nss-cert-ocsp" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.254/32===192.0.2.254/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/perf-debug-ikev2-x509-gdb/west.console.txt
+++ b/testing/pluto/perf-debug-ikev2-x509-gdb/west.console.txt
@@ -33,7 +33,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/perf-debug-ikev2-x509-nss/west.console.txt
+++ b/testing/pluto/perf-debug-ikev2-x509-nss/west.console.txt
@@ -58,7 +58,7 @@ west #
 "ikev2-westnet-eastnet-x509-cr" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "ikev2-westnet-eastnet-x509-cr" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "ikev2-westnet-eastnet-x509-cr" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"ikev2-westnet-eastnet-x509-cr" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"ikev2-westnet-eastnet-x509-cr" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "ikev2-westnet-eastnet-x509-cr" #1: initiator established IKE SA; authenticated peer RSASSA-PSS with SHA2_512
 "ikev2-westnet-eastnet-x509-cr" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #
@@ -81,7 +81,7 @@ west #
 "ikev2-westnet-eastnet-x509-cr" #3: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "ikev2-westnet-eastnet-x509-cr" #3: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "ikev2-westnet-eastnet-x509-cr" #3: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #4 {ESP <0xESPESP}
-"ikev2-westnet-eastnet-x509-cr" #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"ikev2-westnet-eastnet-x509-cr" #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "ikev2-westnet-eastnet-x509-cr" #3: initiator established IKE SA; authenticated peer RSASSA-PSS with SHA2_512
 "ikev2-westnet-eastnet-x509-cr" #4: initiator established Child SA using #3; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #
@@ -95,7 +95,7 @@ west #
 "ikev2-westnet-eastnet-x509-cr" #5: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "ikev2-westnet-eastnet-x509-cr" #5: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "ikev2-westnet-eastnet-x509-cr" #5: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #6 {ESP <0xESPESP}
-"ikev2-westnet-eastnet-x509-cr" #5: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"ikev2-westnet-eastnet-x509-cr" #5: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "ikev2-westnet-eastnet-x509-cr" #5: initiator established IKE SA; authenticated peer RSASSA-PSS with SHA2_512
 "ikev2-westnet-eastnet-x509-cr" #6: initiator established Child SA using #5; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #
@@ -109,7 +109,7 @@ west #
 "ikev2-westnet-eastnet-x509-cr" #7: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "ikev2-westnet-eastnet-x509-cr" #7: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "ikev2-westnet-eastnet-x509-cr" #7: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #8 {ESP <0xESPESP}
-"ikev2-westnet-eastnet-x509-cr" #7: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"ikev2-westnet-eastnet-x509-cr" #7: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "ikev2-westnet-eastnet-x509-cr" #7: initiator established IKE SA; authenticated peer RSASSA-PSS with SHA2_512
 "ikev2-westnet-eastnet-x509-cr" #8: initiator established Child SA using #7; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #
@@ -123,7 +123,7 @@ west #
 "ikev2-westnet-eastnet-x509-cr" #9: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "ikev2-westnet-eastnet-x509-cr" #9: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "ikev2-westnet-eastnet-x509-cr" #9: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #10 {ESP <0xESPESP}
-"ikev2-westnet-eastnet-x509-cr" #9: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"ikev2-westnet-eastnet-x509-cr" #9: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "ikev2-westnet-eastnet-x509-cr" #9: initiator established IKE SA; authenticated peer RSASSA-PSS with SHA2_512
 "ikev2-westnet-eastnet-x509-cr" #10: initiator established Child SA using #9; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #
@@ -137,7 +137,7 @@ west #
 "ikev2-westnet-eastnet-x509-cr" #11: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "ikev2-westnet-eastnet-x509-cr" #11: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "ikev2-westnet-eastnet-x509-cr" #11: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"ikev2-westnet-eastnet-x509-cr" #11: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"ikev2-westnet-eastnet-x509-cr" #11: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "ikev2-westnet-eastnet-x509-cr" #11: initiator established IKE SA; authenticated peer RSASSA-PSS with SHA2_512
 "ikev2-westnet-eastnet-x509-cr" #12: initiator established Child SA using #11; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/perf-oncpu-ikev2-x509-callgrind/west.console.txt
+++ b/testing/pluto/perf-oncpu-ikev2-x509-callgrind/west.console.txt
@@ -33,7 +33,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/pfkeyv2-transport-4in4-ah-ikev2/west.console.txt
+++ b/testing/pluto/pfkeyv2-transport-4in4-ah-ikev2/west.console.txt
@@ -19,7 +19,7 @@ west #
 "eastnet-westnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "eastnet-westnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA1_96 prf=HMAC_SHA1 group=DH19}, initiating IKE_AUTH
 "eastnet-westnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "eastnet-westnet-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "eastnet-westnet-ikev2" #2: initiator established Child SA using #1; IPsec transport [192.1.2.45/32===192.1.2.23/32] {AH=>0xAHAH <0xAHAH xfrm=HMAC_SHA1_96 DPD=passive}
 west #

--- a/testing/pluto/pfkeyv2-transport-4in4-ah-ipcomp-ikev2/west.console.txt
+++ b/testing/pluto/pfkeyv2-transport-4in4-ah-ipcomp-ikev2/west.console.txt
@@ -19,7 +19,7 @@ west #
 "eastnet-westnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "eastnet-westnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA1_96 prf=HMAC_SHA1 group=DH19}, initiating IKE_AUTH
 "eastnet-westnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "eastnet-westnet-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "eastnet-westnet-ikev2" #2: initiator established Child SA using #1; IPsec transport [192.1.2.45/32===192.1.2.23/32] {AH=>0xAHAH <0xAHAH xfrm=HMAC_SHA1_96 IPCOMP=>0xCPI <0xCPI DPD=passive}
 west #

--- a/testing/pluto/pfkeyv2-transport-4in4-esp-ikev2/west.console.txt
+++ b/testing/pluto/pfkeyv2-transport-4in4-esp-ikev2/west.console.txt
@@ -19,7 +19,7 @@ west #
 "eastnet-westnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "eastnet-westnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA1_96 prf=HMAC_SHA1 group=DH19}, initiating IKE_AUTH
 "eastnet-westnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "eastnet-westnet-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "eastnet-westnet-ikev2" #2: initiator established Child SA using #1; IPsec transport [192.1.2.45/32===192.1.2.23/32] {ESP=>0xESPESP <0xESPESP xfrm=AES_CBC_128-HMAC_SHA1_96 DPD=passive}
 west #

--- a/testing/pluto/pfkeyv2-transport-4in4-esp-ipcomp-ikev2/west.console.txt
+++ b/testing/pluto/pfkeyv2-transport-4in4-esp-ipcomp-ikev2/west.console.txt
@@ -19,7 +19,7 @@ west #
 "eastnet-westnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "eastnet-westnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA1_96 prf=HMAC_SHA1 group=DH19}, initiating IKE_AUTH
 "eastnet-westnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "eastnet-westnet-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "eastnet-westnet-ikev2" #2: initiator established Child SA using #1; IPsec transport [192.1.2.45/32===192.1.2.23/32] {ESP=>0xESPESP <0xESPESP xfrm=AES_CBC_128-HMAC_SHA1_96 IPCOMP=>0xCPI <0xCPI DPD=passive}
 west #

--- a/testing/pluto/pfkeyv2-transport-6in6-ah-ikev2/west.console.txt
+++ b/testing/pluto/pfkeyv2-transport-6in6-ah-ikev2/west.console.txt
@@ -19,7 +19,7 @@ west #
 "eastnet-westnet-ikev2" #1: sent IKE_SA_INIT request to [2001:db8:1:2::23]:UDP/500
 "eastnet-westnet-ikev2" #1: processed IKE_SA_INIT response from [2001:db8:1:2::23]:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA1_96 prf=HMAC_SHA1 group=DH19}, initiating IKE_AUTH
 "eastnet-westnet-ikev2" #1: sent IKE_AUTH request to [2001:db8:1:2::23]:UDP/500; Child SA #2 {ESP <0xESPESP}
-"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "eastnet-westnet-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "eastnet-westnet-ikev2" #2: initiator established Child SA using #1; IPsec transport [2001:db8:1:2::45-2001:db8:1:2::45:0-65535 0===2001:db8:1:2::23/128] {AH=>0xAHAH <0xAHAH xfrm=HMAC_SHA1_96 DPD=passive}
 west #

--- a/testing/pluto/pfkeyv2-transport-6in6-ah-ipcomp-ikev2/west.console.txt
+++ b/testing/pluto/pfkeyv2-transport-6in6-ah-ipcomp-ikev2/west.console.txt
@@ -19,7 +19,7 @@ west #
 "eastnet-westnet-ikev2" #1: sent IKE_SA_INIT request to [2001:db8:1:2::23]:UDP/500
 "eastnet-westnet-ikev2" #1: processed IKE_SA_INIT response from [2001:db8:1:2::23]:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA1_96 prf=HMAC_SHA1 group=DH19}, initiating IKE_AUTH
 "eastnet-westnet-ikev2" #1: sent IKE_AUTH request to [2001:db8:1:2::23]:UDP/500; Child SA #2 {ESP <0xESPESP}
-"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "eastnet-westnet-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "eastnet-westnet-ikev2" #2: initiator established Child SA using #1; IPsec transport [2001:db8:1:2::45-2001:db8:1:2::45:0-65535 0===2001:db8:1:2::23/128] {AH=>0xAHAH <0xAHAH xfrm=HMAC_SHA1_96 IPCOMP=>0xCPI <0xCPI DPD=passive}
 west #

--- a/testing/pluto/pfkeyv2-transport-6in6-esp-ikev2/west.console.txt
+++ b/testing/pluto/pfkeyv2-transport-6in6-esp-ikev2/west.console.txt
@@ -19,7 +19,7 @@ west #
 "eastnet-westnet-ikev2" #1: sent IKE_SA_INIT request to [2001:db8:1:2::23]:UDP/500
 "eastnet-westnet-ikev2" #1: processed IKE_SA_INIT response from [2001:db8:1:2::23]:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA1_96 prf=HMAC_SHA1 group=DH19}, initiating IKE_AUTH
 "eastnet-westnet-ikev2" #1: sent IKE_AUTH request to [2001:db8:1:2::23]:UDP/500; Child SA #2 {ESP <0xESPESP}
-"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "eastnet-westnet-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "eastnet-westnet-ikev2" #2: initiator established Child SA using #1; IPsec transport [2001:db8:1:2::45-2001:db8:1:2::45:0-65535 0===2001:db8:1:2::23/128] {ESP=>0xESPESP <0xESPESP xfrm=AES_CBC_128-HMAC_SHA1_96 DPD=passive}
 west #

--- a/testing/pluto/pfkeyv2-transport-6in6-esp-ipcomp-ikev2/west.console.txt
+++ b/testing/pluto/pfkeyv2-transport-6in6-esp-ipcomp-ikev2/west.console.txt
@@ -19,7 +19,7 @@ west #
 "eastnet-westnet-ikev2" #1: sent IKE_SA_INIT request to [2001:db8:1:2::23]:UDP/500
 "eastnet-westnet-ikev2" #1: processed IKE_SA_INIT response from [2001:db8:1:2::23]:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA1_96 prf=HMAC_SHA1 group=DH19}, initiating IKE_AUTH
 "eastnet-westnet-ikev2" #1: sent IKE_AUTH request to [2001:db8:1:2::23]:UDP/500; Child SA #2 {ESP <0xESPESP}
-"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "eastnet-westnet-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "eastnet-westnet-ikev2" #2: initiator established Child SA using #1; IPsec transport [2001:db8:1:2::45-2001:db8:1:2::45:0-65535 0===2001:db8:1:2::23/128] {ESP=>0xESPESP <0xESPESP xfrm=AES_CBC_128-HMAC_SHA1_96 IPCOMP=>0xCPI <0xCPI DPD=passive}
 west #

--- a/testing/pluto/pfkeyv2-tunnel-4in4-ah-ikev2/west.console.txt
+++ b/testing/pluto/pfkeyv2-tunnel-4in4-ah-ikev2/west.console.txt
@@ -22,7 +22,7 @@ west #
 "eastnet-westnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "eastnet-westnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA1_96 prf=HMAC_SHA1 group=DH19}, initiating IKE_AUTH
 "eastnet-westnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "eastnet-westnet-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "eastnet-westnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {AH=>0xAHAH <0xAHAH xfrm=HMAC_SHA1_96 DPD=passive}
 west #

--- a/testing/pluto/pfkeyv2-tunnel-4in4-ah-ipcomp-ikev2/west.console.txt
+++ b/testing/pluto/pfkeyv2-tunnel-4in4-ah-ipcomp-ikev2/west.console.txt
@@ -22,7 +22,7 @@ west #
 "eastnet-westnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "eastnet-westnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA1_96 prf=HMAC_SHA1 group=DH19}, initiating IKE_AUTH
 "eastnet-westnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "eastnet-westnet-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "eastnet-westnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {AH=>0xAHAH <0xAHAH xfrm=HMAC_SHA1_96 IPCOMP=>0xCPI <0xCPI DPD=passive}
 west #

--- a/testing/pluto/pfkeyv2-tunnel-4in4-esp-ikev2/west.console.txt
+++ b/testing/pluto/pfkeyv2-tunnel-4in4-esp-ikev2/west.console.txt
@@ -22,7 +22,7 @@ west #
 "eastnet-westnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "eastnet-westnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA1_96 prf=HMAC_SHA1 group=DH19}, initiating IKE_AUTH
 "eastnet-westnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "eastnet-westnet-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "eastnet-westnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP=>0xESPESP <0xESPESP xfrm=AES_CBC_128-HMAC_SHA1_96 DPD=passive}
 west #

--- a/testing/pluto/pfkeyv2-tunnel-4in4-esp-ipcomp-ikev2/west.console.txt
+++ b/testing/pluto/pfkeyv2-tunnel-4in4-esp-ipcomp-ikev2/west.console.txt
@@ -22,7 +22,7 @@ west #
 "eastnet-westnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "eastnet-westnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA1_96 prf=HMAC_SHA1 group=DH19}, initiating IKE_AUTH
 "eastnet-westnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "eastnet-westnet-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "eastnet-westnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP=>0xESPESP <0xESPESP xfrm=AES_CBC_128-HMAC_SHA1_96 IPCOMP=>0xCPI <0xCPI DPD=passive}
 west #

--- a/testing/pluto/pfkeyv2-tunnel-4in6-ah-ikev2/west.console.txt
+++ b/testing/pluto/pfkeyv2-tunnel-4in6-ah-ikev2/west.console.txt
@@ -24,7 +24,7 @@ west #
 "eastnet-westnet-ikev2" #1: sent IKE_SA_INIT request to [2001:db8:1:2::23]:UDP/500
 "eastnet-westnet-ikev2" #1: processed IKE_SA_INIT response from [2001:db8:1:2::23]:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA1_96 prf=HMAC_SHA1 group=DH19}, initiating IKE_AUTH
 "eastnet-westnet-ikev2" #1: sent IKE_AUTH request to [2001:db8:1:2::23]:UDP/500; Child SA #2 {ESP <0xESPESP}
-"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "eastnet-westnet-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "eastnet-westnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {AH=>0xAHAH <0xAHAH xfrm=HMAC_SHA1_96 DPD=passive}
 west #

--- a/testing/pluto/pfkeyv2-tunnel-4in6-ah-ipcomp-ikev2/west.console.txt
+++ b/testing/pluto/pfkeyv2-tunnel-4in6-ah-ipcomp-ikev2/west.console.txt
@@ -24,7 +24,7 @@ west #
 "eastnet-westnet-ikev2" #1: sent IKE_SA_INIT request to [2001:db8:1:2::23]:UDP/500
 "eastnet-westnet-ikev2" #1: processed IKE_SA_INIT response from [2001:db8:1:2::23]:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA1_96 prf=HMAC_SHA1 group=DH19}, initiating IKE_AUTH
 "eastnet-westnet-ikev2" #1: sent IKE_AUTH request to [2001:db8:1:2::23]:UDP/500; Child SA #2 {ESP <0xESPESP}
-"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "eastnet-westnet-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "eastnet-westnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {AH=>0xAHAH <0xAHAH xfrm=HMAC_SHA1_96 IPCOMP=>0xCPI <0xCPI DPD=passive}
 west #

--- a/testing/pluto/pfkeyv2-tunnel-4in6-esp-ikev2/west.console.txt
+++ b/testing/pluto/pfkeyv2-tunnel-4in6-esp-ikev2/west.console.txt
@@ -24,7 +24,7 @@ west #
 "eastnet-westnet-ikev2" #1: sent IKE_SA_INIT request to [2001:db8:1:2::23]:UDP/500
 "eastnet-westnet-ikev2" #1: processed IKE_SA_INIT response from [2001:db8:1:2::23]:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA1_96 prf=HMAC_SHA1 group=DH19}, initiating IKE_AUTH
 "eastnet-westnet-ikev2" #1: sent IKE_AUTH request to [2001:db8:1:2::23]:UDP/500; Child SA #2 {ESP <0xESPESP}
-"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "eastnet-westnet-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "eastnet-westnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP=>0xESPESP <0xESPESP xfrm=AES_CBC_128-HMAC_SHA1_96 DPD=passive}
 west #

--- a/testing/pluto/pfkeyv2-tunnel-4in6-esp-ipcomp-ikev2/west.console.txt
+++ b/testing/pluto/pfkeyv2-tunnel-4in6-esp-ipcomp-ikev2/west.console.txt
@@ -24,7 +24,7 @@ west #
 "eastnet-westnet-ikev2" #1: sent IKE_SA_INIT request to [2001:db8:1:2::23]:UDP/500
 "eastnet-westnet-ikev2" #1: processed IKE_SA_INIT response from [2001:db8:1:2::23]:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA1_96 prf=HMAC_SHA1 group=DH19}, initiating IKE_AUTH
 "eastnet-westnet-ikev2" #1: sent IKE_AUTH request to [2001:db8:1:2::23]:UDP/500; Child SA #2 {ESP <0xESPESP}
-"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "eastnet-westnet-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "eastnet-westnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP=>0xESPESP <0xESPESP xfrm=AES_CBC_128-HMAC_SHA1_96 IPCOMP=>0xCPI <0xCPI DPD=passive}
 west #

--- a/testing/pluto/pfkeyv2-tunnel-6in4-ah-ikev2/west.console.txt
+++ b/testing/pluto/pfkeyv2-tunnel-6in4-ah-ikev2/west.console.txt
@@ -24,7 +24,7 @@ west #
 "eastnet-westnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "eastnet-westnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA1_96 prf=HMAC_SHA1 group=DH19}, initiating IKE_AUTH
 "eastnet-westnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "eastnet-westnet-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "eastnet-westnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [2001:db8:0:1::/64===2001:db8:0:2::/64] {AH=>0xAHAH <0xAHAH xfrm=HMAC_SHA1_96 DPD=passive}
 west #

--- a/testing/pluto/pfkeyv2-tunnel-6in4-ah-ipcomp-ikev2/west.console.txt
+++ b/testing/pluto/pfkeyv2-tunnel-6in4-ah-ipcomp-ikev2/west.console.txt
@@ -24,7 +24,7 @@ west #
 "eastnet-westnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "eastnet-westnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA1_96 prf=HMAC_SHA1 group=DH19}, initiating IKE_AUTH
 "eastnet-westnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "eastnet-westnet-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "eastnet-westnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [2001:db8:0:1::/64===2001:db8:0:2::/64] {AH=>0xAHAH <0xAHAH xfrm=HMAC_SHA1_96 IPCOMP=>0xCPI <0xCPI DPD=passive}
 west #

--- a/testing/pluto/pfkeyv2-tunnel-6in4-esp-ikev2/west.console.txt
+++ b/testing/pluto/pfkeyv2-tunnel-6in4-esp-ikev2/west.console.txt
@@ -24,7 +24,7 @@ west #
 "eastnet-westnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "eastnet-westnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA1_96 prf=HMAC_SHA1 group=DH19}, initiating IKE_AUTH
 "eastnet-westnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "eastnet-westnet-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "eastnet-westnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [2001:db8:0:1::/64===2001:db8:0:2::/64] {ESP=>0xESPESP <0xESPESP xfrm=AES_CBC_128-HMAC_SHA1_96 DPD=passive}
 west #

--- a/testing/pluto/pfkeyv2-tunnel-6in4-esp-ipcomp-ikev2/west.console.txt
+++ b/testing/pluto/pfkeyv2-tunnel-6in4-esp-ipcomp-ikev2/west.console.txt
@@ -24,7 +24,7 @@ west #
 "eastnet-westnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "eastnet-westnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA1_96 prf=HMAC_SHA1 group=DH19}, initiating IKE_AUTH
 "eastnet-westnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500; Child SA #2 {ESP <0xESPESP}
-"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "eastnet-westnet-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "eastnet-westnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [2001:db8:0:1::/64===2001:db8:0:2::/64] {ESP=>0xESPESP <0xESPESP xfrm=AES_CBC_128-HMAC_SHA1_96 IPCOMP=>0xCPI <0xCPI DPD=passive}
 west #

--- a/testing/pluto/pfkeyv2-tunnel-6in6-ah-ikev2/west.console.txt
+++ b/testing/pluto/pfkeyv2-tunnel-6in6-ah-ikev2/west.console.txt
@@ -22,7 +22,7 @@ west #
 "eastnet-westnet-ikev2" #1: sent IKE_SA_INIT request to [2001:db8:1:2::23]:UDP/500
 "eastnet-westnet-ikev2" #1: processed IKE_SA_INIT response from [2001:db8:1:2::23]:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA1_96 prf=HMAC_SHA1 group=DH19}, initiating IKE_AUTH
 "eastnet-westnet-ikev2" #1: sent IKE_AUTH request to [2001:db8:1:2::23]:UDP/500; Child SA #2 {ESP <0xESPESP}
-"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "eastnet-westnet-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "eastnet-westnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [2001:db8:0:1::/64===2001:db8:0:2::/64] {AH=>0xAHAH <0xAHAH xfrm=HMAC_SHA1_96 DPD=passive}
 west #

--- a/testing/pluto/pfkeyv2-tunnel-6in6-ah-ipcomp-ikev2/west.console.txt
+++ b/testing/pluto/pfkeyv2-tunnel-6in6-ah-ipcomp-ikev2/west.console.txt
@@ -22,7 +22,7 @@ west #
 "eastnet-westnet-ikev2" #1: sent IKE_SA_INIT request to [2001:db8:1:2::23]:UDP/500
 "eastnet-westnet-ikev2" #1: processed IKE_SA_INIT response from [2001:db8:1:2::23]:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA1_96 prf=HMAC_SHA1 group=DH19}, initiating IKE_AUTH
 "eastnet-westnet-ikev2" #1: sent IKE_AUTH request to [2001:db8:1:2::23]:UDP/500; Child SA #2 {ESP <0xESPESP}
-"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "eastnet-westnet-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "eastnet-westnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [2001:db8:0:1::/64===2001:db8:0:2::/64] {AH=>0xAHAH <0xAHAH xfrm=HMAC_SHA1_96 IPCOMP=>0xCPI <0xCPI DPD=passive}
 west #

--- a/testing/pluto/pfkeyv2-tunnel-6in6-esp-ikev2/west.console.txt
+++ b/testing/pluto/pfkeyv2-tunnel-6in6-esp-ikev2/west.console.txt
@@ -22,7 +22,7 @@ west #
 "eastnet-westnet-ikev2" #1: sent IKE_SA_INIT request to [2001:db8:1:2::23]:UDP/500
 "eastnet-westnet-ikev2" #1: processed IKE_SA_INIT response from [2001:db8:1:2::23]:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA1_96 prf=HMAC_SHA1 group=DH19}, initiating IKE_AUTH
 "eastnet-westnet-ikev2" #1: sent IKE_AUTH request to [2001:db8:1:2::23]:UDP/500; Child SA #2 {ESP <0xESPESP}
-"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "eastnet-westnet-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "eastnet-westnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [2001:db8:0:1::/64===2001:db8:0:2::/64] {ESP=>0xESPESP <0xESPESP xfrm=AES_CBC_128-HMAC_SHA1_96 DPD=passive}
 west #

--- a/testing/pluto/pfkeyv2-tunnel-6in6-esp-ipcomp-ikev2/west.console.txt
+++ b/testing/pluto/pfkeyv2-tunnel-6in6-esp-ipcomp-ikev2/west.console.txt
@@ -22,7 +22,7 @@ west #
 "eastnet-westnet-ikev2" #1: sent IKE_SA_INIT request to [2001:db8:1:2::23]:UDP/500
 "eastnet-westnet-ikev2" #1: processed IKE_SA_INIT response from [2001:db8:1:2::23]:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA1_96 prf=HMAC_SHA1 group=DH19}, initiating IKE_AUTH
 "eastnet-westnet-ikev2" #1: sent IKE_AUTH request to [2001:db8:1:2::23]:UDP/500; Child SA #2 {ESP <0xESPESP}
-"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"eastnet-westnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "eastnet-westnet-ikev2" #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "eastnet-westnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [2001:db8:0:1::/64===2001:db8:0:2::/64] {ESP=>0xESPESP <0xESPESP xfrm=AES_CBC_128-HMAC_SHA1_96 IPCOMP=>0xCPI <0xCPI DPD=passive}
 west #

--- a/testing/pluto/seccomp-03-updown/road.console.txt
+++ b/testing/pluto/seccomp-03-updown/road.console.txt
@@ -26,7 +26,7 @@ road #
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/4500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: sent IKE_AUTH request to 192.1.2.23:UDP/4500 with shared-key-mac and FQDN '@road'; Child SA #2 {ESPinUDP <0xESPESP}
-"westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #1: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #2: received INTERNAL_IP4_ADDRESS 100.64.0.1
 "westnet-eastnet-ipv4-psk-ikev2"[1] 192.1.2.23 #2: received INTERNAL_IP4_DNS server address 1.2.3.4

--- a/testing/pluto/whack-hostkey-05-ikev2-rawkey-rsa/west.console.txt
+++ b/testing/pluto/whack-hostkey-05-ikev2-rawkey-rsa/west.console.txt
@@ -55,7 +55,7 @@ west #
 "hostkey" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "hostkey" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "hostkey" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and IPV4_ADDR '192.1.2.45'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"hostkey" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"hostkey" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "hostkey" #1: initiator established IKE SA; authenticated peer using preloaded certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature
 "hostkey" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/whack-hostkey-06-ikev2-pubkey-rsa/west.console.txt
+++ b/testing/pluto/whack-hostkey-06-ikev2-pubkey-rsa/west.console.txt
@@ -55,7 +55,7 @@ west #
 "hostkey" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "hostkey" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "hostkey" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and IPV4_ADDR '192.1.2.45'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"hostkey" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"hostkey" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "hostkey" #1: initiator established IKE SA; authenticated peer using preloaded certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature
 "hostkey" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/whack-hostkey-07-ikev2-ckaid-pubkey-rsa/west.console.txt
+++ b/testing/pluto/whack-hostkey-07-ikev2-ckaid-pubkey-rsa/west.console.txt
@@ -56,7 +56,7 @@ west #
 "hostkey" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "hostkey" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "hostkey" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and IPV4_ADDR '192.1.2.45'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"hostkey" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"hostkey" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr} reassembled from N fragments
 "hostkey" #1: initiator established IKE SA; authenticated peer using preloaded certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature
 "hostkey" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/whack-rereadcerts-01/west.console.txt
+++ b/testing/pluto/whack-rereadcerts-01/west.console.txt
@@ -59,7 +59,7 @@ west #
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"westnet-eastnet-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "westnet-eastnet-ikev2" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "westnet-eastnet-ikev2" #2: initiator established Child SA using #1; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 west #

--- a/testing/pluto/x509-cert-08-expired-responder-ikev2/west.console.txt
+++ b/testing/pluto/x509-cert-08-expired-responder-ikev2/west.console.txt
@@ -33,7 +33,7 @@ west #
 "west" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.254/32===192.0.2.254/32]
-"west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"west" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west" #1: NSS: ERROR: IPsec certificate CN=east-expired invalid: SEC_ERROR_EXPIRED_CERTIFICATE: Peer's Certificate has expired.
 "west" #1: X509: certificate payload rejected for this connection
 "west" #1: encountered fatal error in state IKE_AUTH_I

--- a/testing/pluto/x509-cert-09-notyetvalid-responder-ikev2/west.console.txt
+++ b/testing/pluto/x509-cert-09-notyetvalid-responder-ikev2/west.console.txt
@@ -31,7 +31,7 @@ west #
 "nss-cert" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "nss-cert" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "nss-cert" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.254/32===192.0.2.254/32]
-"nss-cert" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"nss-cert" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "nss-cert" #1: NSS: ERROR: IPsec certificate CN=east-notyetvalid invalid: SEC_ERROR_EXPIRED_CERTIFICATE: Peer's Certificate has expired.
 "nss-cert" #1: X509: certificate payload rejected for this connection
 "nss-cert" #1: encountered fatal error in state IKE_AUTH_I

--- a/testing/pluto/x509-crl-01-revoked-responder-ikev2/west.console.txt
+++ b/testing/pluto/x509-crl-01-revoked-responder-ikev2/west.console.txt
@@ -40,7 +40,7 @@ west #
 "nss-cert-crl" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "nss-cert-crl" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "nss-cert-crl" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.254/32===192.0.2.254/32]
-"nss-cert-crl" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"nss-cert-crl" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "nss-cert-crl" #1: NSS: ERROR: IPsec certificate E=testing@libreswan.org,CN=Libreswan test CA for mainca,OU=Test Department,O=Libreswan,L=Toronto,ST=Ontario,C=CA invalid: SEC_ERROR_REVOKED_CERTIFICATE: Peer's Certificate has been revoked.
 "nss-cert-crl" #1: X509: certificate payload rejected for this connection
 "nss-cert-crl" #1: encountered fatal error in state IKE_AUTH_I

--- a/testing/pluto/x509-crl-02-old-crl-strict-no-ikev2/west.console.txt
+++ b/testing/pluto/x509-crl-02-old-crl-strict-no-ikev2/west.console.txt
@@ -50,7 +50,7 @@ west #
 "nss-cert-crl" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "nss-cert-crl" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "nss-cert-crl" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.254/32===192.0.2.254/32]
-"nss-cert-crl" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"nss-cert-crl" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "nss-cert-crl" #1: NSS: ERROR: IPsec certificate E=testing@libreswan.org,CN=Libreswan test CA for mainca,OU=Test Department,O=Libreswan,L=Toronto,ST=Ontario,C=CA invalid: SEC_ERROR_REVOKED_CERTIFICATE: Peer's Certificate has been revoked.
 "nss-cert-crl" #1: X509: certificate payload rejected for this connection
 "nss-cert-crl" #1: encountered fatal error in state IKE_AUTH_I
@@ -92,7 +92,7 @@ IMPAIR: "nss-cert-crl": dispatch REVIVAL; attempt 1 next in 5s; delete Child SA
 "nss-cert-crl" #3: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "nss-cert-crl" #3: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "nss-cert-crl" #3: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #4 {ESP <0xESPESP} [192.0.1.254/32===192.0.2.254/32]
-"nss-cert-crl" #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"nss-cert-crl" #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "nss-cert-crl" #3: NSS: ERROR: IPsec certificate E=testing@libreswan.org,CN=Libreswan test CA for mainca,OU=Test Department,O=Libreswan,L=Toronto,ST=Ontario,C=CA invalid: SEC_ERROR_REVOKED_CERTIFICATE: Peer's Certificate has been revoked.
 "nss-cert-crl" #3: X509: certificate payload rejected for this connection
 "nss-cert-crl" #3: encountered fatal error in state IKE_AUTH_I

--- a/testing/pluto/x509-crl-02-old-crl-strict-yes-ikev2-manual/west.console.txt
+++ b/testing/pluto/x509-crl-02-old-crl-strict-yes-ikev2-manual/west.console.txt
@@ -45,7 +45,7 @@ west #
 "nss-cert-crl" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "nss-cert-crl" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "nss-cert-crl" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.254/32===192.0.2.254/32]
-"nss-cert-crl" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"nss-cert-crl" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "nss-cert-crl" #1: certificate payload rejected; crl-strict=yes and Certificate Revocation List (CRL) is expired or missing
 warning: "nss-cert-crl" #1: automatic update of Certificate Revocation List (CRL) is disabled; see "crlcheckinterval="
 "nss-cert-crl" #1: X509: certificate payload rejected for this connection

--- a/testing/pluto/x509-crl-02-old-crl-strict-yes-ikev2/west.console.txt
+++ b/testing/pluto/x509-crl-02-old-crl-strict-yes-ikev2/west.console.txt
@@ -50,7 +50,7 @@ west #
 "nss-cert-crl" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "nss-cert-crl" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "nss-cert-crl" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.254/32===192.0.2.254/32]
-"nss-cert-crl" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"nss-cert-crl" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "nss-cert-crl" #1: certificate payload rejected; crl-strict=yes and Certificate Revocation List (CRL) is expired or missing, forcing CRL update
 IMPAIR: "nss-cert-crl" #1: not initiating FETCH_CRL
 "nss-cert-crl" #1: X509: certificate payload rejected for this connection
@@ -99,7 +99,7 @@ IMPAIR: "nss-cert-crl": dispatch REVIVAL; attempt 1 next in 5s; delete Child SA
 "nss-cert-crl" #3: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "nss-cert-crl" #3: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "nss-cert-crl" #3: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #4 {ESP <0xESPESP} [192.0.1.254/32===192.0.2.254/32]
-"nss-cert-crl" #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"nss-cert-crl" #3: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "nss-cert-crl" #3: NSS: ERROR: IPsec certificate E=testing@libreswan.org,CN=Libreswan test CA for mainca,OU=Test Department,O=Libreswan,L=Toronto,ST=Ontario,C=CA invalid: SEC_ERROR_REVOKED_CERTIFICATE: Peer's Certificate has been revoked.
 "nss-cert-crl" #3: X509: certificate payload rejected for this connection
 "nss-cert-crl" #3: encountered fatal error in state IKE_AUTH_I

--- a/testing/pluto/x509-ikev2-frag-01-ike-aes_gcm/road.console.txt
+++ b/testing/pluto/x509-ikev2-frag-01-ike-aes_gcm/road.console.txt
@@ -29,7 +29,7 @@ road #
 "x509" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "x509" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_256 group=DH19}, initiating IKE_AUTH
 "x509" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=key4096.testing.libreswan.org, E=user-key4096@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.3.209/32===192.1.2.23/32]
-"x509" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"x509" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "x509" #1: initiator established IKE SA; authenticated peer certificate 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "x509" #2: initiator established Child SA using #1; IPsec tunnel [192.1.3.209/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 road #

--- a/testing/pluto/x509-profile-01-key-usage/west.console.txt
+++ b/testing/pluto/x509-profile-01-key-usage/west.console.txt
@@ -58,7 +58,7 @@ Redirecting to: [initsystem]
 "west-ku-missing" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-ku-missing" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-ku-missing" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west-ku-missing.testing.libreswan.org, E=user-west-ku-missing@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"west-ku-missing" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"west-ku-missing" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-ku-missing" #1: initiator established IKE SA; authenticated peer certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "west-ku-missing" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
  ipsec stop
@@ -112,7 +112,7 @@ Redirecting to: [initsystem]
 "west-ku-digitalSignature" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-ku-digitalSignature" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-ku-digitalSignature" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west-ku-digitalSignature.testing.libreswan.org, E=user-west-ku-digitalSignature@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"west-ku-digitalSignature" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"west-ku-digitalSignature" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-ku-digitalSignature" #1: initiator established IKE SA; authenticated peer certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "west-ku-digitalSignature" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
  ipsec stop
@@ -166,7 +166,7 @@ Redirecting to: [initsystem]
 "west-ku-nonRepudiation" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-ku-nonRepudiation" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-ku-nonRepudiation" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west-ku-nonRepudiation.testing.libreswan.org, E=user-west-ku-nonRepudiation@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"west-ku-nonRepudiation" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"west-ku-nonRepudiation" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-ku-nonRepudiation" #1: initiator established IKE SA; authenticated peer certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "west-ku-nonRepudiation" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
  ipsec stop
@@ -277,7 +277,7 @@ Redirecting to: [initsystem]
 "west-ku-digitalSignature-certSigning" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-ku-digitalSignature-certSigning" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-ku-digitalSignature-certSigning" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west-ku-digitalSignature-certSigning.testing.libreswan.org, E=user-west-ku-digitalSignature-certSigning@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"west-ku-digitalSignature-certSigning" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"west-ku-digitalSignature-certSigning" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-ku-digitalSignature-certSigning" #1: initiator established IKE SA; authenticated peer certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "west-ku-digitalSignature-certSigning" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
  ipsec stop

--- a/testing/pluto/x509-profile-02-extended-key-usage/west.console.txt
+++ b/testing/pluto/x509-profile-02-extended-key-usage/west.console.txt
@@ -63,7 +63,7 @@ Redirecting to: [initsystem]
 "west-eku-missing" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-eku-missing" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-eku-missing" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west-eku-missing.testing.libreswan.org, E=user-west-eku-missing@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"west-eku-missing" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"west-eku-missing" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-eku-missing" #1: initiator established IKE SA; authenticated peer certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "west-eku-missing" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
  ipsec stop
@@ -119,7 +119,7 @@ Redirecting to: [initsystem]
 "west-eku-ipsecIKE" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-eku-ipsecIKE" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-eku-ipsecIKE" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west-eku-ipsecIKE.testing.libreswan.org, E=user-west-eku-ipsecIKE@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"west-eku-ipsecIKE" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"west-eku-ipsecIKE" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-eku-ipsecIKE" #1: initiator established IKE SA; authenticated peer certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "west-eku-ipsecIKE" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
  ipsec stop
@@ -175,7 +175,7 @@ Redirecting to: [initsystem]
 "west-eku-x509Any" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-eku-x509Any" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-eku-x509Any" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west-eku-x509Any.testing.libreswan.org, E=user-west-eku-x509Any@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"west-eku-x509Any" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"west-eku-x509Any" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-eku-x509Any" #1: initiator established IKE SA; authenticated peer certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "west-eku-x509Any" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
  ipsec stop
@@ -233,7 +233,7 @@ Redirecting to: [initsystem]
 "west-eku-serverAuth" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-eku-serverAuth" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-eku-serverAuth" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west-eku-serverAuth.testing.libreswan.org, E=user-west-eku-serverAuth@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"west-eku-serverAuth" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"west-eku-serverAuth" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-eku-serverAuth" #1: initiator established IKE SA; authenticated peer certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "west-eku-serverAuth" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
  ipsec stop
@@ -290,7 +290,7 @@ Redirecting to: [initsystem]
 "west-eku-serverAuth-ipsecIKE" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-eku-serverAuth-ipsecIKE" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-eku-serverAuth-ipsecIKE" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west-eku-serverAuth-ipsecIKE.testing.libreswan.org, E=user-west-eku-serverAuth-ipsecIKE@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"west-eku-serverAuth-ipsecIKE" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"west-eku-serverAuth-ipsecIKE" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-eku-serverAuth-ipsecIKE" #1: initiator established IKE SA; authenticated peer certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "west-eku-serverAuth-ipsecIKE" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
  ipsec stop
@@ -347,7 +347,7 @@ Redirecting to: [initsystem]
 "west-eku-serverAuth-critical" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-eku-serverAuth-critical" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-eku-serverAuth-critical" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west-eku-serverAuth-critical.testing.libreswan.org, E=user-west-eku-serverAuth-critical@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"west-eku-serverAuth-critical" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"west-eku-serverAuth-critical" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-eku-serverAuth-critical" #1: initiator established IKE SA; authenticated peer certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "west-eku-serverAuth-critical" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
  ipsec stop
@@ -403,7 +403,7 @@ Redirecting to: [initsystem]
 "west-eku-clientAuth" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-eku-clientAuth" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-eku-clientAuth" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west-eku-clientAuth.testing.libreswan.org, E=user-west-eku-clientAuth@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"west-eku-clientAuth" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"west-eku-clientAuth" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-eku-clientAuth" #1: initiator established IKE SA; authenticated peer certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "west-eku-clientAuth" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
  ipsec stop
@@ -460,7 +460,7 @@ Redirecting to: [initsystem]
 "west-eku-clientAuth-ipsecIKE" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-eku-clientAuth-ipsecIKE" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-eku-clientAuth-ipsecIKE" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west-eku-clientAuth-ipsecIKE.testing.libreswan.org, E=user-west-eku-clientAuth-ipsecIKE@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"west-eku-clientAuth-ipsecIKE" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"west-eku-clientAuth-ipsecIKE" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-eku-clientAuth-ipsecIKE" #1: initiator established IKE SA; authenticated peer certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "west-eku-clientAuth-ipsecIKE" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
  ipsec stop
@@ -517,7 +517,7 @@ Redirecting to: [initsystem]
 "west-eku-clientAuth-critical" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-eku-clientAuth-critical" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-eku-clientAuth-critical" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west-eku-clientAuth-critical.testing.libreswan.org, E=user-west-eku-clientAuth-critical@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"west-eku-clientAuth-critical" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"west-eku-clientAuth-critical" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-eku-clientAuth-critical" #1: initiator established IKE SA; authenticated peer certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "west-eku-clientAuth-critical" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
  ipsec stop
@@ -634,7 +634,7 @@ Redirecting to: [initsystem]
 "west-eku-codeSigning-ipsecIKE" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-eku-codeSigning-ipsecIKE" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-eku-codeSigning-ipsecIKE" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west-eku-codeSigning-ipsecIKE.testing.libreswan.org, E=user-west-eku-codeSigning-ipsecIKE@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"west-eku-codeSigning-ipsecIKE" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"west-eku-codeSigning-ipsecIKE" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-eku-codeSigning-ipsecIKE" #1: initiator established IKE SA; authenticated peer certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "west-eku-codeSigning-ipsecIKE" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
  ipsec stop
@@ -691,7 +691,7 @@ Redirecting to: [initsystem]
 "west-eku-codeSigning-serverAuth" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-eku-codeSigning-serverAuth" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-eku-codeSigning-serverAuth" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west-eku-codeSigning-serverAuth.testing.libreswan.org, E=user-west-eku-codeSigning-serverAuth@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"west-eku-codeSigning-serverAuth" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"west-eku-codeSigning-serverAuth" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-eku-codeSigning-serverAuth" #1: initiator established IKE SA; authenticated peer certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "west-eku-codeSigning-serverAuth" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
  ipsec stop
@@ -748,7 +748,7 @@ Redirecting to: [initsystem]
 "west-eku-codeSigning-clientAuth" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-eku-codeSigning-clientAuth" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-eku-codeSigning-clientAuth" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west-eku-codeSigning-clientAuth.testing.libreswan.org, E=user-west-eku-codeSigning-clientAuth@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"west-eku-codeSigning-clientAuth" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"west-eku-codeSigning-clientAuth" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-eku-codeSigning-clientAuth" #1: initiator established IKE SA; authenticated peer certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "west-eku-codeSigning-clientAuth" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
  ipsec stop

--- a/testing/pluto/x509-profile-03-basic-constraints-end/west.console.txt
+++ b/testing/pluto/x509-profile-03-basic-constraints-end/west.console.txt
@@ -60,7 +60,7 @@ Redirecting to: [initsystem]
 "west-bc-ca-missing" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-bc-ca-missing" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-bc-ca-missing" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west-bc-ca-missing.testing.libreswan.org, E=user-west-bc-ca-missing@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"west-bc-ca-missing" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"west-bc-ca-missing" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-bc-ca-missing" #1: initiator established IKE SA; authenticated peer certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "west-bc-ca-missing" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
  ipsec stop
@@ -116,7 +116,7 @@ Redirecting to: [initsystem]
 "west-bc-ca-n" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-bc-ca-n" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-bc-ca-n" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west-bc-ca-n.testing.libreswan.org, E=user-west-bc-ca-n@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"west-bc-ca-n" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"west-bc-ca-n" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-bc-ca-n" #1: initiator established IKE SA; authenticated peer certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "west-bc-ca-n" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
  ipsec stop
@@ -173,7 +173,7 @@ Redirecting to: [initsystem]
 "west-bc-ca-n-critical" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west-bc-ca-n-critical" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 group=DH19}, initiating IKE_AUTH
 "west-bc-ca-n-critical" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west-bc-ca-n-critical.testing.libreswan.org, E=user-west-bc-ca-n-critical@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.1.2.45/32===192.1.2.23/32]
-"west-bc-ca-n-critical" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr}
+"west-bc-ca-n-critical" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,CERT,AUTH,SA,TSi,TSr} reassembled from N fragments
 "west-bc-ca-n-critical" #1: initiator established IKE SA; authenticated peer certificate '192.1.2.23' and 3nnn-bit RSASSA-PSS with SHA2_512 digital signature issued by 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=Libreswan test CA for mainca, E=testing@libreswan.org'
 "west-bc-ca-n-critical" #2: initiator established Child SA using #1; IPsec tunnel [192.1.2.45/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
  ipsec stop

--- a/testing/sanitizers/pluto-whack-sanitize.sed
+++ b/testing/sanitizers/pluto-whack-sanitize.sed
@@ -27,3 +27,4 @@ s/SN: 0x[a-f0-9]*/SN: 0xXX/
 s/ aged [0-9]*\.[0-9]*s / /
 
 /ERROR: asynchronous network error report/d
+s/ reassembled from [0-9][0-9]* fragments/ reassembled from N fragments/g


### PR DESCRIPTION
This change adds a small improvement to logging in `llog_transition_start()` to indicate when an IKEv2 message has been reassembled from fragments.
When `md->v2_frags_total > 0`, it prefixes the log with `SKF[n fragments] ->` to make fragment handling more visible during debugging.
