### PR TITLE
Fix #2717: add exampledir configuration option to support flexible sample file paths

### DIFF
--- a/configs/d.ipsec.conf/setup/exampledir.xml
+++ b/configs/d.ipsec.conf/setup/exampledir.xml
@@ -1,0 +1,21 @@
+<varlistentry id='setup.exampledir'>
+  <term>
+    <option>exampledir=&directory;</option>
+  </term>
+  <listitem>
+    <para>
+      Specifies the directory where libreswan's sample configuration
+      files are installed.  This includes files such as
+      <filename>ipsec.conf-sample</filename> and
+      <filename>ipsec.secrets-sample</filename>.
+      Packaging systems can use this option to specify where these
+      files are installed on the target system.
+    </para>
+    <para>
+      The default is <filename>@@EXAMPLE_IPSEC_SYSCONFDIR@@</filename>.
+    </para>
+    <para>
+      This option was added in Libreswan 5.4.
+    </para>
+  </listitem>
+</varlistentry>

--- a/configs/ipsec.conf.5.xml
+++ b/configs/ipsec.conf.5.xml
@@ -156,6 +156,7 @@
 <!ENTITY setup.dnssec-enable SYSTEM "d.ipsec.conf/setup/dnssec-enable.xml">
 <!ENTITY setup.dnssec-rootkey-file SYSTEM "d.ipsec.conf/setup/dnssec-rootkey-file.xml">
 <!ENTITY setup.dumpdir SYSTEM "d.ipsec.conf/setup/dumpdir.xml">
+<!ENTITY setup.exampledir SYSTEM "d.ipsec.conf/setup/exampledir.xml">
 <!ENTITY setup.expire-lifetime SYSTEM "d.ipsec.conf/setup/expire-lifetime.xml">
 <!ENTITY setup.expire-shunt-interval SYSTEM "d.ipsec.conf/setup/expire-shunt-interval.xml">
 <!ENTITY setup.global-redirect SYSTEM "d.ipsec.conf/setup/global-redirect.xml">
@@ -451,6 +452,7 @@
       &setup.statsbin;
       &setup.ipsecdir;
       &setup.nssdir;
+      &setup.exampledir;
       &setup.secretsfile;
       &setup.seccomp;
       &setup.dnssec-enable;

--- a/include/ipsecconf/setup.h
+++ b/include/ipsecconf/setup.h
@@ -44,6 +44,7 @@ enum config_setup_keyword {
 	KSF_SECRETSFILE,
 	KSF_MYVENDORID,
 	KSF_LOGFILE,
+	KSF_EXAMPLEDIR,
 	KSF_RUNDIR,		/* placeholder, no option */
 	KSF_DNSSEC_ROOTKEY_FILE,
 	KSF_DNSSEC_ANCHORS,

--- a/lib/libswan/ipsecconf/setup.c
+++ b/lib/libswan/ipsecconf/setup.c
@@ -89,6 +89,7 @@ static const char *const config_setup_defaults[CONFIG_SETUP_KEYWORD_ROOF] = {
 	[KSF_SECRETSFILE] = IPSEC_SECRETS,
 	[KSF_DUMPDIR] = IPSEC_RUNDIR,
 	[KSF_IPSECDIR] = IPSEC_CONFDDIR,
+	[KSF_EXAMPLEDIR] = EXAMPLE_IPSEC_SYSCONFDIR,
 	[KSF_MYVENDORID] = libreswan_vendorid,
 #ifdef USE_LOGFILE
 	[KSF_LOGFILE] = LOGFILE,
@@ -477,6 +478,7 @@ static const struct keyword_def config_setup_keyword[] = {
   K("dumpdir",  kt_string,  KSF_DUMPDIR),
   K("ipsecdir",  kt_string,  KSF_IPSECDIR),
   K("nssdir", kt_string, KSF_NSSDIR),
+  K("exampledir", kt_string, KSF_EXAMPLEDIR),
 
   /* these are only allowed on the command line */
   K("rundir", kt_string, KSF_RUNDIR, .validity = kv_optarg_only),

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -336,6 +336,7 @@ TRANSFORMS += -e 's:@@EXAMPLE_IPSEC_CONFDDIR@@:$(EXAMPLE_IPSEC_CONFDDIR):g'
 # libreswan's sample configuration files go into ...
 EXAMPLE_IPSEC_SYSCONFDIR ?= $(PREFIX)/share/doc/libreswan
 TRANSFORMS += -e 's:@@EXAMPLE_IPSEC_SYSCONFDIR@@:$(EXAMPLE_IPSEC_SYSCONFDIR):g'
+USERLAND_CFLAGS += -DEXAMPLE_IPSEC_SYSCONFDIR=\"$(EXAMPLE_IPSEC_SYSCONFDIR)\"
 
 # where per-conn pluto logs go
 VARDIR ?= /var

--- a/testing/guestbin/swan-prep
+++ b/testing/guestbin/swan-prep
@@ -304,6 +304,7 @@ if hostname != "nic":
     ipsecdir = get_configsetup("ipsecdir")
     configfile = get_configsetup("configfile")
     secretsfile = get_configsetup("secretsfile")
+    exampledir = get_configsetup("exampledir")
 
 if args.namespace:
     nsbasepath ="%s/NS/%s" % (testpath, hostname) #will create testpath/NS/hostname/*
@@ -423,10 +424,10 @@ if hostname != "nic":
             os.mkdir("/etc/ipsec.d/policies")
 
             copy_config_file(hostname, testpath, "/etc/ipsec.conf",
-                             default="/usr/local/share/doc/libreswan/ipsec.conf-sample",
+                             default=os.path.join(exampledir, "ipsec.conf-sample"),
                              nsprefix=nsbasepath)
             copy_config_file(hostname, testpath, "/etc/ipsec.secrets",
-                             default="/usr/local/share/doc/libreswan/ipsec.secrets-sample",
+                             default=os.path.join(exampledir, "ipsec.secrets-sample"),
                              nsprefix=nsbasepath)
 
         case "strongswan":


### PR DESCRIPTION
- Fix #2717: add exampledir configuration option to support flexible sample file paths
- add man documentation page

Signed-off-by: Shubham Kumar [chmodshubham@gmail.com](mailto:chmodshubham@gmail.com)