### PR TITLE
ikev2: warn when IKEv1 xauth parameters are specified

### DIFF
--- a/programs/pluto/extract.c
+++ b/programs/pluto/extract.c
@@ -1663,6 +1663,18 @@ static diag_t extract_host_end(enum end end,
 			     YN_NO, &d, verbose);
 	host_config->xauth.username =
 		extract_string(kv(wm, end, KWS_USERNAME), verbose);
+
+	if (ike_version == IKEv2) {
+		if (src->we_xauthserver != NULL) {
+			vwarning("IKEv2 connection ignores \"%sxauthserver=%s\"", 
+				leftright, src->we_xauthserver);
+		}
+		if (src->we_xauthclient != NULL) {
+			vwarning("IKEv2 connection ignores \"%sxauthclient=%s\"", 
+				leftright, src->we_xauthclient);
+		}
+	}
+
 	enum eap_options autheap =
 		extract_sparse_name(kv(wm, end, KWS_AUTHEAP),
 				    /*value_when_unset*/IKE_EAP_NONE,
@@ -4300,6 +4312,17 @@ diag_t extract_connection(const struct whack_message *wm,
 					    /*value_when_unset*/XAUTHFAIL_HARD,
 					    &xauthfail_names,
 					    &d, verbose);
+
+		if (ike_version == IKEv2) {
+			if (wm->wm_xauthby != NULL) {
+				vwarning("IKEv2 connection ignores xauthby=%s",
+					 wm->wm_xauthby);
+			}
+			if (wm->wm_xauthfail != NULL) {
+				vwarning("IKEv2 connection ignores xauthfail=%s",
+					 wm->wm_xauthfail);
+			}
+		}
 
 		/* RFC 8784 and draft-ietf-ipsecme-ikev2-qr-alt-04 */
 		config->ppk_ids = clone_str(wm->wm_ppk_ids, "connection ppk_ids");

--- a/testing/pluto/TESTLIST
+++ b/testing/pluto/TESTLIST
@@ -176,6 +176,7 @@ kvmplutotest	addconn-50-send-vendorid			good
 kvmplutotest	addconn-51-config-setup-dns-resolver		good
 kvmplutotest	addconn-52-clones				good
 kvmplutotest	addconn-53-config-setup-ike-socket		good
+kvmplutotest    addconn-54-xauth          good
 
 #################################################################
 # IKEv2 tests

--- a/testing/pluto/addconn-54-xauth/description.txt
+++ b/testing/pluto/addconn-54-xauth/description.txt
@@ -1,0 +1,1 @@
+test IKEv2 connection with IKEv1 xauth parameters

--- a/testing/pluto/addconn-54-xauth/north.conf
+++ b/testing/pluto/addconn-54-xauth/north.conf
@@ -1,0 +1,22 @@
+
+config setup
+	logfile=/tmp/pluto.log
+	logtime=no
+	logappend=no
+	dumpdir=/tmp
+	plutodebug=all
+
+conn ikev2-north-east
+	keyexchange=ikev2
+	left=192.1.3.33
+	leftid=@GroupID
+	rightxauthserver=yes
+	leftxauthclient=yes
+	rightmodecfgserver=yes
+	leftmodecfgclient=yes
+	right=192.1.2.23
+	rightsubnet=192.0.2.0/24
+	modecfgpull=yes
+	modecfgdns="1.2.3.4, 5.6.7.8"
+	rightid=@east
+	authby=secret

--- a/testing/pluto/addconn-54-xauth/north.console.txt
+++ b/testing/pluto/addconn-54-xauth/north.console.txt
@@ -1,0 +1,12 @@
+/testing/guestbin/swan-prep
+north #
+ ipsec start
+Redirecting to: [initsystem]
+north #
+ ../../guestbin/wait-until-pluto-started
+north #
+ ipsec add ikev2-north-east
+warning: "ikev2-north-east": IKEv2 connection ignores "leftxauthclient=yes"
+warning: "ikev2-north-east": IKEv2 connection ignores "rightxauthserver=yes"
+"ikev2-north-east": added oriented IKEv2 connection
+north #

--- a/testing/pluto/addconn-54-xauth/north.sh
+++ b/testing/pluto/addconn-54-xauth/north.sh
@@ -1,0 +1,4 @@
+/testing/guestbin/swan-prep
+ipsec start
+../../guestbin/wait-until-pluto-started
+ipsec add ikev2-north-east

--- a/testing/pluto/ikev2-cp-01-resolvconf/east.conf
+++ b/testing/pluto/ikev2-cp-01-resolvconf/east.conf
@@ -21,8 +21,6 @@ conn eastnet-any
 	rightid=@GroupID
 	modecfgdns="1.2.3.4, 5.6.7.8"
 	modecfgdomains="libreswan.org"
-	leftxauthserver=yes
-	rightxauthclient=yes
 	leftmodecfgserver=yes
 	rightmodecfgclient=yes
 	modecfgpull=yes

--- a/testing/pluto/ikev2-cp-01-systemd-resolved/east.conf
+++ b/testing/pluto/ikev2-cp-01-systemd-resolved/east.conf
@@ -21,8 +21,6 @@ conn eastnet-any
 	rightid=@GroupID
 	modecfgdns="1.2.3.4, 5.6.7.8"
 	modecfgdomains="libreswan.org"
-	leftxauthserver=yes
-	rightxauthclient=yes
 	leftmodecfgserver=yes
 	rightmodecfgclient=yes
 	modecfgpull=yes


### PR DESCRIPTION
Fixes #2018 

Warn when IKEv1 xauth parameters are specified in an IKEv2 connection.

Example output:

```
north #
 ipsec add ikev2-north-east
warning: "ikev2-north-east": IKEv2 connection ignores leftxauthclient=yes
warning: "ikev2-north-east": IKEv2 connection ignores rightxauthserver=yes
"ikev2-north-east": added oriented IKEv2 connection
```