### PR TITLE
linux_audit: drop duplicate Linux audit support log

### DIFF
--- a/programs/pluto/linux_audit.c
+++ b/programs/pluto/linux_audit.c
@@ -80,7 +80,6 @@ bool linux_audit_enabled(void)
 
 bool linux_audit_init(bool do_audit, struct logger *logger)
 {
-	llog(RC_LOG, logger, "Linux audit support [enabled]");
 	/*
 	 * Always probe for audit support!  Just don't always log
 	 * records.


### PR DESCRIPTION
Fixes #2735

Before = libcap-ng support [enabled]
        Linux audit support [enabled]
        Linux audit support [enabled]
        leak-detective enabled

After =  libcap-ng support [enabled]
        Linux audit support [enabled]
        leak-detective enabled

Dropped the line in linux_audit.c
plutomain.c already logs the correct status