### PR TITLE
Fix #1604: prevent triple responder logs (‘no proposal chosen’)

### DIFF
--- a/programs/pluto/ikev2_child.c
+++ b/programs/pluto/ikev2_child.c
@@ -598,7 +598,7 @@ v2_notification_t process_childs_v2SA_payload(const char *what,
 				 child_proposals, verbose);
 	if (n != v2N_NOTHING_WRONG) {
 		name_buf nb;
-		vlog("%s failed, responder SA processing returned %s",
+		vdbg("%s failed, responder SA processing returned %s",
 		     what, str_enum_short(&v2_notification_names, n, &nb));
 		return n;
 	}

--- a/testing/pluto/ikev2-leak-01-db_v2_prop_conj/east.console.txt
+++ b/testing/pluto/ikev2-leak-01-db_v2_prop_conj/east.console.txt
@@ -14,6 +14,6 @@ east #
  echo "initdone"
 initdone
 east #
- grep '^[^|].*no local proposal' /tmp/pluto.log
+ grep -Ee '^[^|].*(no local proposal|NO_PROPOSAL_CHOSEN)' /tmp/pluto.log
 "westnet-eastnet-ipv4-psk-ikev2" #2: no local proposal matches remote proposals 1:ESP:ENCR=AES_CBC_128;ENCR=AES_CBC_256;INTEG=HMAC_SHA1_96;ESN=YES;ESN=NO
 east #

--- a/testing/pluto/ikev2-leak-01-db_v2_prop_conj/east.console.txt
+++ b/testing/pluto/ikev2-leak-01-db_v2_prop_conj/east.console.txt
@@ -14,6 +14,6 @@ east #
  echo "initdone"
 initdone
 east #
- grep '^[^|].*NO_PROPOSAL_CHOSEN' /tmp/pluto.log
-"westnet-eastnet-ipv4-psk-ikev2" #2: IKE_AUTH responder matching remote ESP/AH proposals failed, responder SA processing returned NO_PROPOSAL_CHOSEN
+ grep '^[^|].*no local proposal' /tmp/pluto.log
+"westnet-eastnet-ipv4-psk-ikev2" #2: no local proposal matches remote proposals 1:ESP:ENCR=AES_CBC_128;ENCR=AES_CBC_256;INTEG=HMAC_SHA1_96;ESN=YES;ESN=NO
 east #

--- a/testing/pluto/ikev2-leak-01-db_v2_prop_conj/final.sh
+++ b/testing/pluto/ikev2-leak-01-db_v2_prop_conj/final.sh
@@ -1,1 +1,1 @@
-grep '^[^|].*NO_PROPOSAL_CHOSEN' /tmp/pluto.log
+grep '^[^|].*no local proposal' /tmp/pluto.log

--- a/testing/pluto/ikev2-leak-01-db_v2_prop_conj/final.sh
+++ b/testing/pluto/ikev2-leak-01-db_v2_prop_conj/final.sh
@@ -1,1 +1,1 @@
-grep '^[^|].*no local proposal' /tmp/pluto.log
+grep -Ee '^[^|].*(no local proposal|NO_PROPOSAL_CHOSEN)' /tmp/pluto.log

--- a/testing/pluto/ikev2-leak-01-db_v2_prop_conj/west.console.txt
+++ b/testing/pluto/ikev2-leak-01-db_v2_prop_conj/west.console.txt
@@ -29,7 +29,7 @@ west #
  echo done
 done
 west #
- grep '^[^|].*NO_PROPOSAL_CHOSEN' /tmp/pluto.log
+ grep -Ee '^[^|].*(no local proposal|NO_PROPOSAL_CHOSEN)' /tmp/pluto.log
 "westnet-eastnet-ipv4-psk-ikev2" #1: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,N(NO_PROPOSAL_CHOSEN)}
 "westnet-eastnet-ipv4-psk-ikev2" #2: IKE_AUTH response rejected Child SA with NO_PROPOSAL_CHOSEN
 west #


### PR DESCRIPTION
Fix #1604: cleanup triple responder logs (move it to debug mode). Updated testsuite ikev2-leak-01-db_v2_prop_conj as it expects this log.

Signed-off-by: Shubham Kumar [chmodshubham@gmail.com](mailto:chmodshubham@gmail.com)