### PR TITLE
fix #2713: add loglimit configuration option to allow disabling log rate limiting

### DIFF
--- a/configs/d.ipsec.conf/setup/loglimit.xml
+++ b/configs/d.ipsec.conf/setup/loglimit.xml
@@ -1,0 +1,25 @@
+<varlistentry id='setup.loglimit'>
+  <term>
+    <option>loglimit=&yn_option;</option>
+  </term>
+  <listitem>
+    <para>
+      Whether pluto's internal log rate limiting is enabled.  When
+      enabled, pluto limits the number of repetitive log messages
+      (such as malformed packets or bad certificates) to prevent
+      excessive logging under heavy load.  Setting this to
+      <option>&no;</option> disables all rate limiters, allowing every
+      log message to be emitted.  This is useful for debugging or
+      when full log visibility is required.
+    </para>
+    <para>
+      The rate limit counters are reset once every hour.
+    </para>
+    <para>
+      The default is &yes;.
+    </para>
+    <para>
+      This option was added in Libreswan 5.4.
+    </para>
+  </listitem>
+</varlistentry>

--- a/configs/ipsec.conf.5.xml
+++ b/configs/ipsec.conf.5.xml
@@ -176,6 +176,7 @@
 <!ENTITY setup.listen-udp SYSTEM "d.ipsec.conf/setup/listen-udp.xml">
 <!ENTITY setup.logappend SYSTEM "d.ipsec.conf/setup/logappend.xml">
 <!ENTITY setup.logfile SYSTEM "d.ipsec.conf/setup/logfile.xml">
+<!ENTITY setup.loglimit SYSTEM "d.ipsec.conf/setup/loglimit.xml">
 <!ENTITY setup.logip SYSTEM "d.ipsec.conf/setup/logip.xml">
 <!ENTITY setup.logtime SYSTEM "d.ipsec.conf/setup/logtime.xml">
 <!ENTITY setup.max-halfopen-ike SYSTEM "d.ipsec.conf/setup/max-halfopen-ike.xml">
@@ -437,6 +438,7 @@
       &setup.logfile;
       &setup.logappend;
       &setup.logip;
+      &setup.loglimit;
       &setup.audit-log;
       &setup.logtime;
       &setup.ddos-mode;

--- a/include/ipsecconf/setup.h
+++ b/include/ipsecconf/setup.h
@@ -65,6 +65,7 @@ enum config_setup_keyword {
 	KYN_LOGTIME,
 	KYN_LOGAPPEND,
 	KYN_LOGIP,
+	KYN_LOGLIMIT,
 	KYN_LOGSTDERR, /*no matching option*/
 	KYN_AUDIT_LOG,
 	KBF_IKE_SOCKET_BUFSIZE,

--- a/lib/libswan/ipsecconf/setup.c
+++ b/lib/libswan/ipsecconf/setup.c
@@ -127,6 +127,7 @@ static const char *const config_setup_defaults[CONFIG_SETUP_KEYWORD_ROOF] = {
 	[KSF_DNSSEC_ROOTKEY_FILE] = DEFAULT_DNSSEC_ROOTKEY_FILE,
 #endif
 
+	[KYN_LOGLIMIT] = "yes",
 	[KYN_LOGIP] = "yes",
 	[KYN_LOGTIME] = "yes",
 	[KYN_LOGAPPEND] = "yes",
@@ -456,6 +457,7 @@ static const struct keyword_def config_setup_keyword[] = {
   K("plutodebug", kt_string, KSF_PLUTODEBUG),
 
   K("logfile",  kt_string,  KSF_LOGFILE),
+  K("loglimit",  kt_sparse_name,  KYN_LOGLIMIT, .sparse_names = &yn_option_names),
   K("logtime",  kt_sparse_name,  KYN_LOGTIME, .sparse_names = &yn_option_names),
   K("logappend",  kt_sparse_name,  KYN_LOGAPPEND, .sparse_names = &yn_option_names),
   K("logip",  kt_sparse_name,  KYN_LOGIP, .sparse_names = &yn_option_names),

--- a/programs/pluto/log_limiter.c
+++ b/programs/pluto/log_limiter.c
@@ -15,12 +15,14 @@
  */
 
 #include <pthread.h>    /* Must be the first include file; XXX: why? */
+#include <limits.h>     /* for UINT_MAX */
 
 #include "log_limiter.h"
 #include "log.h"
 
 #include "defs.h"
 #include "demux.h"
+#include "ipsecconf/setup.h"
 
 static global_timer_cb reset_log_limiter;	/* type check */
 
@@ -31,6 +33,7 @@ struct limiter {
 	const unsigned limit;
 	volatile unsigned count;
 	const char *what;
+	bool unlimited;
 };
 
 struct limiter log_limiters[LOG_LIMITER_ROOF] = {
@@ -58,6 +61,9 @@ struct limiter log_limiters[LOG_LIMITER_ROOF] = {
 
 static unsigned log_limit(const struct limiter *limiter)
 {
+	if (limiter->unlimited) {
+		return UINT_MAX;
+	}
 	if (impair.log_rate_limit.enabled) {
 		return impair.log_rate_limit.value;
 	}
@@ -155,4 +161,14 @@ void init_log_limiter(struct logger *logger)
 			      reset_log_limiter,
 			      RESET_LOG_LIMITER_FREQUENCY,
 			      logger);
+
+	// loglimit=no disables all rate limiters 
+	if (!config_setup_yn(KYN_LOGLIMIT)) {
+		FOR_EACH_ELEMENT(limiter, log_limiters) {
+			limiter->unlimited = true;
+		}
+		llog(RC_LOG, logger, "log rate limiting [disabled]");
+	} else {
+		llog(RC_LOG, logger, "log rate limiting [enabled]");
+	}
 }


### PR DESCRIPTION
- fix #2713: add loglimit configuration option to allow disabling log rate limiting.
- add man documentation for loglimit


Signed-off-by: Shubham Kumar [chmodshubham@gmail.com](mailto:chmodshubham@gmail.com) 