### PR TITLE
alloc: set leak detective to true by default

### DIFF
--- a/initsystems/docker/sysconfig.pluto.in
+++ b/initsystems/docker/sysconfig.pluto.in
@@ -1,2 +1,3 @@
 # Put extra pluto command line options you want here
+# Note: leak-detective is now always enabled by default
 PLUTO_OPTIONS=""

--- a/initsystems/rc.d/freebsd.sh
+++ b/initsystems/rc.d/freebsd.sh
@@ -15,7 +15,7 @@ required_modules=ipsec
 rcvar=${name}_enable
 
 command="@@LIBEXECDIR@@/pluto"
-command_args="--config @@IPSEC_CONF@@ --leak-detective"
+command_args="--config @@IPSEC_CONF@@"
 required_files="@@IPSEC_CONF@@"
 
 pidfile="@@RUNDIR@@/${name}.pid"

--- a/initsystems/rc.d/netbsd.sh
+++ b/initsystems/rc.d/netbsd.sh
@@ -21,7 +21,7 @@ name="pluto"
 rcvar=$name
 pidfile="@@RUNDIR@@/${name}.pid"
 command="@@LIBEXECDIR@@/pluto"
-command_args="--config @@IPSEC_CONF@@ --leak-detective"
+command_args="--config @@IPSEC_CONF@@"
 required_files="@@IPSEC_CONF@@"
 start_precmd="@@SBINDIR@@/ipsec checknss"
 

--- a/initsystems/rc.d/openbsd.sh
+++ b/initsystems/rc.d/openbsd.sh
@@ -1,7 +1,7 @@
 #!/bin/ksh
 
 daemon="@@LIBEXECDIR@@/pluto"
-daemon_flags="--config @@IPSEC_CONF@@ --leak-detective"
+daemon_flags="--config @@IPSEC_CONF@@"
 
 . /etc/rc.d/rc.subr
 

--- a/initsystems/sysvinit/sysconfig.pluto.in
+++ b/initsystems/sysvinit/sysconfig.pluto.in
@@ -1,2 +1,3 @@
 # Put extra pluto command line options you want here
-PLUTO_OPTIONS=" "
+# Note: leak-detective is now always enabled by default
+PLUTO_OPTIONS=""

--- a/initsystems/upstart/default.pluto.in
+++ b/initsystems/upstart/default.pluto.in
@@ -1,2 +1,3 @@
 # Put extra pluto command line options you want here
+# Note: leak-detective is now always enabled by default
 PLUTO_OPTIONS=""

--- a/lib/libswan/alloc.c
+++ b/lib/libswan/alloc.c
@@ -31,7 +31,7 @@
 
 #include "lswalloc.h"
 
-bool leak_detective = false;	/* must not change after first alloc! */
+bool leak_detective = true;	/* default enabled; --no-leak-detective temporarily disables - see issue #2725 */
 
 /*
  * memory allocation
@@ -130,9 +130,7 @@ static union mhdr *pmhdr_where(void *ptr, where_t where)
 void pmemory_where(void *ptr, where_t where)
 {
 	passert(ptr != NULL);
-	if (leak_detective) {
-		pmhdr_where(ptr, where);
-	}
+	pmhdr_where(ptr, where);
 }
 
 /* protects updates to the leak-detective linked list */
@@ -183,27 +181,19 @@ static void *allocate(void *(*alloc)(size_t), size_t size, const char *name)
 		size = 1;
 	}
 
-	if (leak_detective) {
-		/* fail on overflow */
-		if (sizeof(union mhdr) + size < size)
-			return NULL;
+	/* fail on overflow */
+	if (sizeof(union mhdr) + size < size)
+		return NULL;
 
-		p = alloc(sizeof(union mhdr) + size);
-	} else {
-		p = alloc(size);
-	}
+	p = alloc(sizeof(union mhdr) + size);
 
 	if (p == NULL) {
 		llog_passert(&global_logger, HERE,
 			     "unable to allocate %zu bytes for %s", size, name);
 	}
 
-	if (leak_detective) {
-		install_allocation(p, size, name);
-		return p + 1;
-	} else {
-		return p;
-	}
+	install_allocation(p, size, name);
+	return p + 1;
 }
 
 void *uninitialized_malloc(size_t size, const char *name)
@@ -213,18 +203,14 @@ void *uninitialized_malloc(size_t size, const char *name)
 
 void pfree(void *ptr)
 {
-	if (leak_detective) {
-		passert(ptr != NULL);
-		union mhdr *p = pmhdr_where(ptr, HERE);
-		remove_allocation(p);
-		/* stomp on memory!   Is another byte value better? */
-		memset(p, 0xEF, sizeof(union mhdr) + p->i.size);
-		/* put back magic */
-		p->i.magic = ~LEAK_MAGIC;
-		free(p);
-	} else {
-		free(ptr);
-	}
+	passert(ptr != NULL);
+	union mhdr *p = pmhdr_where(ptr, HERE);
+	remove_allocation(p);
+	/* stomp on memory!   Is another byte value better? */
+	memset(p, 0xEF, sizeof(union mhdr) + p->i.size);
+	/* put back magic */
+	p->i.magic = ~LEAK_MAGIC;
+	free(p);
 }
 
 bool report_leaks(struct logger *logger)
@@ -371,26 +357,23 @@ void *uninitialized_realloc(void *ptr, size_t new_size, const char *name)
 {
 	if (ptr == NULL) {
 		return uninitialized_malloc(new_size, name);
-	} else if (leak_detective) {
-		union mhdr *p = pmhdr_where(ptr, HERE);
-		remove_allocation(p);
-		p = realloc(p, sizeof(union mhdr) + new_size);
-		if (p == NULL) {
-			llog_passert(&global_logger, HERE,
-				     "unable to reallocate %zu bytes for %s", new_size, name);
-		}
-		install_allocation(p, new_size, name);
-		return p+1;
-	} else {
-		return realloc(ptr, new_size);
 	}
+	union mhdr *p = pmhdr_where(ptr, HERE);
+	remove_allocation(p);
+	p = realloc(p, sizeof(union mhdr) + new_size);
+	if (p == NULL) {
+		llog_passert(&global_logger, HERE,
+			     "unable to reallocate %zu bytes for %s", new_size, name);
+	}
+	install_allocation(p, new_size, name);
+	return p+1;
 }
 
 void realloc_bytes(void **ptr, size_t old_size, size_t new_size, const char *name)
 {
 	if (*ptr == NULL) {
 		passert(old_size == 0);
-	} else if (leak_detective) {
+	} else {
 		union mhdr *p = pmhdr_where(*ptr, HERE);
 		passert(p->i.size == old_size);
 	}

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -478,7 +478,8 @@ endif
 ifeq ($(INITSYSTEM),systemd)
 USE_SYSTEMD_WATCHDOG ?= true
 SD_RESTART_TYPE ?= on-failure
-SD_PLUTO_OPTIONS ?= --leak-detective
+# Note: leak-detective is now always enabled by default in the code
+SD_PLUTO_OPTIONS ?=
 SYSTEMUNITDIR ?= $(shell $(PKG_CONFIG) systemd --variable=systemdsystemunitdir)
 SYSTEMTMPFILESDIR ?= $(shell $(PKG_CONFIG) systemd --variable=tmpfilesdir)
 TMPFILESDIR ?= $(DESTDIR)$(SYSTEMTMPFILESDIR)

--- a/programs/pluto/ipsec-pluto.8.xml
+++ b/programs/pluto/ipsec-pluto.8.xml
@@ -29,7 +29,6 @@
       <sbr/>
       <arg choice="opt">--nofork</arg>
       <arg choice="opt">--rundir <replaceable>path</replaceable></arg>
-      <arg choice="opt">--leak-detective</arg>
       <arg choice="opt">--efence-protect</arg>
       <sbr/>
       <arg choice="opt">--stderrlog</arg>
@@ -195,16 +194,6 @@
 	      </variablelist>
 	    </para>
           </listitem>
-	</varlistentry>
-	<varlistentry>
-	  <term>
-	    <option>--leak-detective</option>
-	  </term>
-	  <listitem>
-	    <para>
-	      enable leak detective
-	    </para>
-	  </listitem>
 	</varlistentry>
 	<varlistentry>
 	  <term>

--- a/programs/pluto/libreswan.7.xml
+++ b/programs/pluto/libreswan.7.xml
@@ -803,9 +803,9 @@
 
       <para>
 	If you are investigating a potential memory leak in pluto,
-	start pluto with the --leak-detective option.  Before the leak
-	causes the system or pluto to die, shut down pluto in the regular
-	way. pluto will display a list of leaks it has detected.
+	shut down pluto in the regular way. pluto will display a list
+	of leaks it has detected, as leak-detective is now always
+	enabled by default.
       </para>
 
       <para>

--- a/programs/pluto/plutomain.c
+++ b/programs/pluto/plutomain.c
@@ -44,6 +44,7 @@
 #include "lswversion.h"
 #include "fips_mode.h"
 #include "lswnss.h"
+#include "lswalloc.h"
 #include "defs.h"
 #include "x509_ocsp.h"
 #include "server_fork.h"		/* for init_server_fork() */
@@ -394,6 +395,7 @@ enum opt {
 	OPT_VENDORID,
 	OPT_SELFTEST,
 	OPT_LEAK_DETECTIVE,
+	OPT_NO_LEAK_DETECTIVE,
 };
 
 const struct option optarg_options[] = {
@@ -413,7 +415,6 @@ const struct option optarg_options[] = {
 	{ REPLACE_OPT("foodgroupsdir", "ipsecdir", "3.9"), required_argument, NULL, OPT_IPSECDIR },	/* redundant spelling */
 	{ OPT("nssdir", "<dirname>"), required_argument, NULL, OPT_NSSDIR },	/* nss-tools use -d */
 	{ OPT("nhelpers", "<number>"), required_argument, NULL, OPT_NHELPERS },
-	{ OPT("leak-detective"), no_argument, NULL, OPT_LEAK_DETECTIVE },
 	{ OPT("efence-protect"), no_argument, NULL, OPT_EFENCE_PROTECT, },
 
 	{ OPT("dnssec-enable", "<bool>"), required_argument, NULL, OPT_DNSSEC_ENABLE },
@@ -506,6 +507,8 @@ const struct option optarg_options[] = {
 	{ OPT("debug", "help|<debug-flags>"), required_argument, NULL, OPT_DEBUG, },
 	{ OPT("impair", "help|<impairment>"), required_argument, NULL, OPT_IMPAIR, },
 	{ OPT("selftest"), no_argument, NULL, OPT_SELFTEST },
+	{ OPT("leak-detective"), optional_argument, NULL, OPT_LEAK_DETECTIVE },
+	{ OPT("no-leak-detective"), no_argument, NULL, OPT_NO_LEAK_DETECTIVE },
 
 	{ 0, 0, 0, 0 }
 };
@@ -597,17 +600,10 @@ int main(int argc, char **argv)
 	 * Some options MUST be processed before the first malloc()
 	 * call, so scan for them here:
 	 *
-	 * - leak-detective is immutable, it must come before the
-	 *   first malloc()
-	 *
 	 * - efence-protect seems to be less strict, but enabling it
 	 *   early must be a good thing (TM) right?
 	 */
 	for (int i = 1; i < argc; ++i) {
-		if (streq(argv[i], "--leak-detective")) {
-			leak_detective = true;
-			continue;
-		}
 #ifdef USE_EFENCE
 		if (streq(argv[i], "--efence-protect")) {
 			EF_PROTECT_BELOW = 1;
@@ -663,17 +659,6 @@ int main(int argc, char **argv)
 		case OPT_HELP:	/* --help */
 			/* writes to STDOUT so <<| more>> works */
 			optarg_usage("ipsec pluto", "", "");
-
-		case OPT_LEAK_DETECTIVE:	/* --leak-detective */
-			/*
-			 * This flag was already processed at the start of main()
-			 * because leak_detective must be immutable from before
-			 * the first alloc().
-			 * If this option is specified, we must have already
-			 * set it at the start of main(), so assert it.
-			 */
-			passert(leak_detective);
-			continue;
 
 		case OPT_DUMPDIR:	/* --dumpdir */
 			update_setup_string(KSF_DUMPDIR, optarg_nonempty(logger));
@@ -1037,6 +1022,29 @@ int main(int argc, char **argv)
 			}
 			continue;
 		}
+
+		case OPT_LEAK_DETECTIVE: /* --leak-detective */
+			/* optional_argument: --leak-detective, --leak-detective=no, --leak-detective=yes */
+			if (optarg != NULL) {
+				/* explicit value provided */
+				bool enabled = optarg_bool(logger);
+				if (enabled) {
+					llog(RC_LOG, logger, "warning: --leak-detective is now the default and can be omitted");
+				} else {
+					llog(RC_LOG, logger, "warning: --leak-detective=no is deprecated; use --no-leak-detective instead (temporarily)");
+					leak_detective = false;
+				}
+			} else {
+				/* no argument: --leak-detective */
+				llog(RC_LOG, logger, "warning: --leak-detective is now the default and can be omitted");
+			}
+			continue;
+
+		case OPT_NO_LEAK_DETECTIVE: /* --no-leak-detective */
+			llog(RC_LOG, logger, "warning: --no-leak-detective is deprecated and will be removed in a future release");
+			leak_detective = false;
+			continue;
+
 		/* no default: instead ... */
 		}
 

--- a/programs/setup/setup.in
+++ b/programs/setup/setup.in
@@ -81,10 +81,10 @@ case "$1" in
 		echo "Redirecting to: namespaces direct start via ipsec pluto"
 		ipsec checknss > /dev/null
 		ipsec checknflog > /dev/null
-		exec ipsec pluto --config @@IPSEC_CONF@@ --leak-detective
+		exec ipsec pluto --config @@IPSEC_CONF@@
 		;;
 	    "" )
-		what="ipsec pluto --logfile @@LOGDIR@@/pluto.log --config @@IPSEC_CONF@@ --leak-detective"
+		what="ipsec pluto --logfile @@LOGDIR@@/pluto.log --config @@IPSEC_CONF@@"
 		echo "Redirecting to: ${what} [start manually]"
 		exec ${what}
 		;;
@@ -231,7 +231,7 @@ case "$1" in
 	    namespaces )
 		echo "Redirecting to: namespaces"
 		ipsec whack --shutdown
-		exec ipsec pluto --config @@IPSEC_CONF@@ --leak-detective
+		exec ipsec pluto --config @@IPSEC_CONF@@
 		;;
 	    "" )
 		echo "Redirecting to: [stop start manually]"

--- a/testing/baseconfigs/all/etc/sysconfig/pluto
+++ b/testing/baseconfigs/all/etc/sysconfig/pluto
@@ -1,1 +1,2 @@
-PLUTO_OPTIONS="--leak-detective"
+# Note: leak-detective is now always enabled by default
+PLUTO_OPTIONS=""

--- a/testing/baseconfigs/all/etc/sysconfig/pluto.fips
+++ b/testing/baseconfigs/all/etc/sysconfig/pluto.fips
@@ -1,1 +1,1 @@
-PLUTO_OPTIONS="--leak-detective --impair-force-fips"
+PLUTO_OPTIONS="--impair-force-fips"

--- a/testing/pluto/addconn-41-ocsp-config/run.sh
+++ b/testing/pluto/addconn-41-ocsp-config/run.sh
@@ -6,7 +6,7 @@ RUN()
     "$@"
 }
 
-RUN ipsec pluto --config $1 --leak-detective
+RUN ipsec pluto --config $1
 RUN ../../guestbin/wait-until-pluto-started
 RUN grep '^[^|].*OCSP' /tmp/pluto.log
 RUN ipsec whack --shutdown

--- a/testing/pluto/addconn-41-ocsp-config/west.console.txt
+++ b/testing/pluto/addconn-41-ocsp-config/west.console.txt
@@ -53,7 +53,7 @@ west #
  # ocsp-uri= broken
 west #
  ./run.sh ocsp-uri-broken.conf
- ipsec pluto --config ocsp-uri-broken.conf --leak-detective
+ ipsec pluto --config ocsp-uri-broken.conf
  ../../guestbin/wait-until-pluto-started
  grep ^[^|].*OCSP /tmp/pluto.log
 NSS: OCSP [enabled]
@@ -65,7 +65,7 @@ west #
  # ocsp-trustname= broken
 west #
  ./run.sh ocsp-trustname-broken.conf
- ipsec pluto --config ocsp-trustname-broken.conf --leak-detective
+ ipsec pluto --config ocsp-trustname-broken.conf
  ../../guestbin/wait-until-pluto-started
  grep ^[^|].*OCSP /tmp/pluto.log
 NSS: OCSP [enabled]
@@ -77,7 +77,7 @@ west #
  # both ocsp-trustname= and ocsp-uri broken
 west #
  ./run.sh ocsp-broken.conf
- ipsec pluto --config ocsp-broken.conf --leak-detective
+ ipsec pluto --config ocsp-broken.conf
  ../../guestbin/wait-until-pluto-started
  grep ^[^|].*OCSP /tmp/pluto.log
 NSS: OCSP [enabled]
@@ -89,7 +89,7 @@ west #
  # ocsp-uri= wrong
 west #
  ./run.sh ocsp-uri-wrong.conf
- ipsec pluto --config ocsp-uri-wrong.conf --leak-detective
+ ipsec pluto --config ocsp-uri-wrong.conf
  ../../guestbin/wait-until-pluto-started
  grep ^[^|].*OCSP /tmp/pluto.log
 NSS: OCSP [enabled]
@@ -101,7 +101,7 @@ west #
  # ocsp-uri= missing
 west #
  ./run.sh ocsp-uri-missing.conf
- ipsec pluto --config ocsp-uri-missing.conf --leak-detective
+ ipsec pluto --config ocsp-uri-missing.conf
  ../../guestbin/wait-until-pluto-started
  grep ^[^|].*OCSP /tmp/pluto.log
 NSS: OCSP [enabled]
@@ -113,7 +113,7 @@ west #
  # ocsp-trustname= missing
 west #
  ./run.sh ocsp-trustname-missing.conf
- ipsec pluto --config ocsp-trustname-missing.conf --leak-detective
+ ipsec pluto --config ocsp-trustname-missing.conf
  ../../guestbin/wait-until-pluto-started
  grep ^[^|].*OCSP /tmp/pluto.log
 NSS: OCSP [enabled]

--- a/testing/pluto/addconn-42-empty/west.console.txt
+++ b/testing/pluto/addconn-42-empty/west.console.txt
@@ -2,5 +2,5 @@
 west #
  # this is enough to load the config file
 west #
- ipsec pluto --debug all --stderrlog --selftest --leak-detective --config /etc/ipsec.conf > /tmp/pluto.log 2>&1
+ ipsec pluto --debug all --stderrlog --selftest --config /etc/ipsec.conf > /tmp/pluto.log 2>&1
 west #

--- a/testing/pluto/addconn-42-empty/west.sh
+++ b/testing/pluto/addconn-42-empty/west.sh
@@ -1,3 +1,3 @@
 /testing/guestbin/swan-prep
 # this is enough to load the config file
-ipsec pluto --debug all --stderrlog --selftest --leak-detective --config /etc/ipsec.conf > /tmp/pluto.log 2>&1
+ipsec pluto --debug all --stderrlog --selftest --config /etc/ipsec.conf > /tmp/pluto.log 2>&1

--- a/testing/pluto/addconn-45-unknown-parameter/west.console.txt
+++ b/testing/pluto/addconn-45-unknown-parameter/west.console.txt
@@ -34,7 +34,8 @@ west #
 west #
  # will fail
 west #
- ipsec pluto --config bad-config-setup-key.conf
+ ipsec pluto --no-leak-detective --config bad-config-setup-key.conf
+ipsec pluto: warning: --no-leak-detective is deprecated and will be removed in a future release
 FATAL ERROR: ipsec pluto: bad-config-setup-key.conf:7: unrecognized 'config setup' keyword 'unknown'
 systemd watchdog: sending action: stopping, status 1
 west #
@@ -62,7 +63,8 @@ west #
 west #
  # will fail
 west #
- ipsec pluto --config bad-conn-key.conf
+ ipsec pluto --leak-detective=no --config bad-conn-key.conf
+ipsec pluto: warning: --leak-detective=no is deprecated; use --no-leak-detective instead (temporarily)
 FATAL ERROR: ipsec pluto: bad-conn-key.conf:9: unrecognized 'conn' keyword 'unknown'
 systemd watchdog: sending action: stopping, status 1
 west #

--- a/testing/pluto/addconn-45-unknown-parameter/west.sh
+++ b/testing/pluto/addconn-45-unknown-parameter/west.sh
@@ -16,7 +16,7 @@ ipsec addconn --debug --config /dne.conf
 # broken config setup
 
 # will fail
-ipsec pluto --config bad-config-setup-key.conf
+ipsec pluto --no-leak-detective --config bad-config-setup-key.conf
 # should fail but doesn't, hence shutdown
 ipsec pluto --config bad-config-setup-value.conf
 ipsec whack --shutdown
@@ -29,7 +29,7 @@ cp /tmp/pluto.log OUTPUT/obsolete-config-setup-key.log
 # broken conn section; should be grumpy but ignored
 
 # will fail
-ipsec pluto --config bad-conn-key.conf
+ipsec pluto --leak-detective=no --config bad-conn-key.conf
 # should fail?
 ipsec pluto --config bad-conn-value.conf
 ipsec whack --shutdown

--- a/testing/pluto/basic-pluto-08-misc/west.console.txt
+++ b/testing/pluto/basic-pluto-08-misc/west.console.txt
@@ -13,6 +13,7 @@ secrets file: /etc/ipsec.secrets
 Initializing NSS using read-only database "sql:/var/lib/ipsec/nss"
 FATAL ERROR: NSS: initialization using read-only database "sql:/var/lib/ipsec/nss" failed: SEC_ERROR_BAD_DATABASE: security library: bad database.
 systemd watchdog: sending action: stopping, status 1
+leak detective found no leaks
 west #
  # rhbz#1041576 start pluto in dir not owned by root; should not fail
 west #

--- a/testing/pluto/ddos-01-ikev2/roadinit.sh
+++ b/testing/pluto/ddos-01-ikev2/roadinit.sh
@@ -255,7 +255,7 @@
 ../../guestbin/ip.sh address add 192.1.3.253/24 dev eth0
 ../../guestbin/ip.sh address add 192.1.3.254/24 dev eth0
 
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 
 echo "initdone"

--- a/testing/pluto/flush-on-shutdown-xfrm/west.console.txt
+++ b/testing/pluto/flush-on-shutdown-xfrm/west.console.txt
@@ -5,7 +5,7 @@ west #
 west #
  ipsec _kernel policy
 west #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 west #
  ../../guestbin/wait-until-pluto-started
 west #

--- a/testing/pluto/flush-on-shutdown-xfrm/west.sh
+++ b/testing/pluto/flush-on-shutdown-xfrm/west.sh
@@ -3,7 +3,7 @@
 # expect no holes; not ipsec-kernel-policy.sh as that filters
 ipsec _kernel policy
 
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 
 # expect holes; not ipsec-kernel-policy.sh as that filters

--- a/testing/pluto/flush-on-startup-pfkeyv2/freebsdwest.sh
+++ b/testing/pluto/flush-on-startup-pfkeyv2/freebsdwest.sh
@@ -8,7 +8,7 @@ ipsec _kernel state
 ipsec _kernel policy
 
 # start pluto
-ipsec pluto --config /usr/local/etc/ipsec.conf --leak-detective
+ipsec pluto --config /usr/local/etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 
 # check policy/state gone

--- a/testing/pluto/flush-on-startup-pfkeyv2/west.console.txt
+++ b/testing/pluto/flush-on-startup-pfkeyv2/west.console.txt
@@ -40,7 +40,7 @@ west #
 west #
  # start pluto
 west #
- ipsec pluto --config PATH/etc/ipsec.conf --leak-detective
+ ipsec pluto --config PATH/etc/ipsec.conf
 west #
  ../../guestbin/wait-until-pluto-started
 west #

--- a/testing/pluto/flush-on-startup-xfrm/west.console.txt
+++ b/testing/pluto/flush-on-startup-xfrm/west.console.txt
@@ -47,7 +47,7 @@ src 10.0.2.0/24 dst 10.0.1.0/24
 west #
  # start pluto
 west #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 west #
  ../../guestbin/wait-until-pluto-started
 west #

--- a/testing/pluto/flush-on-startup-xfrm/west.sh
+++ b/testing/pluto/flush-on-startup-xfrm/west.sh
@@ -16,7 +16,7 @@ ipsec _kernel state
 ipsec _kernel policy
 
 # start pluto
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 
 # check policy/state gone

--- a/testing/pluto/ikev2-12-x509-ikev1-rw/west.console.txt
+++ b/testing/pluto/ikev2-12-x509-ikev1-rw/west.console.txt
@@ -6,7 +6,7 @@ west #
  ../../guestbin/wait-until-alive -I 192.0.1.254 192.0.2.254
 destination -I 192.0.1.254 192.0.2.254 is alive
 west #
- PATH/libexec/ipsec/pluto --config /etc/ipsec.conf --leak-detective
+ PATH/libexec/ipsec/pluto --config /etc/ipsec.conf
 west #
  ../../guestbin/wait-until-pluto-started
 west #

--- a/testing/pluto/ikev2-12-x509-ikev1-rw/westinit.sh
+++ b/testing/pluto/ikev2-12-x509-ikev1-rw/westinit.sh
@@ -1,7 +1,7 @@
 /testing/guestbin/swan-prep --x509
 # confirm that the network is alive
 ../../guestbin/wait-until-alive -I 192.0.1.254 192.0.2.254
-/usr/local/libexec/ipsec/pluto --config /etc/ipsec.conf --leak-detective
+/usr/local/libexec/ipsec/pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ikev2
 echo "initdone"

--- a/testing/pluto/ikev2-24-cryptoload/eastinit.sh
+++ b/testing/pluto/ikev2-24-cryptoload/eastinit.sh
@@ -1,5 +1,5 @@
 /testing/guestbin/swan-prep
-ipsec pluto --impair helper_thread_delay:10 --config /etc/ipsec.conf --leak-detective
+ipsec pluto --impair helper_thread_delay:10 --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add multi
 echo "initdone"

--- a/testing/pluto/ikev2-68-sa-clones-auto-route/east.console.txt
+++ b/testing/pluto/ikev2-68-sa-clones-auto-route/east.console.txt
@@ -19,7 +19,7 @@ x ipsec.service - Internet Key Exchange (IKE) Protocol Daemon for IPsec
              man:ipsec.conf(5)
     Process: 652 ExecStartPre=PATH/sbin/ipsec checknss (code=exited, status=0/SUCCESS)
     Process: 658 ExecStartPre=PATH/sbin/ipsec checknflog (code=exited, status=0/SUCCESS)
-    Process: 675 ExecStart=PATH/libexec/ipsec/pluto --leak-detective --config /etc/ipsec.conf --nofork (code=exited, status=1/FAILURE)
+    Process: 675 ExecStart=PATH/libexec/ipsec/pluto --config /etc/ipsec.conf --nofork (code=exited, status=1/FAILURE)
     Process: 676 ExecStopPost=PATH/sbin/ipsec stopnflog (code=exited, status=0/SUCCESS)
    Main PID: 675 (code=exited, status=1/FAILURE)
      Status: "Exited."

--- a/testing/pluto/ikev2-68-sa-clones-auto-route/west.console.txt
+++ b/testing/pluto/ikev2-68-sa-clones-auto-route/west.console.txt
@@ -19,7 +19,7 @@ x ipsec.service - Internet Key Exchange (IKE) Protocol Daemon for IPsec
              man:ipsec.conf(5)
     Process: 655 ExecStartPre=PATH/sbin/ipsec checknss (code=exited, status=0/SUCCESS)
     Process: 660 ExecStartPre=PATH/sbin/ipsec checknflog (code=exited, status=0/SUCCESS)
-    Process: 678 ExecStart=PATH/libexec/ipsec/pluto --leak-detective --config /etc/ipsec.conf --nofork (code=exited, status=1/FAILURE)
+    Process: 678 ExecStart=PATH/libexec/ipsec/pluto --config /etc/ipsec.conf --nofork (code=exited, status=1/FAILURE)
     Process: 679 ExecStopPost=PATH/sbin/ipsec stopnflog (code=exited, status=0/SUCCESS)
    Main PID: 678 (code=exited, status=1/FAILURE)
      Status: "Exited."

--- a/testing/pluto/ikev2-labeled-ipsec-03-multi-acquires-permissive/east.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-03-multi-acquires-permissive/east.console.txt
@@ -107,7 +107,7 @@ Certificate Nickname                                         Trust Attributes
 east #
  >>>>>>>>>> post-mortem >>>>>>>>>>../../guestbin/post-mortem.sh
    PPID     PID    PGID     SID TTY        TPGID STAT   UID   TIME COMMAND
-      1     552     552     552 ?             -1 Ssl      0   0:00 PATH/libexec/ipsec/pluto --leak-detective --config /etc/ipsec.conf --nofork
+      1     552     552     552 ?             -1 Ssl      0   0:00 PATH/libexec/ipsec/pluto --config /etc/ipsec.conf --nofork
 :
 : checking shutting down pluto
 :

--- a/testing/pluto/ikev2-labeled-ipsec-03-multi-acquires-permissive/west.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-03-multi-acquires-permissive/west.console.txt
@@ -315,7 +315,7 @@ Certificate Nickname                                         Trust Attributes
 west #
  >>>>>>>>>> post-mortem >>>>>>>>>>../../guestbin/post-mortem.sh
    PPID     PID    PGID     SID TTY        TPGID STAT   UID   TIME COMMAND
-      1     521     521     521 ?             -1 Ssl      0   0:00 PATH/libexec/ipsec/pluto --leak-detective --config /etc/ipsec.conf --nofork
+      1     521     521     521 ?             -1 Ssl      0   0:00 PATH/libexec/ipsec/pluto --config /etc/ipsec.conf --nofork
 :
 : checking shutting down pluto
 :

--- a/testing/pluto/ikev2-labeled-ipsec-03-multi-acquires-rekey/east.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-03-multi-acquires-rekey/east.console.txt
@@ -107,7 +107,7 @@ Certificate Nickname                                         Trust Attributes
 east #
  >>>>>>>>>> post-mortem >>>>>>>>>>../../guestbin/post-mortem.sh
    PPID     PID    PGID     SID TTY        TPGID STAT   UID   TIME COMMAND
-      1     550     550     550 ?             -1 Ssl      0   0:00 PATH/libexec/ipsec/pluto --leak-detective --config /etc/ipsec.conf --nofork
+      1     550     550     550 ?             -1 Ssl      0   0:00 PATH/libexec/ipsec/pluto --config /etc/ipsec.conf --nofork
 :
 : checking shutting down pluto
 :

--- a/testing/pluto/ikev2-labeled-ipsec-03-multi-acquires-rekey/west.console.txt
+++ b/testing/pluto/ikev2-labeled-ipsec-03-multi-acquires-rekey/west.console.txt
@@ -329,7 +329,7 @@ Certificate Nickname                                         Trust Attributes
 west #
  >>>>>>>>>> post-mortem >>>>>>>>>>../../guestbin/post-mortem.sh
    PPID     PID    PGID     SID TTY        TPGID STAT   UID   TIME COMMAND
-      1     520     520     520 ?             -1 Ssl      0   0:00 PATH/libexec/ipsec/pluto --leak-detective --config /etc/ipsec.conf --nofork
+      1     520     520     520 ?             -1 Ssl      0   0:00 PATH/libexec/ipsec/pluto --config /etc/ipsec.conf --nofork
 :
 : checking shutting down pluto
 :

--- a/testing/pluto/ikev2-leak-01-db_v2_prop_conj/west.console.txt
+++ b/testing/pluto/ikev2-leak-01-db_v2_prop_conj/west.console.txt
@@ -1,7 +1,7 @@
 /testing/guestbin/swan-prep --nokeys
 Creating empty NSS database
 west #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 west #
  ../../guestbin/wait-until-pluto-started
 west #

--- a/testing/pluto/ikev2-leak-01-db_v2_prop_conj/westinit.sh
+++ b/testing/pluto/ikev2-leak-01-db_v2_prop_conj/westinit.sh
@@ -1,5 +1,5 @@
 /testing/guestbin/swan-prep --nokeys
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec whack --impair suppress_retransmits
 ipsec auto --add westnet-eastnet-ipv4-psk-ikev2

--- a/testing/pluto/ikev2-leak-02-no-psk/west.console.txt
+++ b/testing/pluto/ikev2-leak-02-no-psk/west.console.txt
@@ -1,7 +1,7 @@
 /testing/guestbin/swan-prep --nokeys
 Creating empty NSS database
 west #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 west #
  ../../guestbin/wait-until-pluto-started
 west #

--- a/testing/pluto/ikev2-leak-02-no-psk/westinit.sh
+++ b/testing/pluto/ikev2-leak-02-no-psk/westinit.sh
@@ -1,5 +1,5 @@
 /testing/guestbin/swan-prep --nokeys
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec whack --impair suppress_retransmits
 ipsec auto --add westnet-eastnet-ipv4-psk-ikev2

--- a/testing/pluto/ikev2-ppk-intermediate-01-insist-yes/east.console.txt
+++ b/testing/pluto/ikev2-ppk-intermediate-01-insist-yes/east.console.txt
@@ -1,7 +1,7 @@
 /testing/guestbin/swan-prep --nokeys
 Creating empty NSS database
 east #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 east #
  ../../guestbin/wait-until-pluto-started
 east #

--- a/testing/pluto/ikev2-ppk-intermediate-01-insist-yes/eastinit.sh
+++ b/testing/pluto/ikev2-ppk-intermediate-01-insist-yes/eastinit.sh
@@ -1,5 +1,5 @@
 /testing/guestbin/swan-prep --nokeys
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ipv4-psk-ppk
 ipsec auto --status | grep westnet-eastnet-ipv4-psk-ppk

--- a/testing/pluto/ikev2-ppk-intermediate-01-insist-yes/west.console.txt
+++ b/testing/pluto/ikev2-ppk-intermediate-01-insist-yes/west.console.txt
@@ -17,7 +17,7 @@ west #
  ../../guestbin/ping-once.sh --down -I 192.0.1.254 192.0.2.254
 down
 west #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 west #
  ../../guestbin/wait-until-pluto-started
 west #

--- a/testing/pluto/ikev2-ppk-intermediate-01-insist-yes/westinit.sh
+++ b/testing/pluto/ikev2-ppk-intermediate-01-insist-yes/westinit.sh
@@ -6,7 +6,7 @@ iptables -A INPUT -i eth1 -s 192.0.2.0/24 -j DROP
 iptables -I INPUT -m policy --dir in --pol ipsec -j ACCEPT
 # confirm clear text does not get through
 ../../guestbin/ping-once.sh --down -I 192.0.1.254 192.0.2.254
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ipv4-psk-ppk
 ipsec auto --status | grep westnet-eastnet-ipv4-psk-ppk

--- a/testing/pluto/ikev2-ppk-static-01-insist-yes/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-01-insist-yes/east.console.txt
@@ -1,7 +1,7 @@
 /testing/guestbin/swan-prep --nokeys
 Creating empty NSS database
 east #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 east #
  ../../guestbin/wait-until-pluto-started
 east #

--- a/testing/pluto/ikev2-ppk-static-01-insist-yes/eastinit.sh
+++ b/testing/pluto/ikev2-ppk-static-01-insist-yes/eastinit.sh
@@ -1,5 +1,5 @@
 /testing/guestbin/swan-prep --nokeys
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ipv4-psk-ppk
 ipsec auto --status | grep westnet-eastnet-ipv4-psk-ppk

--- a/testing/pluto/ikev2-ppk-static-01-insist-yes/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-01-insist-yes/west.console.txt
@@ -17,7 +17,7 @@ west #
  ../../guestbin/ping-once.sh --down -I 192.0.1.254 192.0.2.254
 down
 west #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 west #
  ../../guestbin/wait-until-pluto-started
 west #

--- a/testing/pluto/ikev2-ppk-static-01-insist-yes/westinit.sh
+++ b/testing/pluto/ikev2-ppk-static-01-insist-yes/westinit.sh
@@ -6,7 +6,7 @@ iptables -A INPUT -i eth1 -s 192.0.2.0/24 -j DROP
 iptables -I INPUT -m policy --dir in --pol ipsec -j ACCEPT
 # confirm clear text does not get through
 ../../guestbin/ping-once.sh --down -I 192.0.1.254 192.0.2.254
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ipv4-psk-ppk
 ipsec auto --status | grep westnet-eastnet-ipv4-psk-ppk

--- a/testing/pluto/ikev2-ppk-static-02-insist-insist/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-02-insist-insist/east.console.txt
@@ -1,7 +1,7 @@
 /testing/guestbin/swan-prep --nokeys
 Creating empty NSS database
 east #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 east #
  ../../guestbin/wait-until-pluto-started
 east #

--- a/testing/pluto/ikev2-ppk-static-02-insist-insist/eastinit.sh
+++ b/testing/pluto/ikev2-ppk-static-02-insist-insist/eastinit.sh
@@ -1,5 +1,5 @@
 /testing/guestbin/swan-prep --nokeys
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ipv4-psk-ppk
 ipsec auto --status | grep westnet-eastnet-ipv4-psk-ppk

--- a/testing/pluto/ikev2-ppk-static-02-insist-insist/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-02-insist-insist/west.console.txt
@@ -17,7 +17,7 @@ west #
  ../../guestbin/ping-once.sh --down -I 192.0.1.254 192.0.2.254
 down
 west #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 west #
  ../../guestbin/wait-until-pluto-started
 west #

--- a/testing/pluto/ikev2-ppk-static-02-insist-insist/westinit.sh
+++ b/testing/pluto/ikev2-ppk-static-02-insist-insist/westinit.sh
@@ -6,7 +6,7 @@ iptables -A INPUT -i eth1 -s 192.0.2.0/24 -j DROP
 iptables -I INPUT -m policy --dir in --pol ipsec -j ACCEPT
 # confirm clear text does not get through
 ../../guestbin/ping-once.sh --down -I 192.0.1.254 192.0.2.254
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ipv4-psk-ppk
 ipsec auto --status | grep westnet-eastnet-ipv4-psk-ppk

--- a/testing/pluto/ikev2-ppk-static-03-no-insist-fail/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-03-no-insist-fail/east.console.txt
@@ -1,7 +1,7 @@
 /testing/guestbin/swan-prep --nokeys
 Creating empty NSS database
 east #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 east #
  ../../guestbin/wait-until-pluto-started
 east #

--- a/testing/pluto/ikev2-ppk-static-03-no-insist-fail/eastinit.sh
+++ b/testing/pluto/ikev2-ppk-static-03-no-insist-fail/eastinit.sh
@@ -1,5 +1,5 @@
 /testing/guestbin/swan-prep --nokeys
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ipv4-psk-ppk
 ipsec auto --status | grep westnet-eastnet-ipv4-psk-ppk

--- a/testing/pluto/ikev2-ppk-static-03-no-insist-fail/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-03-no-insist-fail/west.console.txt
@@ -6,7 +6,7 @@ west #
  ../../guestbin/wait-until-alive -I 192.0.1.254 192.0.2.254
 destination -I 192.0.1.254 192.0.2.254 is alive
 west #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 west #
  ../../guestbin/wait-until-pluto-started
 west #

--- a/testing/pluto/ikev2-ppk-static-03-no-insist-fail/westinit.sh
+++ b/testing/pluto/ikev2-ppk-static-03-no-insist-fail/westinit.sh
@@ -1,7 +1,7 @@
 /testing/guestbin/swan-prep --nokeys
 # confirm that newtwork is alive
 ../../guestbin/wait-until-alive -I 192.0.1.254 192.0.2.254
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ipv4-psk-ppk
 ipsec auto --status | grep westnet-eastnet-ipv4-psk-ppk

--- a/testing/pluto/ikev2-ppk-static-04-insist-no-fail/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-04-insist-no-fail/east.console.txt
@@ -1,7 +1,7 @@
 /testing/guestbin/swan-prep --nokeys
 Creating empty NSS database
 east #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 east #
  ../../guestbin/wait-until-pluto-started
 east #

--- a/testing/pluto/ikev2-ppk-static-04-insist-no-fail/eastinit.sh
+++ b/testing/pluto/ikev2-ppk-static-04-insist-no-fail/eastinit.sh
@@ -1,5 +1,5 @@
 /testing/guestbin/swan-prep --nokeys
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ipv4-psk-ppk
 ipsec auto --status | grep westnet-eastnet-ipv4-psk-ppk

--- a/testing/pluto/ikev2-ppk-static-04-insist-no-fail/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-04-insist-no-fail/west.console.txt
@@ -6,7 +6,7 @@ west #
  ../../guestbin/wait-until-alive -I 192.0.1.254 192.0.2.254
 destination -I 192.0.1.254 192.0.2.254 is alive
 west #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 west #
  ../../guestbin/wait-until-pluto-started
 west #

--- a/testing/pluto/ikev2-ppk-static-04-insist-no-fail/westinit.sh
+++ b/testing/pluto/ikev2-ppk-static-04-insist-no-fail/westinit.sh
@@ -1,7 +1,7 @@
 /testing/guestbin/swan-prep --nokeys
 # confirm that newtwork is alive
 ../../guestbin/wait-until-alive -I 192.0.1.254 192.0.2.254
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ipv4-psk-ppk
 ipsec auto --status | grep westnet-eastnet-ipv4-psk-ppk

--- a/testing/pluto/ikev2-ppk-static-05-insist-nokey-insist-fail/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-05-insist-nokey-insist-fail/east.console.txt
@@ -1,7 +1,7 @@
 /testing/guestbin/swan-prep --nokeys
 Creating empty NSS database
 east #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 east #
  ../../guestbin/wait-until-pluto-started
 east #

--- a/testing/pluto/ikev2-ppk-static-05-insist-nokey-insist-fail/eastinit.sh
+++ b/testing/pluto/ikev2-ppk-static-05-insist-nokey-insist-fail/eastinit.sh
@@ -1,5 +1,5 @@
 /testing/guestbin/swan-prep --nokeys
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ipv4-psk-ppk
 ipsec auto --status | grep westnet-eastnet-ipv4-psk-ppk

--- a/testing/pluto/ikev2-ppk-static-05-insist-nokey-insist-fail/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-05-insist-nokey-insist-fail/west.console.txt
@@ -6,7 +6,7 @@ west #
  ../../guestbin/wait-until-alive -I 192.0.1.254 192.0.2.254
 destination -I 192.0.1.254 192.0.2.254 is alive
 west #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 west #
  ../../guestbin/wait-until-pluto-started
 west #

--- a/testing/pluto/ikev2-ppk-static-05-insist-nokey-insist-fail/westinit.sh
+++ b/testing/pluto/ikev2-ppk-static-05-insist-nokey-insist-fail/westinit.sh
@@ -1,7 +1,7 @@
 /testing/guestbin/swan-prep --nokeys
 # confirm that newtwork is alive
 ../../guestbin/wait-until-alive -I 192.0.1.254 192.0.2.254
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ipv4-psk-ppk
 ipsec auto --status | grep westnet-eastnet-ipv4-psk-ppk

--- a/testing/pluto/ikev2-ppk-static-06-insist-insist-nokey-fail/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-06-insist-insist-nokey-fail/east.console.txt
@@ -1,7 +1,7 @@
 /testing/guestbin/swan-prep --nokeys
 Creating empty NSS database
 east #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 east #
  ../../guestbin/wait-until-pluto-started
 east #

--- a/testing/pluto/ikev2-ppk-static-06-insist-insist-nokey-fail/eastinit.sh
+++ b/testing/pluto/ikev2-ppk-static-06-insist-insist-nokey-fail/eastinit.sh
@@ -1,5 +1,5 @@
 /testing/guestbin/swan-prep --nokeys
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ipv4-psk-ppk
 ipsec auto --status | grep westnet-eastnet-ipv4-psk-ppk

--- a/testing/pluto/ikev2-ppk-static-06-insist-insist-nokey-fail/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-06-insist-insist-nokey-fail/west.console.txt
@@ -6,7 +6,7 @@ west #
  ../../guestbin/wait-until-alive -I 192.0.1.254 192.0.2.254
 destination -I 192.0.1.254 192.0.2.254 is alive
 west #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 west #
  ../../guestbin/wait-until-pluto-started
 west #

--- a/testing/pluto/ikev2-ppk-static-06-insist-insist-nokey-fail/westinit.sh
+++ b/testing/pluto/ikev2-ppk-static-06-insist-insist-nokey-fail/westinit.sh
@@ -1,7 +1,7 @@
 /testing/guestbin/swan-prep --nokeys
 # confirm that newtwork is alive
 ../../guestbin/wait-until-alive -I 192.0.1.254 192.0.2.254
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ipv4-psk-ppk
 ipsec auto --status | grep westnet-eastnet-ipv4-psk-ppk

--- a/testing/pluto/ikev2-ppk-static-07-large-id/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-07-large-id/east.console.txt
@@ -1,7 +1,7 @@
 /testing/guestbin/swan-prep --nokeys
 Creating empty NSS database
 east #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 east #
  ../../guestbin/wait-until-pluto-started
 east #

--- a/testing/pluto/ikev2-ppk-static-07-large-id/eastinit.sh
+++ b/testing/pluto/ikev2-ppk-static-07-large-id/eastinit.sh
@@ -1,5 +1,5 @@
 /testing/guestbin/swan-prep --nokeys
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ipv4-psk-ppk
 ipsec auto --status | grep westnet-eastnet-ipv4-psk-ppk

--- a/testing/pluto/ikev2-ppk-static-07-large-id/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-07-large-id/west.console.txt
@@ -17,7 +17,7 @@ west #
  ../../guestbin/ping-once.sh --down -I 192.0.1.254 192.0.2.254
 down
 west #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 west #
  ../../guestbin/wait-until-pluto-started
 west #

--- a/testing/pluto/ikev2-ppk-static-07-large-id/westinit.sh
+++ b/testing/pluto/ikev2-ppk-static-07-large-id/westinit.sh
@@ -6,7 +6,7 @@ iptables -A INPUT -i eth1 -s 192.0.2.0/24 -j DROP
 iptables -I INPUT -m policy --dir in --pol ipsec -j ACCEPT
 # confirm clear text does not get through
 ../../guestbin/ping-once.sh --down -I 192.0.1.254 192.0.2.254
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ipv4-psk-ppk
 ipsec auto --status | grep westnet-eastnet-ipv4-psk-ppk

--- a/testing/pluto/ikev2-ppk-static-08-no_ppk-responder/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-08-no_ppk-responder/east.console.txt
@@ -1,7 +1,7 @@
 /testing/guestbin/swan-prep --nokeys
 Creating empty NSS database
 east #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 east #
  ../../guestbin/wait-until-pluto-started
 east #

--- a/testing/pluto/ikev2-ppk-static-08-no_ppk-responder/eastinit.sh
+++ b/testing/pluto/ikev2-ppk-static-08-no_ppk-responder/eastinit.sh
@@ -1,5 +1,5 @@
 /testing/guestbin/swan-prep --nokeys
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ipv4-psk-ppk
 ipsec auto --status | grep westnet-eastnet-ipv4-psk-ppk

--- a/testing/pluto/ikev2-ppk-static-08-no_ppk-responder/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-08-no_ppk-responder/west.console.txt
@@ -17,7 +17,7 @@ west #
  ../../guestbin/ping-once.sh --down -I 192.0.1.254 192.0.2.254
 down
 west #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 west #
  ../../guestbin/wait-until-pluto-started
 west #

--- a/testing/pluto/ikev2-ppk-static-08-no_ppk-responder/westinit.sh
+++ b/testing/pluto/ikev2-ppk-static-08-no_ppk-responder/westinit.sh
@@ -6,7 +6,7 @@ iptables -A INPUT -i eth1 -s 192.0.2.0/24 -j DROP
 iptables -I INPUT -m policy --dir in --pol ipsec -j ACCEPT
 # confirm clear text does not get through
 ../../guestbin/ping-once.sh --down -I 192.0.1.254 192.0.2.254
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ipv4-psk-ppk
 ipsec auto --status | grep westnet-eastnet-ipv4-psk-ppk

--- a/testing/pluto/ikev2-ppk-static-09-no_ppk-initiator/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-09-no_ppk-initiator/east.console.txt
@@ -1,7 +1,7 @@
 /testing/guestbin/swan-prep --nokeys
 Creating empty NSS database
 east #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 east #
  ../../guestbin/wait-until-pluto-started
 east #

--- a/testing/pluto/ikev2-ppk-static-09-no_ppk-initiator/eastinit.sh
+++ b/testing/pluto/ikev2-ppk-static-09-no_ppk-initiator/eastinit.sh
@@ -1,5 +1,5 @@
 /testing/guestbin/swan-prep --nokeys
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ipv4-psk-ppk
 ipsec auto --status | grep westnet-eastnet-ipv4-psk-ppk

--- a/testing/pluto/ikev2-ppk-static-09-no_ppk-initiator/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-09-no_ppk-initiator/west.console.txt
@@ -17,7 +17,7 @@ west #
  ../../guestbin/ping-once.sh --down -I 192.0.1.254 192.0.2.254
 down
 west #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 west #
  ../../guestbin/wait-until-pluto-started
 west #

--- a/testing/pluto/ikev2-ppk-static-09-no_ppk-initiator/westinit.sh
+++ b/testing/pluto/ikev2-ppk-static-09-no_ppk-initiator/westinit.sh
@@ -6,7 +6,7 @@ iptables -A INPUT -i eth1 -s 192.0.2.0/24 -j DROP
 iptables -I INPUT -m policy --dir in --pol ipsec -j ACCEPT
 # confirm clear text does not get through
 ../../guestbin/ping-once.sh --down -I 192.0.1.254 192.0.2.254
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ipv4-psk-ppk
 ipsec auto --status | grep westnet-eastnet-ipv4-psk-ppk

--- a/testing/pluto/ikev2-ppk-static-10-yes-no/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-10-yes-no/east.console.txt
@@ -1,7 +1,7 @@
 /testing/guestbin/swan-prep --nokeys
 Creating empty NSS database
 east #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 east #
  ../../guestbin/wait-until-pluto-started
 east #

--- a/testing/pluto/ikev2-ppk-static-10-yes-no/eastinit.sh
+++ b/testing/pluto/ikev2-ppk-static-10-yes-no/eastinit.sh
@@ -1,5 +1,5 @@
 /testing/guestbin/swan-prep --nokeys
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ipv4-psk-ppk
 ipsec auto --status | grep westnet-eastnet-ipv4-psk-ppk

--- a/testing/pluto/ikev2-ppk-static-10-yes-no/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-10-yes-no/west.console.txt
@@ -17,7 +17,7 @@ west #
  ../../guestbin/ping-once.sh --down -I 192.0.1.254 192.0.2.254
 down
 west #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 west #
  ../../guestbin/wait-until-pluto-started
 west #

--- a/testing/pluto/ikev2-ppk-static-10-yes-no/westinit.sh
+++ b/testing/pluto/ikev2-ppk-static-10-yes-no/westinit.sh
@@ -6,7 +6,7 @@ iptables -A INPUT -i eth1 -s 192.0.2.0/24 -j DROP
 iptables -I INPUT -m policy --dir in --pol ipsec -j ACCEPT
 # confirm clear text does not get through
 ../../guestbin/ping-once.sh --down -I 192.0.1.254 192.0.2.254
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ipv4-psk-ppk
 ipsec auto --status | grep westnet-eastnet-ipv4-psk-ppk

--- a/testing/pluto/ikev2-ppk-static-11-multiple-ppk-ids/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-11-multiple-ppk-ids/east.console.txt
@@ -1,7 +1,7 @@
 /testing/guestbin/swan-prep --nokeys
 Creating empty NSS database
 east #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 east #
  ../../guestbin/wait-until-pluto-started
 east #

--- a/testing/pluto/ikev2-ppk-static-11-multiple-ppk-ids/eastinit.sh
+++ b/testing/pluto/ikev2-ppk-static-11-multiple-ppk-ids/eastinit.sh
@@ -1,5 +1,5 @@
 /testing/guestbin/swan-prep --nokeys
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ipv4-psk-ppk
 ipsec auto --status | grep westnet-eastnet-ipv4-psk-ppk

--- a/testing/pluto/ikev2-ppk-static-11-multiple-ppk-ids/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-11-multiple-ppk-ids/west.console.txt
@@ -17,7 +17,7 @@ west #
  ../../guestbin/ping-once.sh --down -I 192.0.1.254 192.0.2.254
 down
 west #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 west #
  ../../guestbin/wait-until-pluto-started
 west #

--- a/testing/pluto/ikev2-ppk-static-11-multiple-ppk-ids/westinit.sh
+++ b/testing/pluto/ikev2-ppk-static-11-multiple-ppk-ids/westinit.sh
@@ -6,7 +6,7 @@ iptables -A INPUT -i eth1 -s 192.0.2.0/24 -j DROP
 iptables -I INPUT -m policy --dir in --pol ipsec -j ACCEPT
 # confirm clear text does not get through
 ../../guestbin/ping-once.sh --down -I 192.0.1.254 192.0.2.254
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ipv4-psk-ppk
 ipsec auto --status | grep westnet-eastnet-ipv4-psk-ppk

--- a/testing/pluto/ikev2-x509-ecdsa-04-also-rsa/east.console.txt
+++ b/testing/pluto/ikev2-x509-ecdsa-04-also-rsa/east.console.txt
@@ -9,7 +9,7 @@ east #
 east #
  #ipsec start
 east #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 east #
  ../../guestbin/wait-until-pluto-started
 east #

--- a/testing/pluto/ikev2-x509-ecdsa-04-also-rsa/eastinit.sh
+++ b/testing/pluto/ikev2-x509-ecdsa-04-also-rsa/eastinit.sh
@@ -3,7 +3,7 @@
 # Tuomo: why doesn't ipsec checknss --settrust work here?
 ipsec certutil -M -n "strongSwan CA - strongSwan" -t CT,,
 #ipsec start
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ikev2
 ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-x509-ecdsa-04-also-rsa/westinit.sh
+++ b/testing/pluto/ikev2-x509-ecdsa-04-also-rsa/westinit.sh
@@ -10,7 +10,7 @@ iptables -I INPUT -m policy --dir in --pol ipsec -j ACCEPT
 # Tuomo: why doesn't ipsec checknss --settrust work here?
 ipsec certutil -M -n "strongSwan CA - strongSwan" -t CT,,
 #ipsec start
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ikev2
 ipsec status

--- a/testing/pluto/ikev2-x509-ecdsa-05-rsa-asym/east.console.txt
+++ b/testing/pluto/ikev2-x509-ecdsa-05-rsa-asym/east.console.txt
@@ -10,7 +10,7 @@ east #
 east #
  #ipsec start
 east #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 east #
  ../../guestbin/wait-until-pluto-started
 east #

--- a/testing/pluto/ikev2-x509-ecdsa-05-rsa-asym/eastinit.sh
+++ b/testing/pluto/ikev2-x509-ecdsa-05-rsa-asym/eastinit.sh
@@ -3,7 +3,7 @@
 # Tuomo: why doesn't ipsec checknss --settrust work here?
 ipsec certutil -M -n "strongSwan CA - strongSwan" -t CT,,
 #ipsec start
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ikev2
 ipsec status | grep "our auth:"

--- a/testing/pluto/ikev2-x509-ecdsa-05-rsa-asym/west.console.txt
+++ b/testing/pluto/ikev2-x509-ecdsa-05-rsa-asym/west.console.txt
@@ -26,7 +26,7 @@ west #
 west #
  #ipsec start
 west #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 west #
  ../../guestbin/wait-until-pluto-started
 west #

--- a/testing/pluto/ikev2-x509-ecdsa-05-rsa-asym/westinit.sh
+++ b/testing/pluto/ikev2-x509-ecdsa-05-rsa-asym/westinit.sh
@@ -10,7 +10,7 @@ iptables -I INPUT -m policy --dir in --pol ipsec -j ACCEPT
 # Tuomo: why doesn't ipsec checknss --settrust work here?
 ipsec certutil -M -n "strongSwan CA - strongSwan" -t CT,,
 #ipsec start
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ikev2
 ipsec status | grep "our auth:"

--- a/testing/pluto/ikev2-x509-ecdsa-06-rsa-asym-flip/east.console.txt
+++ b/testing/pluto/ikev2-x509-ecdsa-06-rsa-asym-flip/east.console.txt
@@ -10,7 +10,7 @@ east #
 east #
  #ipsec start
 east #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 east #
  ../../guestbin/wait-until-pluto-started
 east #

--- a/testing/pluto/ikev2-x509-ecdsa-06-rsa-asym-flip/eastinit.sh
+++ b/testing/pluto/ikev2-x509-ecdsa-06-rsa-asym-flip/eastinit.sh
@@ -3,7 +3,7 @@
 # Tuomo: why doesn't ipsec checknss --settrust work here?
 ipsec certutil -M -n "strongSwan CA - strongSwan" -t CT,,
 #ipsec start
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ikev2
 ipsec status | grep "our auth:"

--- a/testing/pluto/ikev2-x509-ecdsa-06-rsa-asym-flip/west.console.txt
+++ b/testing/pluto/ikev2-x509-ecdsa-06-rsa-asym-flip/west.console.txt
@@ -26,7 +26,7 @@ west #
 west #
  #ipsec start
 west #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 west #
  ../../guestbin/wait-until-pluto-started
 west #

--- a/testing/pluto/ikev2-x509-ecdsa-06-rsa-asym-flip/westinit.sh
+++ b/testing/pluto/ikev2-x509-ecdsa-06-rsa-asym-flip/westinit.sh
@@ -10,7 +10,7 @@ iptables -I INPUT -m policy --dir in --pol ipsec -j ACCEPT
 # Tuomo: why doesn't ipsec checknss --settrust work here?
 ipsec certutil -M -n "strongSwan CA - strongSwan" -t CT,,
 #ipsec start
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec auto --add westnet-eastnet-ikev2
 ipsec status | grep "our auth:"

--- a/testing/pluto/nss-cert-chain-01-ikev2/gdb.ini
+++ b/testing/pluto/nss-cert-chain-01-ikev2/gdb.ini
@@ -4,7 +4,7 @@ set width unlimited
 set height unlimited
 
 file /usr/local/libexec/ipsec/pluto
-set args --leak-detective --config /etc/ipsec.conf --nofork
+set args --config /etc/ipsec.conf --nofork
 tbreak main
 run
 

--- a/testing/pluto/whack-pluto-01-startup/west.console.txt
+++ b/testing/pluto/whack-pluto-01-startup/west.console.txt
@@ -21,9 +21,9 @@ west #
  ipsec whack --shutdown
 Pluto is shutting down
 west #
- # leak-detective
+ # leak-detective is now always enabled by default
 west #
- ipsec pluto --leak-detective --config /etc/ipsec.conf
+ ipsec pluto --config /etc/ipsec.conf
 west #
  # wait to startup to finish; shutting down early causes leaks.
 west #

--- a/testing/pluto/whack-pluto-01-startup/west.sh
+++ b/testing/pluto/whack-pluto-01-startup/west.sh
@@ -10,8 +10,8 @@ ipsec pluto --efence-protect     --config /etc/ipsec.conf # >=5.3
 ../../guestbin/wait-until-pluto-started
 ipsec whack --shutdown
 
-# leak-detective
-ipsec pluto --leak-detective --config /etc/ipsec.conf
+# leak-detective is now always enabled by default
+ipsec pluto --config /etc/ipsec.conf
 # wait to startup to finish; shutting down early causes leaks.
 ../../guestbin/wait-until-pluto-started
 ipsec whack --shutdown

--- a/testing/pluto/whack-pluto-03-seedbits/west.console.txt
+++ b/testing/pluto/whack-pluto-03-seedbits/west.console.txt
@@ -40,7 +40,7 @@ west #
  grep -E "^seeded" /tmp/pluto.log
 seeded 256 bytes into the NSS PRNG from /dev/random
 west #
- ipsec pluto --config /etc/ipsec.conf --leak-detective --seedbits=1024
+ ipsec pluto --config /etc/ipsec.conf --seedbits=1024
 west #
  ../../guestbin/wait-until-pluto-started
 west #
@@ -52,7 +52,7 @@ seeded 128 bytes into the NSS PRNG from /dev/random
 west #
  # Test with custom seeddev
 west #
- ipsec pluto --config /etc/ipsec.conf --leak-detective --seedbits=520 --seeddev /dev/urandom
+ ipsec pluto --config /etc/ipsec.conf --seedbits=520 --seeddev /dev/urandom
 west #
  ../../guestbin/wait-until-pluto-started
 west #

--- a/testing/pluto/whack-pluto-03-seedbits/west.sh
+++ b/testing/pluto/whack-pluto-03-seedbits/west.sh
@@ -18,7 +18,7 @@ ipsec start
 ipsec stop
 grep -E "^seeded" /tmp/pluto.log
 
-ipsec pluto --config /etc/ipsec.conf --leak-detective --seedbits=1024
+ipsec pluto --config /etc/ipsec.conf --seedbits=1024
 ../../guestbin/wait-until-pluto-started
 ipsec whack --shutdown
 grep -E "^seeded" /tmp/pluto.log

--- a/testing/pluto/whack-pluto-03-seedbits/west.sh
+++ b/testing/pluto/whack-pluto-03-seedbits/west.sh
@@ -24,7 +24,7 @@ ipsec whack --shutdown
 grep -E "^seeded" /tmp/pluto.log
 
 # Test with custom seeddev
-ipsec pluto --config /etc/ipsec.conf --leak-detective --seedbits=520 --seeddev /dev/urandom
+ipsec pluto --config /etc/ipsec.conf --seedbits=520 --seeddev /dev/urandom
 ../../guestbin/wait-until-pluto-started
 ipsec whack --shutdown
 grep -E "^seeded" /tmp/pluto.log

--- a/testing/pluto/x509-crl-02-old-crl-strict-no-ikev1/west.console.txt
+++ b/testing/pluto/x509-crl-02-old-crl-strict-no-ikev1/west.console.txt
@@ -27,7 +27,7 @@ nic                                                          P,,
 west #
  # need to pass impair into pluto
 west #
- ipsec pluto --config /etc/ipsec.conf --leak-detective --impair event_check_crls
+ ipsec pluto --config /etc/ipsec.conf --impair event_check_crls
 ipsec pluto: impair: event_check_crls: no -> yes
 west #
  ../../guestbin/wait-until-pluto-started

--- a/testing/pluto/x509-crl-02-old-crl-strict-no-ikev1/westinit.sh
+++ b/testing/pluto/x509-crl-02-old-crl-strict-no-ikev1/westinit.sh
@@ -7,7 +7,7 @@
 ipsec certutil -L
 
 # need to pass impair into pluto
-ipsec pluto --config /etc/ipsec.conf --leak-detective --impair event_check_crls
+ipsec pluto --config /etc/ipsec.conf --impair event_check_crls
 ../../guestbin/wait-until-pluto-started
 ipsec whack --impair suppress_retransmits
 ipsec whack --impair revival

--- a/testing/pluto/x509-crl-02-old-crl-strict-no-ikev2/west.console.txt
+++ b/testing/pluto/x509-crl-02-old-crl-strict-no-ikev2/west.console.txt
@@ -27,7 +27,7 @@ nic                                                          P,,
 west #
  # need to pass impair into pluto
 west #
- ipsec pluto --config /etc/ipsec.conf --leak-detective --impair event_check_crls
+ ipsec pluto --config /etc/ipsec.conf --impair event_check_crls
 ipsec pluto: impair: event_check_crls: no -> yes
 west #
  ../../guestbin/wait-until-pluto-started

--- a/testing/pluto/x509-crl-02-old-crl-strict-no-ikev2/westinit.sh
+++ b/testing/pluto/x509-crl-02-old-crl-strict-no-ikev2/westinit.sh
@@ -7,7 +7,7 @@
 ipsec certutil -L
 
 # need to pass impair into pluto
-ipsec pluto --config /etc/ipsec.conf --leak-detective --impair event_check_crls
+ipsec pluto --config /etc/ipsec.conf --impair event_check_crls
 ../../guestbin/wait-until-pluto-started
 ipsec whack --impair suppress_retransmits
 ipsec whack --impair revival

--- a/testing/pluto/x509-crl-02-old-crl-strict-yes-ikev1/west.console.txt
+++ b/testing/pluto/x509-crl-02-old-crl-strict-yes-ikev1/west.console.txt
@@ -27,7 +27,7 @@ nic                                                          P,,
 west #
  # need to pass impair into pluto
 west #
- ipsec pluto --config /etc/ipsec.conf --leak-detective --impair event_check_crls
+ ipsec pluto --config /etc/ipsec.conf --impair event_check_crls
 ipsec pluto: impair: event_check_crls: no -> yes
 west #
  ../../guestbin/wait-until-pluto-started

--- a/testing/pluto/x509-crl-02-old-crl-strict-yes-ikev1/westinit.sh
+++ b/testing/pluto/x509-crl-02-old-crl-strict-yes-ikev1/westinit.sh
@@ -7,7 +7,7 @@
 ipsec certutil -L
 
 # need to pass impair into pluto
-ipsec pluto --config /etc/ipsec.conf --leak-detective --impair event_check_crls
+ipsec pluto --config /etc/ipsec.conf --impair event_check_crls
 ../../guestbin/wait-until-pluto-started
 ipsec whack --impair suppress_retransmits
 ipsec whack --impair revival

--- a/testing/pluto/x509-crl-02-old-crl-strict-yes-ikev2-manual/west.console.txt
+++ b/testing/pluto/x509-crl-02-old-crl-strict-yes-ikev2-manual/west.console.txt
@@ -25,7 +25,7 @@ west                                                         u,u,u
 mainca                                                       CT,, 
 nic                                                          P,,  
 west #
- ipsec pluto --config /etc/ipsec.conf --leak-detective
+ ipsec pluto --config /etc/ipsec.conf
 west #
  ../../guestbin/wait-until-pluto-started
 west #

--- a/testing/pluto/x509-crl-02-old-crl-strict-yes-ikev2-manual/westinit.sh
+++ b/testing/pluto/x509-crl-02-old-crl-strict-yes-ikev2-manual/westinit.sh
@@ -6,7 +6,7 @@
 
 ipsec certutil -L
 
-ipsec pluto --config /etc/ipsec.conf --leak-detective
+ipsec pluto --config /etc/ipsec.conf
 ../../guestbin/wait-until-pluto-started
 ipsec whack --impair suppress_retransmits
 ipsec whack --impair revival

--- a/testing/pluto/x509-crl-02-old-crl-strict-yes-ikev2/west.console.txt
+++ b/testing/pluto/x509-crl-02-old-crl-strict-yes-ikev2/west.console.txt
@@ -27,7 +27,7 @@ nic                                                          P,,
 west #
  # need to pass impair into pluto
 west #
- ipsec pluto --config /etc/ipsec.conf --leak-detective --impair event_check_crls
+ ipsec pluto --config /etc/ipsec.conf --impair event_check_crls
 ipsec pluto: impair: event_check_crls: no -> yes
 west #
  ../../guestbin/wait-until-pluto-started

--- a/testing/pluto/x509-crl-02-old-crl-strict-yes-ikev2/westinit.sh
+++ b/testing/pluto/x509-crl-02-old-crl-strict-yes-ikev2/westinit.sh
@@ -7,7 +7,7 @@
 ipsec certutil -L
 
 # need to pass impair into pluto
-ipsec pluto --config /etc/ipsec.conf --leak-detective --impair event_check_crls
+ipsec pluto --config /etc/ipsec.conf --impair event_check_crls
 ../../guestbin/wait-until-pluto-started
 ipsec whack --impair suppress_retransmits
 ipsec whack --impair revival


### PR DESCRIPTION
Solves #2725 


**Summary of Changes**

makes leak detective mandatory and merging its functionality with refcnt.

Set leak_detective = true in alloc.c & removed ability to disable it at runtime.

Removed leak detective cli option. Deleted option parsing and handling from plutomain.c

Updated docs to reflect that leak detective is always enabled.

