### PR TITLE
pluto: add rate limit for UDP logs and expand test coverage

### DIFF
--- a/programs/pluto/iface_udp.c
+++ b/programs/pluto/iface_udp.c
@@ -263,9 +263,8 @@ struct msg_digest *unpack_udp_packet(struct logger *logger,
 		 * can reach this point. Complain and discard them.
 		 * Possibly too if the NAT mapping vanished on the initiator NAT gw ?
 		 */
-		endpoint_buf eb;
-		ldbg(logger, "NAT-T keep-alive (bogus ?) should not reach this point. Ignored. Sender: %s",
-		    str_endpoint(&sender, &eb)); /* sensitive? */
+		limited_llog(logger, MD_LOG_LIMITER, "NAT-T keep-alive");
+		pstats_ike_mangled++;
 		return NULL;
 	}
 

--- a/programs/pluto/iface_udp.c
+++ b/programs/pluto/iface_udp.c
@@ -45,6 +45,7 @@
 #include "state_db.h"		/* for state_by_ike_spis() */
 #include "log.h"
 #include "log_limiter.h"
+#include "pluto_stats.h"
 #include "ip_info.h"
 #include "ip_sockaddr.h"
 
@@ -223,14 +224,16 @@ struct msg_digest *unpack_udp_packet(struct logger *logger,
 		uint32_t non_esp;
 
 		if (packet.len < (int)sizeof(uint32_t)) {
-			llog(RC_LOG, logger, "too small packet (%zd)",
-			     packet.len);
+			limited_llog(logger, MD_LOG_LIMITER, "too small packet (%zd)",
+				     packet.len);
+			pstats_ike_mangled++;
 			return NULL;
 		}
 
 		memcpy(&non_esp, packet.ptr, sizeof(uint32_t));
 		if (non_esp != 0) {
-			llog(RC_LOG, logger, "has no Non-ESP marker");
+			limited_llog(logger, MD_LOG_LIMITER, "has no Non-ESP marker");
+			pstats_ike_mangled++;
 			return NULL;
 		}
 		packet.ptr += sizeof(uint32_t);
@@ -246,8 +249,9 @@ struct msg_digest *unpack_udp_packet(struct logger *logger,
 		if (ifp->esp_encapsulation_enabled &&
 		    packet.len >= NON_ESP_MARKER_SIZE &&
 		    memeq(packet.ptr, non_ESP_marker, NON_ESP_MARKER_SIZE)) {
-			llog(RC_LOG, logger,
-			     "mangled with potential spurious non-esp marker");
+			limited_llog(logger, MD_LOG_LIMITER,
+				     "mangled with potential spurious non-esp marker");
+			pstats_ike_mangled++;
 			return NULL;
 		}
 	}

--- a/testing/pluto/impair-41-log-rate-limit/description.txt
+++ b/testing/pluto/impair-41-log-rate-limit/description.txt
@@ -1,3 +1,8 @@
 IKEv2: force the log-limiter code to kick in
 
-- west keeps initiating bogs exchanges
+- west sends crafted UDP packets to east on both port 500 and port 4500
+- exercises iface_udp.c paths: too-small, no Non-ESP marker, spurious
+  non-ESP marker, NAT-T keep-alive
+- exercises demux.c path: mangled IKE header
+- verifies rate-limiter sentinel fires at limit and suppresses beyond
+- verifies pstats_ike_mangled increments even when logs are suppressed

--- a/testing/pluto/impair-41-log-rate-limit/description.txt
+++ b/testing/pluto/impair-41-log-rate-limit/description.txt
@@ -1,8 +1,16 @@
 IKEv2: force the log-limiter code to kick in
 
-- west sends crafted UDP packets to east on both port 500 and port 4500
+- west sends crafted UDP packets to east on both port 500 and port
+  4500
+
+  This includes an empty packet, which is correctly interpreted as a
+  NAT keepalive.
+
 - exercises iface_udp.c paths: too-small, no Non-ESP marker, spurious
   non-ESP marker, NAT-T keep-alive
+
 - exercises demux.c path: mangled IKE header
+
 - verifies rate-limiter sentinel fires at limit and suppresses beyond
+
 - verifies pstats_ike_mangled increments even when logs are suppressed

--- a/testing/pluto/impair-41-log-rate-limit/east.console.txt
+++ b/testing/pluto/impair-41-log-rate-limit/east.console.txt
@@ -14,19 +14,33 @@ east #
  echo "initdone"
 initdone
 east #
- # On EAST this will show the dropped packets and the log-limiter
+ # Grep east's log for all rate-limited UDP events and the limiter sentinel.
 east #
- # reaching its limit.  Because of a quirk in the implementation, the
+ # Columns: plain RC_LOG lines start with 'packet from',
 east #
- # limit reached message appears before the final log.  After the final
+ #          debug-stream (over-limit) lines start with '| ',
 east #
- # message there should be a debug-log message.
+ #          impair lines start with 'impair: '
 east #
- grep -e '^packet from' -e '^| dropping packet with mangled IKE header' -e '^impair: ' /tmp/pluto.log
+ grep -e '^packet from' \
+east #
+      -e '^| ' \
+east #
+      -e '^impair: ' \
+east #
+      /tmp/pluto.log
 impair: log_rate_limit: no -> 2
+packet from 192.1.2.45:EPHEM: too small packet (2)
 packet from 192.1.2.45:EPHEM: has no Non-ESP marker
-packet from 192.1.2.45:EPHEM: dropping packet with mangled IKE header: not enough room in input packet for ISAKMP Message (remain=1, sd->size=28)
 packet from 192.1.2.45:EPHEM: message digest rate limited log reached limit of 2 entries
+packet from 192.1.2.45:EPHEM: mangled with potential spurious non-esp marker
+| NAT-T keep-alive
+packet from 192.1.2.45:EPHEM: dropping packet with mangled IKE header: not enough room in input packet for ISAKMP Message (remain=1, sd->size=28)
 packet from 192.1.2.45:EPHEM: dropping packet with mangled IKE header: not enough room in input packet for ISAKMP Message (remain=2, sd->size=28)
 | dropping packet with mangled IKE header: not enough room in input packet for ISAKMP Message (remain=3, sd->size=28)
+east #
+ # Verify pstats_ike_mangled reflects all drops including suppressed ones.
+east #
+ ipsec globalstatus | grep total.ike.mangled
+total.ike.mangled=7
 east #

--- a/testing/pluto/impair-41-log-rate-limit/east.console.txt
+++ b/testing/pluto/impair-41-log-rate-limit/east.console.txt
@@ -9,7 +9,7 @@ east #
  ipsec add common
 "common": added oriented IKEv2 connection
 east #
- ipsec whack --impair log_rate_limit:2
+ ipsec whack --impair log_rate_limit:6
 east #
  echo "initdone"
 initdone
@@ -22,25 +22,14 @@ east #
 east #
  #          impair lines start with 'impair: '
 east #
- grep -e '^packet from' \
-east #
-      -e '^| ' \
-east #
-      -e '^impair: ' \
-east #
-      /tmp/pluto.log
-impair: log_rate_limit: no -> 2
+ grep -e '^packet from' -e '^| dropping packet with mangled IKE header' -e '^impair: ' /tmp/pluto.log
+impair: log_rate_limit: no -> 6
 packet from 192.1.2.45:EPHEM: too small packet (2)
 packet from 192.1.2.45:EPHEM: has no Non-ESP marker
-packet from 192.1.2.45:EPHEM: message digest rate limited log reached limit of 2 entries
 packet from 192.1.2.45:EPHEM: mangled with potential spurious non-esp marker
-| NAT-T keep-alive
-packet from 192.1.2.45:EPHEM: dropping packet with mangled IKE header: not enough room in input packet for ISAKMP Message (remain=1, sd->size=28)
-packet from 192.1.2.45:EPHEM: dropping packet with mangled IKE header: not enough room in input packet for ISAKMP Message (remain=2, sd->size=28)
-| dropping packet with mangled IKE header: not enough room in input packet for ISAKMP Message (remain=3, sd->size=28)
-east #
- # Verify pstats_ike_mangled reflects all drops including suppressed ones.
-east #
- ipsec globalstatus | grep total.ike.mangled
-total.ike.mangled=7
+packet from 192.1.2.45:EPHEM: NAT-T keep-alive
+packet from 192.1.2.45:EPHEM: dropping packet with mangled IKE header: not enough room in input packet for ISAKMP Message (remain=5, sd->size=28)
+packet from 192.1.2.45:EPHEM: message digest rate limited log reached limit of 6 entries
+packet from 192.1.2.45:EPHEM: dropping packet with mangled IKE header: not enough room in input packet for ISAKMP Message (remain=6, sd->size=28)
+| dropping packet with mangled IKE header: not enough room in input packet for ISAKMP Message (remain=7, sd->size=28)
 east #

--- a/testing/pluto/impair-41-log-rate-limit/eastinit.sh
+++ b/testing/pluto/impair-41-log-rate-limit/eastinit.sh
@@ -2,5 +2,5 @@
 ipsec start
 ../../guestbin/wait-until-pluto-started
 ipsec add common
-ipsec whack --impair log_rate_limit:2
+ipsec whack --impair log_rate_limit:6
 echo "initdone"

--- a/testing/pluto/impair-41-log-rate-limit/final.sh
+++ b/testing/pluto/impair-41-log-rate-limit/final.sh
@@ -1,6 +1,5 @@
-# On EAST this will show the dropped packets and the log-limiter
-# reaching its limit.  Because of a quirk in the implementation, the
-# limit reached message appears before the final log.  After the final
-# message there should be a debug-log message.
-
+# Grep east's log for all rate-limited UDP events and the limiter sentinel.
+# Columns: plain RC_LOG lines start with 'packet from',
+#          debug-stream (over-limit) lines start with '| ',
+#          impair lines start with 'impair: '
 grep -e '^packet from' -e '^| dropping packet with mangled IKE header' -e '^impair: ' /tmp/pluto.log

--- a/testing/pluto/impair-41-log-rate-limit/ipsec.conf
+++ b/testing/pluto/impair-41-log-rate-limit/ipsec.conf
@@ -10,6 +10,7 @@ config setup
 	logappend=no
 	plutodebug=all,crypt
 	dumpdir=/tmp
+	keep-alive=0
 
 conn common
 	left=192.1.2.45

--- a/testing/pluto/impair-41-log-rate-limit/west.console.txt
+++ b/testing/pluto/impair-41-log-rate-limit/west.console.txt
@@ -4,35 +4,37 @@ west #
  echo "initdone"
 initdone
 west #
- # Send different sized packets so that the limited log can be
+ # ── port 4500 (esp_encapsulation_enabled) ──────────────────────────────────
 west #
- # recognized based on the packet length.
+ # iface_udp.c: "too small packet" — packet shorter than 4 bytes (sizeof uint32_t)
 west #
- # This should tickle the log limit but doesn't see #2727
+ printf 'ab' | nc -4 -u 192.1.2.23 4500
 west #
- echo "asdf" | nc -4 -u 192.1.2.23 4500
+ # iface_udp.c: "has no Non-ESP marker" — first 4 bytes non-zero, no zero marker
 west #
- # This tickles demux.c's code.
+ printf '\x01\x02\x03\x04rest' | nc -4 -u 192.1.2.23 4500
 west #
- # under limit
+ # iface_udp.c: "mangled with potential spurious non-esp marker"
 west #
- printf '\0\0\0\0a' | nc -4 -u 192.1.2.23 4500
+ # valid Non-ESP marker (4 zero bytes) followed by NON_ESP_MARKER_SIZE more zero bytes
 west #
- # at limit
+ printf '\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0' | nc -4 -u 192.1.2.23 4500
 west #
- printf '\0\0\0\0as' | nc -4 -u 192.1.2.23 4500
+ # iface_udp.c: "NAT-T keep-alive" — single 0xff byte with Non-ESP marker prefix
 west #
- # over limit -> debug log
+ printf '\0\0\0\0\xff' | nc -4 -u 192.1.2.23 4500
 west #
- printf '\0\0\0\0asd' | nc -4 -u 192.1.2.23 4500
+ # ── port 500 (plain IKE, no esp_encapsulation) ──────────────────────────────
 west #
- # On EAST this will show the dropped packets and the log-limiter
+ # demux.c: "dropping packet with mangled IKE header" — under limit
 west #
- # reaching its limit.  Because of a quirk in the implementation, the
+ printf '\0\0\0\0a' | nc -4 -u 192.1.2.23 500
 west #
- # limit reached message appears before the final log.  After the final
+ # demux.c: at limit — sentinel fires here
 west #
- # message there should be a debug-log message.
+ printf '\0\0\0\0as' | nc -4 -u 192.1.2.23 500
 west #
- grep -e '^packet from' -e '^| dropping packet with mangled IKE header' -e '^impair: ' /tmp/pluto.log
+ # demux.c: over limit — suppressed to debug log
+west #
+ printf '\0\0\0\0asd' | nc -4 -u 192.1.2.23 500
 west #

--- a/testing/pluto/impair-41-log-rate-limit/west.console.txt
+++ b/testing/pluto/impair-41-log-rate-limit/west.console.txt
@@ -38,3 +38,13 @@ west #
 west #
  printf '\0\0\0\0asd' | nc -4 -u 192.1.2.23 500
 west #
+ # Grep east's log for all rate-limited UDP events and the limiter sentinel.
+west #
+ # Columns: plain RC_LOG lines start with 'packet from',
+west #
+ #          debug-stream (over-limit) lines start with '| ',
+west #
+ #          impair lines start with 'impair: '
+west #
+ grep -e '^packet from' -e '^| dropping packet with mangled IKE header' -e '^impair: ' /tmp/pluto.log
+west #

--- a/testing/pluto/impair-41-log-rate-limit/westrun.sh
+++ b/testing/pluto/impair-41-log-rate-limit/westrun.sh
@@ -1,14 +1,21 @@
-# Send different sized packets so that the limited log can be
-# recognized based on the packet length.
+# ── port 4500 (esp_encapsulation_enabled) ──────────────────────────────────
+# iface_udp.c: "too small packet" — packet shorter than 4 bytes (sizeof uint32_t)
+printf 'ab' | nc -4 -u 192.1.2.23 4500
 
-# This should tickle the log limit but doesn't see #2727
-echo "asdf" | nc -4 -u 192.1.2.23 4500
+# iface_udp.c: "has no Non-ESP marker" — first 4 bytes non-zero, no zero marker
+printf '\x01\x02\x03\x04rest' | nc -4 -u 192.1.2.23 4500
 
-# This tickles demux.c's code.
+# iface_udp.c: "mangled with potential spurious non-esp marker"
+# valid Non-ESP marker (4 zero bytes) followed by NON_ESP_MARKER_SIZE more zero bytes
+printf '\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0' | nc -4 -u 192.1.2.23 4500
 
-# under limit
-printf '\0\0\0\0a' | nc -4 -u 192.1.2.23 4500
-# at limit
-printf '\0\0\0\0as' | nc -4 -u 192.1.2.23 4500
-# over limit -> debug log
-printf '\0\0\0\0asd' | nc -4 -u 192.1.2.23 4500
+# iface_udp.c: "NAT-T keep-alive" — single 0xff byte with Non-ESP marker prefix
+printf '\0\0\0\0\xff' | nc -4 -u 192.1.2.23 4500
+
+# ── port 500 (plain IKE, no esp_encapsulation) ──────────────────────────────
+# demux.c: "dropping packet with mangled IKE header" — under limit
+printf '\0\0\0\0a' | nc -4 -u 192.1.2.23 500
+# demux.c: at limit — sentinel fires here
+printf '\0\0\0\0as' | nc -4 -u 192.1.2.23 500
+# demux.c: over limit — suppressed to debug log
+printf '\0\0\0\0asd' | nc -4 -u 192.1.2.23 500


### PR DESCRIPTION
This change adds rate limiting to always-printing UDP logs in iface_udp.c
using MD_LOG_LIMITER and updates the NAT-T keep-alive log to use
limited_llog().

All early-exit UDP paths now consistently increment pstats_ike_mangled
and use rate-limited logging.

The impair-41-ikev2-log-rate-limit test is expanded to cover both
ports 4500 (NAT-T) and 500 (IKE), ensuring rate-limiter behavior
and statistics are validated across all relevant paths.