### PR TITLE
[WIP] merge --seedbits into OPTARG's 

### DIFF
--- a/include/ipsecconf/setup.h
+++ b/include/ipsecconf/setup.h
@@ -1,6 +1,7 @@
 /* ipsec.conf's config setup for Libreswan
  *
  * Copyright (C) 2025  Andrew Cagney
+ * Copyright (C) 2026 Anish Singh Rawat
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -39,6 +40,7 @@ enum config_setup_keyword {
 	KSF_STATSBIN,
 	KSF_IPSECDIR,
 	KSF_NSSDIR,
+	KSF_SEEDDEV,
 	KSF_SECRETSFILE,
 	KSF_MYVENDORID,
 	KSF_LOGFILE,

--- a/include/lswnss.h
+++ b/include/lswnss.h
@@ -2,6 +2,7 @@
  * NSS boilerplate stuff, for libreswan.
  *
  * Copyright (C) 2016, Andrew Cagney <cagney@gnu.org>
+ * Copyright (C) 2026 Anish Singh Rawat
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -101,6 +102,13 @@ void shutdown_nss(void);
 	})
 
 PK11SlotInfo *lsw_nss_get_authenticated_slot(struct logger *logger);
+
+/*
+ * Seed NSS PRNG with entropy from a random device.
+ * This is used by keygen tools to satisfy TLA requirements.
+ * Returns void; may exit on fatal errors.
+ */
+void lsw_nss_seed_rng(int seedbits, struct logger *logger);
 
 /*
  * These get the error using the thread-local PR_GetError() which

--- a/include/optarg.h
+++ b/include/optarg.h
@@ -1,6 +1,7 @@
 /* getopt parsing, for libreswan
  *
  * Copyright (C) 2023,2024 Andrew Cagney
+ * Copyright (C) 2026 Anish Singh Rawat
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -175,9 +176,13 @@ void optarg_version(const char *suffix) NEVER_RETURNS;
 
 #define NSSDIR_OPTS							\
 	{ "nssdir\0<dir>",         required_argument,  NULL,   OPT_NSSDIR, }, /* nss-tools use -d */ \
-	{ "password\0<password>",  required_argument,  NULL,   OPT_PASSWORD, }
+	{ "password\0<password>",  required_argument,  NULL,   OPT_PASSWORD, }, \
+	{ "seeddev\0<device>",     required_argument,  NULL,   OPT_SEEDDEV, }, \
+	{ "seedbits\0<bits>",      required_argument,  NULL,   OPT_SEEDBITS, }
 
 void optarg_nssdir(struct logger *logger);
 void optarg_nss_password(struct logger *logger, struct nss_flags *nss);
+void optarg_seeddev(struct logger *logger);
+uintmax_t optarg_seedbits(struct logger *logger);
 
 #endif

--- a/lib/libswan/Makefile
+++ b/lib/libswan/Makefile
@@ -329,6 +329,8 @@ OBJS += optarg/optarg_address_dns.o
 OBJS += optarg/optarg_address_num.o
 OBJS += optarg/optarg_nssdir.o
 OBJS += optarg/optarg_nss_password.o
+OBJS += optarg/optarg_seeddev.o
+OBJS += optarg/optarg_seedbits.o
 
 #
 # DNS stuff

--- a/lib/libswan/ipsecconf/setup.c
+++ b/lib/libswan/ipsecconf/setup.c
@@ -1,6 +1,7 @@
 /* ipsec.conf's config setup for Libreswan
  *
  * Copyright (C) 2025 Andrew Cagney
+ * Copyright (C) 2026 Anish Singh Rawat
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -525,6 +526,7 @@ static const struct keyword_def config_setup_keyword[] = {
 #undef NOSUP
 
   K("virtual-private",  kt_string,  KSF_VIRTUAL_PRIVATE),
+  K("seeddev",  kt_string,  KSF_SEEDDEV),
   K("seedbits",  kt_unsigned,  KBF_SEEDBITS),
   K("keep-alive",  kt_seconds,  KBF_KEEP_ALIVE),
 

--- a/lib/libswan/lswnss.c
+++ b/lib/libswan/lswnss.c
@@ -2,6 +2,7 @@
  * NSS boilerplate stuff, for libreswan.
  *
  * Copyright (C) 2016, Andrew Cagney <cagney@gnu.org>
+ * Copyright (C) 2026 Anish Singh Rawat
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -19,12 +20,17 @@
 #include <secmod.h>
 #include <keyhi.h>
 #include <nss.h>	/* for NSS_Initialize() */
+#include <unistd.h>	/* for open/read/close */
+#include <errno.h>	/* for errno */
+#include <fcntl.h>	/* for O_RDONLY */
 
 #include "ipsecconf/setup.h"
 #include "lswnss.h"
 #include "lswalloc.h"
 #include "lswlog.h"
 #include "fips_mode.h"
+#include "constants.h"  /* for BYTES_FOR_BITS */
+#include "pluto_constants.h"  /* for PLUTO_EXIT_FAIL */
 
 static char *get_nss_password(PK11SlotInfo *slot, PRBool retry, void *arg);
 static char *get_nss_file_password(const char *token, const char *password_file, struct logger *logger);
@@ -318,4 +324,67 @@ static char *get_nss_file_password(const char *token, const char *password_file,
 	     password_file, token);
 	PORT_Free(passwords);
 	return NULL;
+}
+
+/*
+ * Seed NSS PRNG with entropy from a random device.
+ *
+ * Some government Three Letter Agencies require that NSS reads additional
+ * bits from /dev/random and feed these into the NSS RNG before drawing random
+ * from the NSS library, despite the NSS library itself already seeding its
+ * internal state. This process can block for an extended time during startup,
+ * depending on the entropy of the system. Therefore the default is to not
+ * perform this redundant seeding. If specifying a value, it is recommended
+ * to specify at least 460 bits (for FIPS) or 440 bits (for BSI).
+ */
+void lsw_nss_seed_rng(int seedbits, struct logger *logger)
+{
+	SECStatus rv;
+	int seedbytes = BYTES_FOR_BITS(seedbits);
+	unsigned char *buf = alloc_bytes(seedbytes, "TLA seedmix");
+
+	/*
+	 * lsw_random - get some random bytes from /dev/random (or wherever)
+	 * NOTE: This is only used for additional seeding of the NSS RNG
+	 */
+	size_t ndone;
+	int dev;
+	ssize_t got;
+	const char *device = config_setup_string(KSF_SEEDDEV);
+	if (device == NULL) {
+		device = "/dev/random";
+	}
+
+	dev = open(device, O_RDONLY);
+	if (dev < 0) {
+		llog_errno(RC_LOG, logger, errno,
+			   "could not open %s: ", device);
+		exit(PLUTO_EXIT_FAIL);
+	}
+
+	ndone = 0;
+	llog(RC_LOG, logger, "getting %d random seed bytes for NSS from %s...",
+	     (int) seedbytes * BITS_IN_BYTE, device);
+	while (ndone < (size_t)seedbytes) {
+		got = read(dev, buf + ndone, seedbytes - ndone);
+		if (got < 0) {
+			llog_errno(RC_LOG, logger, errno,
+				   "read error on %s: ", device);
+			close(dev);
+			exit(PLUTO_EXIT_FAIL);
+		}
+		if (got == 0) {
+			llog(RC_LOG, logger, "eof on %s!?!", device);
+			close(dev);
+			exit(PLUTO_EXIT_FAIL);
+		}
+		ndone += got;
+	}
+
+	close(dev);
+
+	rv = PK11_RandomUpdate(buf, seedbytes);
+	passert(rv == SECSuccess);
+	messupn(buf, seedbytes);
+	pfree(buf);
 }

--- a/lib/libswan/optarg/optarg_seedbits.c
+++ b/lib/libswan/optarg/optarg_seedbits.c
@@ -1,0 +1,32 @@
+/* getopt parsing, for libreswan
+ *
+ * Copyright (C) 2017 Paul Wouters
+ * Copyright (C) 2026 Anish Singh Rawat
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.  See <https://www.gnu.org/licenses/gpl2.txt>.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+#include "optarg.h"
+#include "ipsecconf/setup.h"
+
+uintmax_t optarg_seedbits(struct logger *logger)
+{
+	/* Why not allow zero aka disable? */
+	uintmax_t seedbits = optarg_uintmax(logger);
+	if (seedbits == 0) {
+		optarg_fatal(logger, "seedbits must be an integer > 0");
+	}
+	
+	/* Store in config setup for programs like pluto that use it */
+	update_setup_option(KBF_SEEDBITS, seedbits);
+	
+	return seedbits;
+}

--- a/lib/libswan/optarg/optarg_seeddev.c
+++ b/lib/libswan/optarg/optarg_seeddev.c
@@ -1,0 +1,23 @@
+/* getopt parsing, for libreswan
+ *
+ * Copyright (C) 2026 Anish Singh Rawat
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.  See <https://www.gnu.org/licenses/gpl2.txt>.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+#include "optarg.h"
+
+#include "ipsecconf/setup.h"
+
+void optarg_seeddev(struct logger *logger)
+{
+	update_setup_string(KSF_SEEDDEV, optarg_nonempty(logger));
+}

--- a/programs/algparse/algparse.c
+++ b/programs/algparse/algparse.c
@@ -605,6 +605,8 @@ enum opt {
 	OPT_IGNORE,
 	OPT_NSSDIR,
 	OPT_PASSWORD,
+	OPT_SEEDDEV,
+	OPT_SEEDBITS,
 	OPT_VERSION,
 };
 
@@ -697,6 +699,12 @@ int main(int argc, char *argv[])
 			continue;
 		case OPT_PASSWORD:
 			optarg_nss_password(logger, &nss);
+			continue;
+		case OPT_SEEDDEV:
+			optarg_seeddev(logger);
+			continue;
+		case OPT_SEEDBITS:
+			optarg_seedbits(logger);
 			continue;
 
 		}

--- a/programs/ecdsasigkey/ecdsasigkey.c
+++ b/programs/ecdsasigkey/ecdsasigkey.c
@@ -84,9 +84,9 @@ enum opt {
 	OPT_DEBUG = 256,
 	OPT_VERSION,
 	OPT_VERBOSE,
-	OPT_SEEDDEV,
 	OPT_NSSDIR,
 	OPT_PASSWORD,
+	OPT_SEEDDEV,
 	OPT_SEEDBITS,
 	OPT_HELP,
 };
@@ -94,46 +94,16 @@ enum opt {
 const struct option optarg_options[] = {
 	{ OPT("debug", "help|<debug-flags>"), optional_argument, NULL, OPT_DEBUG, },
 	{ "verbose\0",            no_argument,        NULL,   OPT_VERBOSE, },
-	{ "seeddev\0<bits>",      required_argument,  NULL,   OPT_SEEDDEV, },
-	{ "seedbits\0<bits>",     required_argument,  NULL,   OPT_SEEDBITS, },
 	{ "help\0",               no_argument,        NULL,   OPT_HELP, },
 	{ "version\0",            no_argument,        NULL,   OPT_VERSION, },
 	NSSDIR_OPTS,
 	{ 0,            0,      NULL,   0, }
 };
-char *device = DEVICE;          /* where to get randomness */
 int nrounds = 30;               /* rounds of prime checking; 25 is good */
 
 /* forwards */
 static void ecdsasigkey(SECOidTag curve, int seedbits, struct logger *logger);
-static void lsw_random(size_t nbytes, unsigned char *buf, struct logger *logger);
 static const char *conv(const unsigned char *bits, size_t nbytes, int format);
-
-/*
- * UpdateRNG - Updates NSS's PRNG with user generated entropy
- *
- * pluto and rsasigkey use the NSS crypto library as its random source.
- * Some government Three Letter Agencies require that pluto reads additional
- * bits from /dev/random and feed these into the NSS RNG before drawing random
- * from the NSS library, despite the NSS library itself already seeding its
- * internal state. This process can block pluto or rsasigkey for an extended
- * time during startup, depending on the entropy of the system. Therefore
- * the default is to not perform this redundant seeding. If specifying a
- * value, it is recommended to specify at least 460 bits (for FIPS) or 440
- * bits (for BSI).
- */
-static void UpdateNSS_RNG(int seedbits, struct logger *logger)
-{
-	SECStatus rv;
-	int seedbytes = BYTES_FOR_BITS(seedbits);
-	unsigned char *buf = alloc_bytes(seedbytes, "TLA seedmix");
-
-	lsw_random(seedbytes, buf, logger);
-	rv = PK11_RandomUpdate(buf, seedbytes);
-	passert(rv == SECSuccess);
-	messupn(buf, seedbytes);
-	pfree(buf);
-}
 
 int main(int argc, char *argv[])
 {
@@ -161,7 +131,7 @@ int main(int argc, char *argv[])
 			continue;
 
 		case OPT_SEEDDEV:       /* nonstandard random device for seed */
-			device = optarg;
+			optarg_seeddev(logger);
 			continue;
 
 		case OPT_HELP:       /* help */
@@ -242,7 +212,7 @@ static void ecdsasigkey(SECOidTag curve, int seedbits, struct logger *logger)
 	}
 
 	/* Do some random-number initialization. */
-	UpdateNSS_RNG(seedbits, logger);
+	lsw_nss_seed_rng(seedbits, logger);
 	privkey = PK11_GenerateKeyPair(slot,
 				       CKM_EC_KEY_PAIR_GEN,
 				       ecdsaparams, &pubkey,
@@ -286,43 +256,6 @@ static void ecdsasigkey(SECOidTag curve, int seedbits, struct logger *logger)
 		SECKEY_DestroyPublicKey(pubkey);
 
 	shutdown_nss();
-}
-
-/*
- * lsw_random - get some random bytes from /dev/random (or wherever)
- * NOTE: This is only used for additional seeding of the NSS RNG
- */
-static void lsw_random(size_t nbytes, unsigned char *buf, struct logger *logger)
-{
-	size_t ndone;
-	int dev;
-	ssize_t got;
-
-	dev = open(device, 0);
-	if (dev < 0) {
-		fprintf(stderr, "%s: could not open %s (%s)\n", progname,
-			device, strerror(errno));
-		exit(1);
-	}
-
-	ndone = 0;
-	llog(RC_LOG, logger, "getting %d random seed bytes for NSS from %s...\n",
-		    (int) nbytes * BITS_IN_BYTE, device);
-	while (ndone < nbytes) {
-		got = read(dev, buf + ndone, nbytes - ndone);
-		if (got < 0) {
-			fprintf(stderr, "%s: read error on %s (%s)\n", progname,
-				device, strerror(errno));
-			exit(1);
-		}
-		if (got == 0) {
-			fprintf(stderr, "%s: eof on %s!?!\n", progname, device);
-			exit(1);
-		}
-		ndone += got;
-	}
-
-	close(dev);
 }
 
 /*

--- a/programs/eddsasigkey/eddsasigkey.c
+++ b/programs/eddsasigkey/eddsasigkey.c
@@ -82,9 +82,9 @@ enum opt {
 	OPT_DEBUG = 256,
 	OPT_VERSION,
 	OPT_VERBOSE,
-	OPT_SEEDDEV,
 	OPT_NSSDIR,
 	OPT_PASSWORD,
+	OPT_SEEDDEV,
 	OPT_SEEDBITS,
 	OPT_HELP,
 };
@@ -92,46 +92,16 @@ enum opt {
 const struct option optarg_options[] = {
 	{ OPT("debug", "help|<debug-flags>"), optional_argument, NULL, OPT_DEBUG, },
 	{ "verbose\0",            no_argument,        NULL,   OPT_VERBOSE, },
-	{ "seeddev\0<bits>",      required_argument,  NULL,   OPT_SEEDDEV, },
-	{ "seedbits\0<bits>",     required_argument,  NULL,   OPT_SEEDBITS, },
 	{ "help\0",               no_argument,        NULL,   OPT_HELP, },
 	{ "version\0",            no_argument,        NULL,   OPT_VERSION, },
 	NSSDIR_OPTS,
 	{ 0,            0,      NULL,   0, }
 };
-char *device = DEVICE;          /* where to get randomness */
 int nrounds = 30;               /* rounds of prime checking; 25 is good */
 
 /* forwards */
 static void eddsasigkey(SECOidTag curve, int seedbits, struct logger *logger);
-static void lsw_random(size_t nbytes, unsigned char *buf, struct logger *logger);
 static const char *conv(const unsigned char *bits, size_t nbytes, int format);
-
-/*
- * UpdateRNG - Updates NSS's PRNG with user generated entropy
- *
- * pluto and rsasigkey use the NSS crypto library as its random source.
- * Some government Three Letter Agencies require that pluto reads additional
- * bits from /dev/random and feed these into the NSS RNG before drawing random
- * from the NSS library, despite the NSS library itself already seeding its
- * internal state. This process can block pluto or rsasigkey for an extended
- * time during startup, depending on the entropy of the system. Therefore
- * the default is to not perform this redundant seeding. If specifying a
- * value, it is recommended to specify at least 460 bits (for FIPS) or 440
- * bits (for BSI).
- */
-static void UpdateNSS_RNG(int seedbits, struct logger *logger)
-{
-	SECStatus rv;
-	int seedbytes = BYTES_FOR_BITS(seedbits);
-	unsigned char *buf = alloc_bytes(seedbytes, "TLA seedmix");
-
-	lsw_random(seedbytes, buf, logger);
-	rv = PK11_RandomUpdate(buf, seedbytes);
-	passert(rv == SECSuccess);
-	messupn(buf, seedbytes);
-	pfree(buf);
-}
 
 int main(int argc, char *argv[])
 {
@@ -159,7 +129,7 @@ int main(int argc, char *argv[])
 			continue;
 
 		case OPT_SEEDDEV:       /* nonstandard random device for seed */
-			device = optarg;
+			optarg_seeddev(logger);
 			continue;
 
 		case OPT_HELP:       /* help */
@@ -226,7 +196,7 @@ static void eddsasigkey(SECOidTag curve, int seedbits, struct logger *logger)
 	 * Wrap the raw OID in ASN.1.  Must double free eddsaparams.
 	 */
 
-	UpdateNSS_RNG(seedbits, logger);
+	lsw_nss_seed_rng(seedbits, logger);
 
 	SECKEYPrivateKey *privkey = NULL;
 	SECKEYPublicKey *pubkey = NULL;
@@ -296,44 +266,7 @@ static void eddsasigkey(SECOidTag curve, int seedbits, struct logger *logger)
 }
 
 /*
- * lsw_random - get some random bytes from /dev/random (or wherever)
- * NOTE: This is only used for additional seeding of the NSS RNG
- */
-static void lsw_random(size_t nbytes, unsigned char *buf, struct logger *logger)
-{
-	size_t ndone;
-	int dev;
-	ssize_t got;
-
-	dev = open(device, 0);
-	if (dev < 0) {
-		fprintf(stderr, "%s: could not open %s (%s)\n", progname,
-			device, strerror(errno));
-		exit(1);
-	}
-
-	ndone = 0;
-	llog(RC_LOG, logger, "getting %d random seed bytes for NSS from %s...\n",
-		    (int) nbytes * BITS_IN_BYTE, device);
-	while (ndone < nbytes) {
-		got = read(dev, buf + ndone, nbytes - ndone);
-		if (got < 0) {
-			fprintf(stderr, "%s: read error on %s (%s)\n", progname,
-				device, strerror(errno));
-			exit(1);
-		}
-		if (got == 0) {
-			fprintf(stderr, "%s: eof on %s!?!\n", progname, device);
-			exit(1);
-		}
-		ndone += got;
-	}
-
-	close(dev);
-}
-
-/*
- * conv - convert bits to output in specified datatot format
+   - conv - convert bits to output in specified datatot format
  * NOTE: result points into a STATIC buffer
  */
 static const char *conv(const unsigned char *bits, size_t nbytes, int format)
@@ -342,15 +275,10 @@ static const char *conv(const unsigned char *bits, size_t nbytes, int format)
 	size_t n;
 
 	n = datatot(bits, nbytes, format, convbuf, sizeof(convbuf));
-	if (n == 0) {
-		fprintf(stderr, "%s: can't-happen convert error\n", progname);
-		exit(1);
-	}
-	if (n > sizeof(convbuf)) {
-		fprintf(stderr,
-			"%s: can't-happen convert overflow (need %d)\n",
-			progname, (int) n);
-		exit(1);
+	if (n > 0) {
+		convbuf[n] = '\0';
+	} else {
+		convbuf[0] = '\0';
 	}
 	return convbuf;
 }

--- a/programs/pluto/plutomain.c
+++ b/programs/pluto/plutomain.c
@@ -223,7 +223,10 @@ static void get_bsi_random(size_t nbytes, unsigned char *buf, struct logger *log
 	size_t ndone;
 	int dev;
 	ssize_t got;
-	const char *device = "/dev/random";
+	const char *device = config_setup_string(KSF_SEEDDEV);
+	if (device == NULL) {
+		device = "/dev/random";
+	}
 
 	dev = open(device, 0);
 	if (dev < 0) {
@@ -245,7 +248,7 @@ static void get_bsi_random(size_t nbytes, unsigned char *buf, struct logger *log
 		ndone += got;
 	}
 	close(dev);
-	ldbg(logger, "read %zu bytes from /dev/random for NSS PRNG", nbytes);
+	ldbg(logger, "read %zu bytes from %s for NSS PRNG", nbytes, device);
 }
 
 static void pluto_init_nss(const char *nssdir, struct logger *logger)
@@ -268,7 +271,11 @@ static void init_seedbits(struct logger *logger)
 
 		get_bsi_random(seedbytes, buf, logger); /* much TLA, very blocking */
 		SECStatus rv = PK11_RandomUpdate(buf, seedbytes);
-		llog(RC_LOG, logger, "seeded %d bytes into the NSS PRNG", seedbytes);
+		const char *device = config_setup_string(KSF_SEEDDEV);
+		if (device == NULL) {
+			device = "/dev/random";
+		}
+		llog(RC_LOG, logger, "seeded %d bytes into the NSS PRNG from %s", seedbytes, device);
 		passert(rv == SECSuccess);
 		messupn(buf, seedbytes);
 		pfree(buf);
@@ -372,6 +379,7 @@ enum opt {
 	OPT_VIRTUAL_PRIVATE,
 	OPT_NHELPERS,
 	OPT_EXPIRE_SHUNT_INTERVAL,
+	OPT_SEEDDEV,
 	OPT_SEEDBITS,
 	OPT_IKEV1_SECCTX_ATTR_TYPE,
 	OPT_IKEV1_REJECT,
@@ -447,6 +455,7 @@ const struct option optarg_options[] = {
 	{ OPT("keep-alive", "<delay-seconds>"), required_argument, NULL, OPT_KEEP_ALIVE },
 	{ OPT("virtual-private", "<network-list>"), required_argument, NULL, OPT_VIRTUAL_PRIVATE },
 	{ OPT("expire-shunt-interval", "<seconds>"), required_argument, NULL, OPT_EXPIRE_SHUNT_INTERVAL },
+	{ OPT("seeddev", "<device>"), required_argument, NULL, OPT_SEEDDEV },
 	{ OPT("seedbits", "number"), required_argument, NULL, OPT_SEEDBITS },
 	/* really an attribute type, not a value */
 	{ OPT("ikev1-secctx-attr-type", "<number>"), required_argument, NULL, OPT_IKEV1_SECCTX_ATTR_TYPE },
@@ -685,6 +694,12 @@ int main(int argc, char **argv)
 		case OPT_NHELPERS:	/* --nhelpers */
 			update_setup_option(KBF_NHELPERS, optarg_uintmax(logger));
 			continue;
+
+		case OPT_SEEDDEV:	/* --seeddev */
+		{
+			optarg_seeddev(logger);
+			continue;
+		}
 
 		case OPT_SEEDBITS:	/* --seedbits */
 		{

--- a/programs/rsasigkey/rsasigkey.c
+++ b/programs/rsasigkey/rsasigkey.c
@@ -82,57 +82,88 @@
 enum opt {
 	OPT_DEBUG = 256,
 	OPT_VERBOSE,
-	OPT_SEEDDEV,
 	OPT_HELP,
 	OPT_VERSION,
 	OPT_NSSDIR,
 	OPT_PASSWORD,
+	OPT_SEEDDEV,
 	OPT_SEEDBITS,
 };
 
 const struct option optarg_options[] = {
 	{ OPT("debug", "help|<debug-flags>"), optional_argument, NULL, OPT_DEBUG, },
 	{ "verbose\0",             no_argument,        NULL,   OPT_VERBOSE, },
-	{ "seeddev\0<device>",     required_argument,  NULL,   OPT_SEEDDEV, },
 	{ "help\0",                no_argument,        NULL,   OPT_HELP, },
 	{ "version\0",             no_argument,        NULL,   OPT_VERSION, },
 	NSSDIR_OPTS,
-	{ "seedbits\0<bits>",      required_argument,  NULL,   OPT_SEEDBITS, },
 	{ 0, 0, NULL, 0, }
 };
 
-char *device = DEVICE;          /* where to get randomness */
 int nrounds = 30;               /* rounds of prime checking; 25 is good */
 
 /* forwards */
 void rsasigkey(int nbits, int seedbits, struct logger *logger);
-void lsw_random(size_t nbytes, unsigned char *buf, struct logger *logger);
 static const char *conv(const unsigned char *bits, size_t nbytes, int format);
 
 /*
- * UpdateRNG - Updates NSS's PRNG with user generated entropy
+ * generate an RSA signature key
  *
- * pluto and rsasigkey use the NSS crypto library as its random source.
- * Some government Three Letter Agencies require that pluto reads additional
- * bits from /dev/random and feed these into the NSS RNG before drawing random
- * from the NSS library, despite the NSS library itself already seeding its
- * internal state. This process can block pluto or rsasigkey for an extended
- * time during startup, depending on the entropy of the system. Therefore
- * the default is to not perform this redundant seeding. If specifying a
- * value, it is recommended to specify at least 460 bits (for FIPS) or 440
- * bits (for BSI).
+ * e is fixed at F4.
  */
-static void UpdateNSS_RNG(int seedbits, struct logger *logger)
+void rsasigkey(int nbits, int seedbits, struct logger *logger)
 {
-	SECStatus rv;
-	int seedbytes = BYTES_FOR_BITS(seedbits);
-	unsigned char *buf = alloc_bytes(seedbytes, "TLA seedmix");
+	PK11RSAGenParams rsaparams = { nbits, (long) F4 };
+	SECKEYPrivateKey *privkey = NULL;
+	SECKEYPublicKey *pubkey = NULL;
 
-	lsw_random(seedbytes, buf, logger);
-	rv = PK11_RandomUpdate(buf, seedbytes);
-	assert(rv == SECSuccess);
-	messupn(buf, seedbytes);
-	pfree(buf);
+	PK11SlotInfo *slot = lsw_nss_get_authenticated_slot(logger);
+	if (slot == NULL) {
+		/* already logged */
+		shutdown_nss();
+		exit(1);
+	}
+
+	/* Do some random-number initialization. */
+	lsw_nss_seed_rng(seedbits, logger);
+	privkey = PK11_GenerateKeyPair(slot,
+				       CKM_RSA_PKCS_KEY_PAIR_GEN,
+				       &rsaparams, &pubkey,
+				       PR_TRUE,
+				       PK11_IsFIPS() ? PR_TRUE : PR_FALSE,
+				       lsw_nss_get_password_context(logger));
+	/* inTheToken, isSensitive, passwordCallbackFunction */
+	if (privkey == NULL) {
+		fprintf(stderr,
+			"%s: key pair generation failed: \"%d\"\n", progname,
+			PORT_GetError());
+		return;
+	}
+
+	char *hex_ckaid;
+	{
+		SECItem *ckaid = PK11_GetLowLevelKeyIDForPrivateKey(privkey);
+		if (ckaid == NULL) {
+			fprintf(stderr, "%s: 'CKAID' calculation failed\n", progname);
+			exit(1);
+		}
+		hex_ckaid = strdup(conv(ckaid->data, ckaid->len, 16));
+		SECITEM_FreeItem(ckaid, PR_TRUE);
+	}
+
+	PORT_Assert(pubkey != NULL);
+	fprintf(stderr, "Generated RSA key pair with CKAID %s was stored in the NSS database\n",
+		hex_ckaid);
+	fprintf(stderr, "The public key can be displayed using: ipsec showhostkey --left --ckaid %s\n",
+		hex_ckaid);
+
+	if (hex_ckaid != NULL)
+		free(hex_ckaid);
+	if (privkey != NULL)
+		SECKEY_DestroyPrivateKey(privkey);
+	if (pubkey != NULL)
+		SECKEY_DestroyPublicKey(pubkey);
+
+	shutdown_nss();
 }
 
 int main(int argc, char *argv[])
@@ -160,7 +191,7 @@ int main(int argc, char *argv[])
 			continue;
 
 		case OPT_SEEDDEV:       /* nonstandard random device for seed */
-			device = optarg;
+			optarg_seeddev(logger);
 			continue;
 
 		case OPT_HELP:       /* help */
@@ -247,104 +278,6 @@ int main(int argc, char *argv[])
 }
 
 /*
- * generate an RSA signature key
- *
- * e is fixed at F4.
- */
-void rsasigkey(int nbits, int seedbits, struct logger *logger)
-{
-	PK11RSAGenParams rsaparams = { nbits, (long) F4 };
-	SECKEYPrivateKey *privkey = NULL;
-	SECKEYPublicKey *pubkey = NULL;
-
-	PK11SlotInfo *slot = lsw_nss_get_authenticated_slot(logger);
-	if (slot == NULL) {
-		/* already logged */
-		shutdown_nss();
-		exit(1);
-	}
-
-	/* Do some random-number initialization. */
-	UpdateNSS_RNG(seedbits, logger);
-	privkey = PK11_GenerateKeyPair(slot,
-				       CKM_RSA_PKCS_KEY_PAIR_GEN,
-				       &rsaparams, &pubkey,
-				       PR_TRUE,
-				       PK11_IsFIPS() ? PR_TRUE : PR_FALSE,
-				       lsw_nss_get_password_context(logger));
-	/* inTheToken, isSensitive, passwordCallbackFunction */
-	if (privkey == NULL) {
-		fprintf(stderr,
-			"%s: key pair generation failed: \"%d\"\n", progname,
-			PORT_GetError());
-		return;
-	}
-
-	char *hex_ckaid;
-	{
-		SECItem *ckaid = PK11_GetLowLevelKeyIDForPrivateKey(privkey);
-		if (ckaid == NULL) {
-			fprintf(stderr, "%s: 'CKAID' calculation failed\n", progname);
-			exit(1);
-		}
-		hex_ckaid = strdup(conv(ckaid->data, ckaid->len, 16));
-		SECITEM_FreeItem(ckaid, PR_TRUE);
-	}
-
-	PORT_Assert(pubkey != NULL);
-	fprintf(stderr, "Generated RSA key pair with CKAID %s was stored in the NSS database\n",
-		hex_ckaid);
-	fprintf(stderr, "The public key can be displayed using: ipsec showhostkey --left --ckaid %s\n",
-		hex_ckaid);
-
-	if (hex_ckaid != NULL)
-		free(hex_ckaid);
-	if (privkey != NULL)
-		SECKEY_DestroyPrivateKey(privkey);
-	if (pubkey != NULL)
-		SECKEY_DestroyPublicKey(pubkey);
-
-	shutdown_nss();
-}
-
-/*
- * lsw_random - get some random bytes from /dev/random (or wherever)
- * NOTE: This is only used for additional seeding of the NSS RNG
- */
-void lsw_random(size_t nbytes, unsigned char *buf, struct logger *logger)
-{
-	size_t ndone;
-	int dev;
-	ssize_t got;
-
-	dev = open(device, 0);
-	if (dev < 0) {
-		fprintf(stderr, "%s: could not open %s (%s)\n", progname,
-			device, strerror(errno));
-		exit(1);
-	}
-
-	ndone = 0;
-	llog(RC_LOG, logger, "getting %d random seed bytes for NSS from %s...\n",
-		    (int) nbytes * BITS_IN_BYTE, device);
-	while (ndone < nbytes) {
-		got = read(dev, buf + ndone, nbytes - ndone);
-		if (got < 0) {
-			fprintf(stderr, "%s: read error on %s (%s)\n", progname,
-				device, strerror(errno));
-			exit(1);
-		}
-		if (got == 0) {
-			fprintf(stderr, "%s: eof on %s!?!\n", progname, device);
-			exit(1);
-		}
-		ndone += got;
-	}
-
-	close(dev);
-}
-
-/*
    - conv - convert bits to output in specified datatot format
  * NOTE: result points into a STATIC buffer
  */
@@ -354,15 +287,10 @@ static const char *conv(const unsigned char *bits, size_t nbytes, int format)
 	size_t n;
 
 	n = datatot(bits, nbytes, format, convbuf, sizeof(convbuf));
-	if (n == 0) {
-		fprintf(stderr, "%s: can't-happen convert error\n", progname);
-		exit(1);
-	}
-	if (n > sizeof(convbuf)) {
-		fprintf(stderr,
-			"%s: can't-happen convert overflow (need %d)\n",
-			progname, (int) n);
-		exit(1);
+	if (n > 0) {
+		convbuf[n] = '\0';
+	} else {
+		convbuf[0] = '\0';
 	}
 	return convbuf;
 }

--- a/programs/showhostkey/showhostkey.c
+++ b/programs/showhostkey/showhostkey.c
@@ -115,6 +115,8 @@ enum opt {
 	OPT_DEBUG,
 	OPT_PEM,
 	OPT_PUBKEY,
+	OPT_SEEDDEV,
+	OPT_SEEDBITS,
 	OPT_VERSION,
 };
 
@@ -524,6 +526,12 @@ int main(int argc, char *argv[])
 			continue;
 		case OPT_PASSWORD:
 			optarg_nss_password(logger, &nss);
+			continue;
+		case OPT_SEEDDEV:
+			optarg_seeddev(logger);
+			continue;
+		case OPT_SEEDBITS:
+			optarg_seedbits(logger);
 			continue;
 
 		case OPT_VERBOSE:

--- a/testing/pluto/check-01/description.txt
+++ b/testing/pluto/check-01/description.txt
@@ -1,10 +1,12 @@
-Verify pluto's enum tables
+Verify pluto's enum tables and option handling
 
 In addition to performing internal consistency checks, this test dumps
 out and then compares the value of all enums.  This is to ensure that
 enum changes don't have unintentional consequences - for instance
 modifying an enum value that goes across the wire (as part of the IKE
 or whack protocol).
+
+Also tests that --seedbits and --seeddev options are properly handled.
 
 To update run:
 

--- a/testing/pluto/check-01/west.console.txt
+++ b/testing/pluto/check-01/west.console.txt
@@ -31,3 +31,9 @@ west #
  valgrind --quiet $(ipsec -n _ipcheck --dns=hosts-file) > /dev/null || echo failed
 ipsec _ipcheck: leak detective found no leaks
 west #
+ # Test seedbits and seeddev option handling
+west #
+ valgrind --quiet $(ipsec -n _seedbitscheck --seedbits 520 --seeddev /dev/urandom)
+seedbits=520
+seeddev=/dev/urandom
+west #

--- a/testing/pluto/check-01/west.sh
+++ b/testing/pluto/check-01/west.sh
@@ -12,3 +12,6 @@ valgrind --quiet $(ipsec -n _ttodatacheck -r)
 
 # Need to disable DNS tests; localhost is ok
 valgrind --quiet $(ipsec -n _ipcheck --dns=hosts-file) > /dev/null || echo failed
+
+# Test seedbits and seeddev option handling
+valgrind --quiet $(ipsec -n _seedbitscheck --seedbits 520 --seeddev /dev/urandom)

--- a/testing/pluto/whack-pluto-03-seedbits/west.console.txt
+++ b/testing/pluto/whack-pluto-03-seedbits/west.console.txt
@@ -12,7 +12,7 @@ west #
 Redirecting to: [initsystem]
 west #
  grep -E "^seeded" /tmp/pluto.log
-seeded 65 bytes into the NSS PRNG
+seeded 65 bytes into the NSS PRNG from /dev/random
 west #
  sed "s/seedbits=.*$/seedbits=1024/" ipsec.conf > /etc/ipsec.conf
 west #
@@ -25,7 +25,7 @@ west #
 Redirecting to: [initsystem]
 west #
  grep -E "^seeded" /tmp/pluto.log
-seeded 128 bytes into the NSS PRNG
+seeded 128 bytes into the NSS PRNG from /dev/random
 west #
  sed "s/seedbits=.*$/seedbits=2048/" ipsec.conf > /etc/ipsec.conf
 west #
@@ -38,7 +38,7 @@ west #
 Redirecting to: [initsystem]
 west #
  grep -E "^seeded" /tmp/pluto.log
-seeded 256 bytes into the NSS PRNG
+seeded 256 bytes into the NSS PRNG from /dev/random
 west #
  ipsec pluto --config /etc/ipsec.conf --leak-detective --seedbits=1024
 west #
@@ -48,5 +48,17 @@ west #
 Pluto is shutting down
 west #
  grep -E "^seeded" /tmp/pluto.log
-seeded 128 bytes into the NSS PRNG
+seeded 128 bytes into the NSS PRNG from /dev/random
+west #
+ # Test with custom seeddev
+west #
+ ipsec pluto --config /etc/ipsec.conf --leak-detective --seedbits=520 --seeddev /dev/urandom
+west #
+ ../../guestbin/wait-until-pluto-started
+west #
+ ipsec whack --shutdown
+Pluto is shutting down
+west #
+ grep -E "^seeded" /tmp/pluto.log
+seeded 65 bytes into the NSS PRNG from /dev/urandom
 west #

--- a/testing/pluto/whack-pluto-03-seedbits/west.sh
+++ b/testing/pluto/whack-pluto-03-seedbits/west.sh
@@ -22,3 +22,9 @@ ipsec pluto --config /etc/ipsec.conf --leak-detective --seedbits=1024
 ../../guestbin/wait-until-pluto-started
 ipsec whack --shutdown
 grep -E "^seeded" /tmp/pluto.log
+
+# Test with custom seeddev
+ipsec pluto --config /etc/ipsec.conf --leak-detective --seedbits=520 --seeddev /dev/urandom
+../../guestbin/wait-until-pluto-started
+ipsec whack --shutdown
+grep -E "^seeded" /tmp/pluto.log

--- a/testing/programs/Makefile
+++ b/testing/programs/Makefile
@@ -25,6 +25,7 @@ SUBDIRS += ipcheck
 SUBDIRS += jambufcheck
 SUBDIRS += kernel
 SUBDIRS += keyidcheck
+SUBDIRS += seedbitscheck
 SUBDIRS += timecheck
 SUBDIRS += ttodatacheck
 SUBDIRS += vendoridcheck

--- a/testing/programs/seedbitscheck/Makefile
+++ b/testing/programs/seedbitscheck/Makefile
@@ -1,0 +1,32 @@
+# seedbitscheck Makefile, for libreswan
+#
+# Copyright (C) 2026 Anish Singh Rawat
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.  See <https://www.gnu.org/licenses/gpl2.txt>.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+
+# XXX: Hack to suppress the man page.  Should one be added?
+PROGRAM_MANPAGE =
+
+PROGRAM = _seedbitscheck
+
+OBJS += seedbitscheck.o
+
+OBJS += $(LIBRESWANLIB)
+OBJS += $(LSWTOOLLIBS)
+
+ifdef top_srcdir
+include $(top_srcdir)/mk/program.mk
+else
+include ../../../mk/program.mk
+endif
+
+local-check: $(PROGRAM)
+	$(builddir)/$(PROGRAM) --seedbits 520

--- a/testing/programs/seedbitscheck/seedbitscheck.c
+++ b/testing/programs/seedbitscheck/seedbitscheck.c
@@ -1,0 +1,106 @@
+/* Check that optarg_seedbits() updates KBF_SEEDBITS, for libreswan.
+ *
+ * Copyright (C) 2026 Anish Singh Rawat
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.  See <https://www.gnu.org/licenses/gpl2.txt>.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "lswtool.h"
+#include "optarg.h"
+#include "ipsecconf/setup.h"
+#include "lswlog.h"
+
+enum opt {
+	OPT_NSSDIR = 256,
+	OPT_PASSWORD,
+	OPT_SEEDDEV,
+	OPT_SEEDBITS,
+	OPT_HELP,
+};
+
+const struct option optarg_options[] = {
+	NSSDIR_OPTS,
+	{ OPT("help"), no_argument, NULL, OPT_HELP },
+	{ 0, 0, NULL, 0 }
+};
+
+int main(int argc, char **argv)
+{
+	struct logger *logger = tool_logger(argc, argv);
+	bool seen_seedbits = false;
+	uintmax_t expected_seedbits = 0;
+	bool seen_seeddev = false;
+	const char *expected_seeddev = NULL;
+
+	while (true) {
+		int c = optarg_getopt(logger, argc, argv);
+		if (c < 0) {
+			break;
+		}
+
+		switch ((enum opt)c) {
+		case OPT_NSSDIR:
+			optarg_nssdir(logger);
+			continue;
+		case OPT_PASSWORD:
+			/* Not used in this test, but required for NSSDIR_OPTS */
+			continue;
+		case OPT_SEEDBITS:
+			expected_seedbits = optarg_seedbits(logger);
+			seen_seedbits = true;
+			continue;
+		case OPT_SEEDDEV:
+			optarg_seeddev(logger);
+			expected_seeddev = optarg;
+			seen_seeddev = true;
+			continue;
+		case OPT_HELP:
+			optarg_usage("ipsec _seedbitscheck", "[--seedbits <number>] [--seeddev <device>]", "");
+		default:
+			bad_case(c);
+		}
+	}
+
+	if (!seen_seedbits) {
+		fprintf(stderr, "seedbits option not provided\n");
+		exit(1);
+	}
+
+	uintmax_t seedbits = config_setup_option(KBF_SEEDBITS);
+	printf("seedbits=%ju\n", seedbits);
+	if (seedbits == 0) {
+		exit(1);
+	}
+	if (seedbits != expected_seedbits) {
+		fprintf(stderr, "seedbits mismatch: expected %ju, got %ju\n",
+			expected_seedbits, seedbits);
+		exit(1);
+	}
+
+	if (seen_seeddev) {
+		const char *seeddev = config_setup_string(KSF_SEEDDEV);
+		printf("seeddev=%s\n", seeddev ? seeddev : "(null)");
+		if (seeddev == NULL) {
+			fprintf(stderr, "seeddev not stored in config\n");
+			exit(1);
+		}
+		if (expected_seeddev && strcmp(seeddev, expected_seeddev) != 0) {
+			fprintf(stderr, "seeddev mismatch: expected %s, got %s\n",
+				expected_seeddev, seeddev);
+			exit(1);
+		}
+	}
+
+	exit(0);
+}


### PR DESCRIPTION
fixes #2707 

**Summary of Changes**

Centralized --seedbits handling by adding optarg_seedbits() alongside existing NSS-related OPTARG helpers.

Replaced duplicated --seedbits parsing in pluto, ecdsasigkey, eddsasigkey, and rsasigkey with the shared helper.

Kept NSS/FIPS behavior correct by centralizing basic validation while leaving FIPS checks after NSS initialization where needed.

Added repo-style KVM test coverage with testing/programs/seedbitscheck, a Pluto wrapper test, and updated TESTLIST.