### PR TITLE
Fix(libswan): warn when integ is specified before the prf in proposal

### DIFF
--- a/lib/libswan/proposals.c
+++ b/lib/libswan/proposals.c
@@ -1338,8 +1338,10 @@ static bool parse_prf_transforms(struct proposal_parser *parser,
 	 *
 	 *     <encrypt>-<PRF>...
 	 *
-	 * When PRF succeeds, the proposal is assumed to be
-	 * <encrypt>-<prf>[-<kem>] (i.e., <integ> can't follow).
+	 * When PRF succeeds, optionally try to also parse <INTEG>
+	 * that follows (i.e., <encrypt>-<prf>-<integ>[-<kem>]).
+	 * If the next token isn't a valid INTEG, backtrack and
+	 * let the caller handle it (likely as KEM).
 	 *
 	 * The merge code will then either build the INTEG from the
 	 * PRF or, when AEAD, set INTEG to NONE.
@@ -1356,6 +1358,53 @@ static bool parse_prf_transforms(struct proposal_parser *parser,
 	if (parse_transform_algorithms(parser, proposal, transform_type_prf, tokens, verbose)) {
 		/* advance */
 		vdbg("<encrypt>-<PRF> succeeded");
+		/*
+		 * After PRF succeeds, optionally try to parse <INTEG>
+		 * that follows, as in <encrypt>-<prf>-<INTEG>[-<kem>].
+		 * If the next token isn't a valid INTEG algorithm,
+		 * backtrack and return with just PRF (the caller will
+		 * try the remaining tokens as KEM).
+		 */
+		if (tokens->curr.token.ptr != NULL &&
+		    tokens->prev.delim != ';' &&
+		    parser->protocol->integ) {
+			struct tokens saved_tokens = (*tokens);
+			const unsigned saved_len = proposal->transforms.len;
+
+			if (parse_transform_algorithms(parser, proposal,
+						       transform_type_integ,
+						       tokens, verbose) &&
+			    !proposal_integ_none(proposal)) {
+				/*
+				 * INTEG parse succeeded and isn't NONE.
+				 * Verify the token is FQN integ (not
+				 * also valid as PRF).  If it also
+				 * resolves as PRF, the proposal is
+				 * ambiguous (<prf>-<prf>) and must be
+				 * rejected.
+				 */
+				struct tokens check_tokens = saved_tokens;
+				unsigned check_len = proposal->transforms.len;
+				bool also_prf = parse_transform_algorithms(
+					parser, proposal,
+					transform_type_prf,
+					&check_tokens, verbose);
+				pfree_diag(&parser->diag);
+				realloc_data(&proposal->transforms, check_len);
+
+				if (!also_prf) {
+					vdbg("<encrypt>-<PRF>-<INTEG> succeeded");
+					return true;
+				}
+				vdbg("<encrypt>-<PRF>-<INTEG> ambiguous (also valid PRF), backtracking");
+			}
+
+			/* INTEG failed, NONE or was ambigous; backtrack - remaining tokens may be KEM */
+			vdbg("<encrypt>-<PRF>-<INTEG>, backtracking");
+			pfree_diag(&parser->diag);
+			(*tokens) = saved_tokens;
+			realloc_data(&proposal->transforms, saved_len);
+		}
 		return true;
 	}
 
@@ -1410,6 +1459,14 @@ static bool parse_prf_transforms(struct proposal_parser *parser,
 	if (tokens->curr.token.ptr == NULL /*more?*/ ||
 	    tokens->prev.delim == ';' /*;KEM>*/) {
 		return true;
+	}
+	/*
+	 * Reaching here means INTEG was already consumed from the
+	 * proposal string before PRF.  Warn: the order is encrypt-prf-integ-kem.
+	 */
+	if (!proposal_integ_none(proposal)) {
+		llog(parser->policy->stream, parser->policy->logger,
+		     "WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order");
 	}
 
 	vdbg("trying <encrypt>-<prf>-<INTEG>");
@@ -1621,7 +1678,17 @@ bool parse_proposal(struct proposal_parser *parser,
 					       pri_shunk(tokens.curr.token));
 				return false;
 			}
-
+			/*
+			 * Warn when integ= is specified explicitly before prf=.
+			 * The new-syntax order is encrypt-prf-integ-kem;
+			 * specifying integ before prf produces confusing output.
+			 */
+			if (tmp == transform_type_integ &&
+			    transform_type <= transform_type_prf &&
+			    parser->protocol->prf) {
+				llog(parser->policy->stream, parser->policy->logger,
+				     "WARNING: IKE proposal has integ= specified before prf=; use encrypt-prf-integ-kem order");
+			}
 			vdbg("switching from '%s' transforms to '%s' transforms",
 			     transform_type->name,
 			     tmp->name);

--- a/programs/algparse/algparse.c
+++ b/programs/algparse/algparse.c
@@ -499,14 +499,19 @@ static void test_ike(struct logger *logger)
 	ike(false, "3des-id2"); /* should be rejected; idXXX removed */
 	ike(false, "aes_ccm"); /* ESP/AH only */
 
-	/* quads: <encrypt>-<integ>-<prf>[-;]<kem> */
-
-	/* can't follow valid <prf> with <integ> */
+	/* bad: <prf>-<prf> */
 	ike(false, "aes-sha1-sha2-ecp_521");
+	ike(false, "aes-sha2-sha1-ecp_521");
 	ike(false, "aes-sha2-sha2;ecp_521");
-	/* good; integ forced by fqn sha1_96 */
+	/* bad: <integ>-<integ> */
+	ike(false, "aes-sha1_96-sha2_256_128-ecp_521");
+	/* good: <fqn-integ>-<prf>; */
+	ike(ike_version == IKEv2, "aes-sha1_96-sha1-ecp_521");
 	ike(ike_version == IKEv2, "aes-sha1_96-sha2-ecp_521");
 	ike(ike_version == IKEv2, "aes-sha1_96-sha2;ecp_521");
+	/* good: <prf>-<fqn-integ>; NEW IKEv2 SYNTAX */
+	ike(ike_version == IKEv2, "aes-sha1-sha1_96-ecp_521");
+	ike(ike_version == IKEv2, "aes-sha2-sha1_96-ecp_521");
 	/* need to back out all PRFs */
 	ike(ike_version == IKEv2, "aes-sha2_256+sha1_96");
 	ike(ike_version == IKEv2, "aes-sha2_256+sha1_96-sha2_512");
@@ -547,6 +552,7 @@ static void test_ike(struct logger *logger)
 	ike(ike_version == IKEv2, "aes_gcm-none;modp2048");
 	ike(false, "aes_gcm-sha1-none-modp2048"); /* old syntax */
 	ike(false, "aes_gcm-sha1-none;modp2048"); /* old syntax */
+	ike(false, "aes_gcm-sha2-none-modp2048");
 
 	ike(false, "aes+aes_gcm"); /* mixing AEAD and NORM encryption */
 

--- a/testing/pluto/algparse-01/west.console.txt
+++ b/testing/pluto/algparse-01/west.console.txt
@@ -496,12 +496,22 @@ algparse -v1 'ike=aes_ccm' (expect ERROR)
 	ERROR: IKE Encryption Algorithm (cipher) 'aes_ccm' is not supported by IKEv1
 algparse -v1 'ike=aes-sha1-sha2-ecp_521' (expect ERROR)
 	ERROR: IKE Key Exchange Method (DH) 'sha2' is not recognized
+algparse -v1 'ike=aes-sha2-sha1-ecp_521' (expect ERROR)
+	ERROR: IKE Key Exchange Method (DH) 'sha1' is not recognized
 algparse -v1 'ike=aes-sha2-sha2;ecp_521' (expect ERROR)
 	ERROR: IKE Key Exchange Method (DH) 'sha2' is not recognized
+algparse -v1 'ike=aes-sha1_96-sha2_256_128-ecp_521' (expect ERROR)
+	ERROR: IKE Pseudorandom Function (KDF) 'sha1_96' is not recognized
+algparse -v1 'ike=aes-sha1_96-sha1-ecp_521' (expect ERROR)
+	ERROR: IKE Pseudorandom Function (KDF) 'sha1_96' is not recognized
 algparse -v1 'ike=aes-sha1_96-sha2-ecp_521' (expect ERROR)
 	ERROR: IKE Pseudorandom Function (KDF) 'sha1_96' is not recognized
 algparse -v1 'ike=aes-sha1_96-sha2;ecp_521' (expect ERROR)
 	ERROR: IKE Pseudorandom Function (KDF) 'sha1_96' is not recognized
+algparse -v1 'ike=aes-sha1-sha1_96-ecp_521' (expect ERROR)
+	ERROR: IKE Key Exchange Method (DH) 'sha1_96' is not recognized
+algparse -v1 'ike=aes-sha2-sha1_96-ecp_521' (expect ERROR)
+	ERROR: IKE Key Exchange Method (DH) 'sha1_96' is not recognized
 algparse -v1 'ike=aes-sha2_256+sha1_96' (expect ERROR)
 	ERROR: '+' invalid, IKEv1 proposals do not support multiple transforms of the same type
 algparse -v1 'ike=aes-sha2_256+sha1_96-sha2_512' (expect ERROR)
@@ -556,6 +566,8 @@ algparse -v1 'ike=aes_gcm-none;modp2048' (expect ERROR)
 algparse -v1 'ike=aes_gcm-sha1-none-modp2048' (expect ERROR)
 	ERROR: IKE Encryption Algorithm (cipher) 'aes_gcm' is not supported by IKEv1
 algparse -v1 'ike=aes_gcm-sha1-none;modp2048' (expect ERROR)
+	ERROR: IKE Encryption Algorithm (cipher) 'aes_gcm' is not supported by IKEv1
+algparse -v1 'ike=aes_gcm-sha2-none-modp2048' (expect ERROR)
 	ERROR: IKE Encryption Algorithm (cipher) 'aes_gcm' is not supported by IKEv1
 algparse -v1 'ike=aes+aes_gcm' (expect ERROR)
 	ERROR: '+' invalid, IKEv1 proposals do not support multiple transforms of the same type
@@ -1059,12 +1071,22 @@ algparse -v1 -pfs 'ike=aes_ccm' (expect ERROR)
 	ERROR: IKE Encryption Algorithm (cipher) 'aes_ccm' is not supported by IKEv1
 algparse -v1 -pfs 'ike=aes-sha1-sha2-ecp_521' (expect ERROR)
 	ERROR: IKE Key Exchange Method (DH) 'sha2' is not recognized
+algparse -v1 -pfs 'ike=aes-sha2-sha1-ecp_521' (expect ERROR)
+	ERROR: IKE Key Exchange Method (DH) 'sha1' is not recognized
 algparse -v1 -pfs 'ike=aes-sha2-sha2;ecp_521' (expect ERROR)
 	ERROR: IKE Key Exchange Method (DH) 'sha2' is not recognized
+algparse -v1 -pfs 'ike=aes-sha1_96-sha2_256_128-ecp_521' (expect ERROR)
+	ERROR: IKE Pseudorandom Function (KDF) 'sha1_96' is not recognized
+algparse -v1 -pfs 'ike=aes-sha1_96-sha1-ecp_521' (expect ERROR)
+	ERROR: IKE Pseudorandom Function (KDF) 'sha1_96' is not recognized
 algparse -v1 -pfs 'ike=aes-sha1_96-sha2-ecp_521' (expect ERROR)
 	ERROR: IKE Pseudorandom Function (KDF) 'sha1_96' is not recognized
 algparse -v1 -pfs 'ike=aes-sha1_96-sha2;ecp_521' (expect ERROR)
 	ERROR: IKE Pseudorandom Function (KDF) 'sha1_96' is not recognized
+algparse -v1 -pfs 'ike=aes-sha1-sha1_96-ecp_521' (expect ERROR)
+	ERROR: IKE Key Exchange Method (DH) 'sha1_96' is not recognized
+algparse -v1 -pfs 'ike=aes-sha2-sha1_96-ecp_521' (expect ERROR)
+	ERROR: IKE Key Exchange Method (DH) 'sha1_96' is not recognized
 algparse -v1 -pfs 'ike=aes-sha2_256+sha1_96' (expect ERROR)
 	ERROR: '+' invalid, IKEv1 proposals do not support multiple transforms of the same type
 algparse -v1 -pfs 'ike=aes-sha2_256+sha1_96-sha2_512' (expect ERROR)
@@ -1119,6 +1141,8 @@ algparse -v1 -pfs 'ike=aes_gcm-none;modp2048' (expect ERROR)
 algparse -v1 -pfs 'ike=aes_gcm-sha1-none-modp2048' (expect ERROR)
 	ERROR: IKE Encryption Algorithm (cipher) 'aes_gcm' is not supported by IKEv1
 algparse -v1 -pfs 'ike=aes_gcm-sha1-none;modp2048' (expect ERROR)
+	ERROR: IKE Encryption Algorithm (cipher) 'aes_gcm' is not supported by IKEv1
+algparse -v1 -pfs 'ike=aes_gcm-sha2-none-modp2048' (expect ERROR)
 	ERROR: IKE Encryption Algorithm (cipher) 'aes_gcm' is not supported by IKEv1
 algparse -v1 -pfs 'ike=aes+aes_gcm' (expect ERROR)
 	ERROR: '+' invalid, IKEv1 proposals do not support multiple transforms of the same type
@@ -1613,19 +1637,36 @@ algparse -v2 'ike=aes_ccm' (expect ERROR)
 	ERROR: IKE Encryption Algorithm (cipher) 'aes_ccm' is not supported
 algparse -v2 'ike=aes-sha1-sha2-ecp_521' (expect ERROR)
 	ERROR: IKE Key Exchange Method (DH) 'sha2' is not recognized
+algparse -v2 'ike=aes-sha2-sha1-ecp_521' (expect ERROR)
+	ERROR: IKE Key Exchange Method (DH) 'sha1' is not recognized
 algparse -v2 'ike=aes-sha2-sha2;ecp_521' (expect ERROR)
 	ERROR: IKE Key Exchange Method (DH) 'sha2' is not recognized
+algparse -v2 'ike=aes-sha1_96-sha2_256_128-ecp_521' (expect ERROR)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
+	ERROR: IKE Pseudorandom Function (KDF) 'sha2_256_128' is not recognized
+algparse -v2 'ike=aes-sha1_96-sha1-ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
+	AES_CBC-HMAC_SHA1-DH21
 algparse -v2 'ike=aes-sha1_96-sha2-ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
 	AES_CBC-HMAC_SHA1_96-HMAC_SHA2_256-DH21
 algparse -v2 'ike=aes-sha1_96-sha2;ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
+	AES_CBC-HMAC_SHA1_96-HMAC_SHA2_256-DH21
+algparse -v2 'ike=aes-sha1-sha1_96-ecp_521' (expect SUCCESS)
+	AES_CBC-HMAC_SHA1-DH21
+algparse -v2 'ike=aes-sha2-sha1_96-ecp_521' (expect SUCCESS)
 	AES_CBC-HMAC_SHA1_96-HMAC_SHA2_256-DH21
 algparse -v2 'ike=aes-sha2_256+sha1_96' (expect SUCCESS)
 	AES_CBC-HMAC_SHA2_256_128+HMAC_SHA1_96-HMAC_SHA2_512+HMAC_SHA2_256-DH19+DH20+DH21+DH31+MODP4096+MODP3072+MODP2048+MODP8192
 algparse -v2 'ike=aes-sha2_256+sha1_96-sha2_512' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
 	AES_CBC-HMAC_SHA2_256_128+HMAC_SHA1_96-HMAC_SHA2_512-DH19+DH20+DH21+DH31+MODP4096+MODP3072+MODP2048+MODP8192
 algparse -v2 'ike=aes-sha2_256+sha1_96-sha2_512-ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
 	AES_CBC-HMAC_SHA2_256_128+HMAC_SHA1_96-HMAC_SHA2_512-DH21
 algparse -v2 'ike=aes-sha2_256+sha1_96-sha2_512;ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
 	AES_CBC-HMAC_SHA2_256_128+HMAC_SHA1_96-HMAC_SHA2_512-DH21
 algparse -v2 'ike=aes+aes-sha1+sha1-modp8192+modp8192' (expect SUCCESS)
 ipsec algparse: discarding duplicate IKE Encryption Algorithm (cipher) AES_CBC
@@ -1689,6 +1730,8 @@ algparse -v2 'ike=aes_gcm-sha1-none-modp2048' (expect ERROR)
 	ERROR: IKE proposal contains unexpected '-modp2048', expecting ';<transform>=...'
 algparse -v2 'ike=aes_gcm-sha1-none;modp2048' (expect ERROR)
 	ERROR: IKE proposal contains unexpected ';modp2048', expecting ';<transform>=...'
+algparse -v2 'ike=aes_gcm-sha2-none-modp2048' (expect ERROR)
+	ERROR: IKE proposal contains unexpected '-modp2048', expecting ';<transform>=...'
 algparse -v2 'ike=aes+aes_gcm' (expect ERROR)
 	ERROR: AEAD and non-AEAD IKE encryption algorithm cannot be combined
 algparse -v2 'ike=,' (expect ERROR)
@@ -2133,19 +2176,36 @@ algparse -v2 -pfs 'ike=aes_ccm' (expect ERROR)
 	ERROR: IKE Encryption Algorithm (cipher) 'aes_ccm' is not supported
 algparse -v2 -pfs 'ike=aes-sha1-sha2-ecp_521' (expect ERROR)
 	ERROR: IKE Key Exchange Method (DH) 'sha2' is not recognized
+algparse -v2 -pfs 'ike=aes-sha2-sha1-ecp_521' (expect ERROR)
+	ERROR: IKE Key Exchange Method (DH) 'sha1' is not recognized
 algparse -v2 -pfs 'ike=aes-sha2-sha2;ecp_521' (expect ERROR)
 	ERROR: IKE Key Exchange Method (DH) 'sha2' is not recognized
+algparse -v2 -pfs 'ike=aes-sha1_96-sha2_256_128-ecp_521' (expect ERROR)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
+	ERROR: IKE Pseudorandom Function (KDF) 'sha2_256_128' is not recognized
+algparse -v2 -pfs 'ike=aes-sha1_96-sha1-ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
+	AES_CBC-HMAC_SHA1-DH21
 algparse -v2 -pfs 'ike=aes-sha1_96-sha2-ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
 	AES_CBC-HMAC_SHA1_96-HMAC_SHA2_256-DH21
 algparse -v2 -pfs 'ike=aes-sha1_96-sha2;ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
+	AES_CBC-HMAC_SHA1_96-HMAC_SHA2_256-DH21
+algparse -v2 -pfs 'ike=aes-sha1-sha1_96-ecp_521' (expect SUCCESS)
+	AES_CBC-HMAC_SHA1-DH21
+algparse -v2 -pfs 'ike=aes-sha2-sha1_96-ecp_521' (expect SUCCESS)
 	AES_CBC-HMAC_SHA1_96-HMAC_SHA2_256-DH21
 algparse -v2 -pfs 'ike=aes-sha2_256+sha1_96' (expect SUCCESS)
 	AES_CBC-HMAC_SHA2_256_128+HMAC_SHA1_96-HMAC_SHA2_512+HMAC_SHA2_256-DH19+DH20+DH21+DH31+MODP4096+MODP3072+MODP2048+MODP8192
 algparse -v2 -pfs 'ike=aes-sha2_256+sha1_96-sha2_512' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
 	AES_CBC-HMAC_SHA2_256_128+HMAC_SHA1_96-HMAC_SHA2_512-DH19+DH20+DH21+DH31+MODP4096+MODP3072+MODP2048+MODP8192
 algparse -v2 -pfs 'ike=aes-sha2_256+sha1_96-sha2_512-ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
 	AES_CBC-HMAC_SHA2_256_128+HMAC_SHA1_96-HMAC_SHA2_512-DH21
 algparse -v2 -pfs 'ike=aes-sha2_256+sha1_96-sha2_512;ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
 	AES_CBC-HMAC_SHA2_256_128+HMAC_SHA1_96-HMAC_SHA2_512-DH21
 algparse -v2 -pfs 'ike=aes+aes-sha1+sha1-modp8192+modp8192' (expect SUCCESS)
 ipsec algparse: discarding duplicate IKE Encryption Algorithm (cipher) AES_CBC
@@ -2209,6 +2269,8 @@ algparse -v2 -pfs 'ike=aes_gcm-sha1-none-modp2048' (expect ERROR)
 	ERROR: IKE proposal contains unexpected '-modp2048', expecting ';<transform>=...'
 algparse -v2 -pfs 'ike=aes_gcm-sha1-none;modp2048' (expect ERROR)
 	ERROR: IKE proposal contains unexpected ';modp2048', expecting ';<transform>=...'
+algparse -v2 -pfs 'ike=aes_gcm-sha2-none-modp2048' (expect ERROR)
+	ERROR: IKE proposal contains unexpected '-modp2048', expecting ';<transform>=...'
 algparse -v2 -pfs 'ike=aes+aes_gcm' (expect ERROR)
 	ERROR: AEAD and non-AEAD IKE encryption algorithm cannot be combined
 algparse -v2 -pfs 'ike=,' (expect ERROR)
@@ -2653,19 +2715,36 @@ algparse -addke -v2 -pfs 'ike=aes_ccm' (expect ERROR)
 	ERROR: IKE Encryption Algorithm (cipher) 'aes_ccm' is not supported
 algparse -addke -v2 -pfs 'ike=aes-sha1-sha2-ecp_521' (expect ERROR)
 	ERROR: IKE Key Exchange Method (DH) 'sha2' is not recognized
+algparse -addke -v2 -pfs 'ike=aes-sha2-sha1-ecp_521' (expect ERROR)
+	ERROR: IKE Key Exchange Method (DH) 'sha1' is not recognized
 algparse -addke -v2 -pfs 'ike=aes-sha2-sha2;ecp_521' (expect ERROR)
 	ERROR: IKE Key Exchange Method (DH) 'sha2' is not recognized
+algparse -addke -v2 -pfs 'ike=aes-sha1_96-sha2_256_128-ecp_521' (expect ERROR)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
+	ERROR: IKE Pseudorandom Function (KDF) 'sha2_256_128' is not recognized
+algparse -addke -v2 -pfs 'ike=aes-sha1_96-sha1-ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
+	AES_CBC-HMAC_SHA1-DH21
 algparse -addke -v2 -pfs 'ike=aes-sha1_96-sha2-ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
 	AES_CBC-HMAC_SHA1_96-HMAC_SHA2_256-DH21
 algparse -addke -v2 -pfs 'ike=aes-sha1_96-sha2;ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
+	AES_CBC-HMAC_SHA1_96-HMAC_SHA2_256-DH21
+algparse -addke -v2 -pfs 'ike=aes-sha1-sha1_96-ecp_521' (expect SUCCESS)
+	AES_CBC-HMAC_SHA1-DH21
+algparse -addke -v2 -pfs 'ike=aes-sha2-sha1_96-ecp_521' (expect SUCCESS)
 	AES_CBC-HMAC_SHA1_96-HMAC_SHA2_256-DH21
 algparse -addke -v2 -pfs 'ike=aes-sha2_256+sha1_96' (expect SUCCESS)
 	AES_CBC-HMAC_SHA2_256_128+HMAC_SHA1_96-HMAC_SHA2_512+HMAC_SHA2_256-DH19+DH20+DH21+DH31+MODP4096+MODP3072+MODP2048+MODP8192
 algparse -addke -v2 -pfs 'ike=aes-sha2_256+sha1_96-sha2_512' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
 	AES_CBC-HMAC_SHA2_256_128+HMAC_SHA1_96-HMAC_SHA2_512-DH19+DH20+DH21+DH31+MODP4096+MODP3072+MODP2048+MODP8192
 algparse -addke -v2 -pfs 'ike=aes-sha2_256+sha1_96-sha2_512-ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
 	AES_CBC-HMAC_SHA2_256_128+HMAC_SHA1_96-HMAC_SHA2_512-DH21
 algparse -addke -v2 -pfs 'ike=aes-sha2_256+sha1_96-sha2_512;ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
 	AES_CBC-HMAC_SHA2_256_128+HMAC_SHA1_96-HMAC_SHA2_512-DH21
 algparse -addke -v2 -pfs 'ike=aes+aes-sha1+sha1-modp8192+modp8192' (expect SUCCESS)
 ipsec algparse: discarding duplicate IKE Encryption Algorithm (cipher) AES_CBC
@@ -2729,6 +2808,8 @@ algparse -addke -v2 -pfs 'ike=aes_gcm-sha1-none-modp2048' (expect ERROR)
 	ERROR: IKE Key Exchange algorithm 'NONE' not permitted
 algparse -addke -v2 -pfs 'ike=aes_gcm-sha1-none;modp2048' (expect ERROR)
 	ERROR: IKE proposal contains unexpected ';modp2048', expecting ';<transform>=...'
+algparse -addke -v2 -pfs 'ike=aes_gcm-sha2-none-modp2048' (expect ERROR)
+	ERROR: IKE Key Exchange algorithm 'NONE' not permitted
 algparse -addke -v2 -pfs 'ike=aes+aes_gcm' (expect ERROR)
 	ERROR: AEAD and non-AEAD IKE encryption algorithm cannot be combined
 algparse -addke -v2 -pfs 'ike=,' (expect ERROR)

--- a/testing/pluto/algparse-02-fips/west.console.txt
+++ b/testing/pluto/algparse-02-fips/west.console.txt
@@ -473,12 +473,22 @@ algparse -fips -v1 'ike=aes_ccm' (expect ERROR)
 	ERROR: IKE Encryption Algorithm (cipher) 'aes_ccm' is not supported by IKEv1
 algparse -fips -v1 'ike=aes-sha1-sha2-ecp_521' (expect ERROR)
 	ERROR: IKE Key Exchange Method (DH) 'sha2' is not recognized
+algparse -fips -v1 'ike=aes-sha2-sha1-ecp_521' (expect ERROR)
+	ERROR: IKE Key Exchange Method (DH) 'sha1' is not recognized
 algparse -fips -v1 'ike=aes-sha2-sha2;ecp_521' (expect ERROR)
 	ERROR: IKE Key Exchange Method (DH) 'sha2' is not recognized
+algparse -fips -v1 'ike=aes-sha1_96-sha2_256_128-ecp_521' (expect ERROR)
+	ERROR: IKE Pseudorandom Function (KDF) 'sha1_96' is not recognized
+algparse -fips -v1 'ike=aes-sha1_96-sha1-ecp_521' (expect ERROR)
+	ERROR: IKE Pseudorandom Function (KDF) 'sha1_96' is not recognized
 algparse -fips -v1 'ike=aes-sha1_96-sha2-ecp_521' (expect ERROR)
 	ERROR: IKE Pseudorandom Function (KDF) 'sha1_96' is not recognized
 algparse -fips -v1 'ike=aes-sha1_96-sha2;ecp_521' (expect ERROR)
 	ERROR: IKE Pseudorandom Function (KDF) 'sha1_96' is not recognized
+algparse -fips -v1 'ike=aes-sha1-sha1_96-ecp_521' (expect ERROR)
+	ERROR: IKE Key Exchange Method (DH) 'sha1_96' is not recognized
+algparse -fips -v1 'ike=aes-sha2-sha1_96-ecp_521' (expect ERROR)
+	ERROR: IKE Key Exchange Method (DH) 'sha1_96' is not recognized
 algparse -fips -v1 'ike=aes-sha2_256+sha1_96' (expect ERROR)
 	ERROR: '+' invalid, IKEv1 proposals do not support multiple transforms of the same type
 algparse -fips -v1 'ike=aes-sha2_256+sha1_96-sha2_512' (expect ERROR)
@@ -533,6 +543,8 @@ algparse -fips -v1 'ike=aes_gcm-none;modp2048' (expect ERROR)
 algparse -fips -v1 'ike=aes_gcm-sha1-none-modp2048' (expect ERROR)
 	ERROR: IKE Encryption Algorithm (cipher) 'aes_gcm' is not supported by IKEv1
 algparse -fips -v1 'ike=aes_gcm-sha1-none;modp2048' (expect ERROR)
+	ERROR: IKE Encryption Algorithm (cipher) 'aes_gcm' is not supported by IKEv1
+algparse -fips -v1 'ike=aes_gcm-sha2-none-modp2048' (expect ERROR)
 	ERROR: IKE Encryption Algorithm (cipher) 'aes_gcm' is not supported by IKEv1
 algparse -fips -v1 'ike=aes+aes_gcm' (expect ERROR)
 	ERROR: '+' invalid, IKEv1 proposals do not support multiple transforms of the same type
@@ -1010,12 +1022,22 @@ algparse -fips -v1 -pfs 'ike=aes_ccm' (expect ERROR)
 	ERROR: IKE Encryption Algorithm (cipher) 'aes_ccm' is not supported by IKEv1
 algparse -fips -v1 -pfs 'ike=aes-sha1-sha2-ecp_521' (expect ERROR)
 	ERROR: IKE Key Exchange Method (DH) 'sha2' is not recognized
+algparse -fips -v1 -pfs 'ike=aes-sha2-sha1-ecp_521' (expect ERROR)
+	ERROR: IKE Key Exchange Method (DH) 'sha1' is not recognized
 algparse -fips -v1 -pfs 'ike=aes-sha2-sha2;ecp_521' (expect ERROR)
 	ERROR: IKE Key Exchange Method (DH) 'sha2' is not recognized
+algparse -fips -v1 -pfs 'ike=aes-sha1_96-sha2_256_128-ecp_521' (expect ERROR)
+	ERROR: IKE Pseudorandom Function (KDF) 'sha1_96' is not recognized
+algparse -fips -v1 -pfs 'ike=aes-sha1_96-sha1-ecp_521' (expect ERROR)
+	ERROR: IKE Pseudorandom Function (KDF) 'sha1_96' is not recognized
 algparse -fips -v1 -pfs 'ike=aes-sha1_96-sha2-ecp_521' (expect ERROR)
 	ERROR: IKE Pseudorandom Function (KDF) 'sha1_96' is not recognized
 algparse -fips -v1 -pfs 'ike=aes-sha1_96-sha2;ecp_521' (expect ERROR)
 	ERROR: IKE Pseudorandom Function (KDF) 'sha1_96' is not recognized
+algparse -fips -v1 -pfs 'ike=aes-sha1-sha1_96-ecp_521' (expect ERROR)
+	ERROR: IKE Key Exchange Method (DH) 'sha1_96' is not recognized
+algparse -fips -v1 -pfs 'ike=aes-sha2-sha1_96-ecp_521' (expect ERROR)
+	ERROR: IKE Key Exchange Method (DH) 'sha1_96' is not recognized
 algparse -fips -v1 -pfs 'ike=aes-sha2_256+sha1_96' (expect ERROR)
 	ERROR: '+' invalid, IKEv1 proposals do not support multiple transforms of the same type
 algparse -fips -v1 -pfs 'ike=aes-sha2_256+sha1_96-sha2_512' (expect ERROR)
@@ -1070,6 +1092,8 @@ algparse -fips -v1 -pfs 'ike=aes_gcm-none;modp2048' (expect ERROR)
 algparse -fips -v1 -pfs 'ike=aes_gcm-sha1-none-modp2048' (expect ERROR)
 	ERROR: IKE Encryption Algorithm (cipher) 'aes_gcm' is not supported by IKEv1
 algparse -fips -v1 -pfs 'ike=aes_gcm-sha1-none;modp2048' (expect ERROR)
+	ERROR: IKE Encryption Algorithm (cipher) 'aes_gcm' is not supported by IKEv1
+algparse -fips -v1 -pfs 'ike=aes_gcm-sha2-none-modp2048' (expect ERROR)
 	ERROR: IKE Encryption Algorithm (cipher) 'aes_gcm' is not supported by IKEv1
 algparse -fips -v1 -pfs 'ike=aes+aes_gcm' (expect ERROR)
 	ERROR: '+' invalid, IKEv1 proposals do not support multiple transforms of the same type
@@ -1558,19 +1582,36 @@ algparse -fips -v2 'ike=aes_ccm' (expect ERROR)
 	ERROR: IKE Encryption Algorithm (cipher) 'aes_ccm' is not supported
 algparse -fips -v2 'ike=aes-sha1-sha2-ecp_521' (expect ERROR)
 	ERROR: IKE Key Exchange Method (DH) 'sha2' is not recognized
+algparse -fips -v2 'ike=aes-sha2-sha1-ecp_521' (expect ERROR)
+	ERROR: IKE Key Exchange Method (DH) 'sha1' is not recognized
 algparse -fips -v2 'ike=aes-sha2-sha2;ecp_521' (expect ERROR)
 	ERROR: IKE Key Exchange Method (DH) 'sha2' is not recognized
+algparse -fips -v2 'ike=aes-sha1_96-sha2_256_128-ecp_521' (expect ERROR)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
+	ERROR: IKE Pseudorandom Function (KDF) 'sha2_256_128' is not recognized
+algparse -fips -v2 'ike=aes-sha1_96-sha1-ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
+	AES_CBC-HMAC_SHA1-DH21
 algparse -fips -v2 'ike=aes-sha1_96-sha2-ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
 	AES_CBC-HMAC_SHA1_96-HMAC_SHA2_256-DH21
 algparse -fips -v2 'ike=aes-sha1_96-sha2;ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
+	AES_CBC-HMAC_SHA1_96-HMAC_SHA2_256-DH21
+algparse -fips -v2 'ike=aes-sha1-sha1_96-ecp_521' (expect SUCCESS)
+	AES_CBC-HMAC_SHA1-DH21
+algparse -fips -v2 'ike=aes-sha2-sha1_96-ecp_521' (expect SUCCESS)
 	AES_CBC-HMAC_SHA1_96-HMAC_SHA2_256-DH21
 algparse -fips -v2 'ike=aes-sha2_256+sha1_96' (expect SUCCESS)
 	AES_CBC-HMAC_SHA2_256_128+HMAC_SHA1_96-HMAC_SHA2_512+HMAC_SHA2_256-DH19+DH20+DH21+DH31+MODP4096+MODP3072+MODP2048+MODP8192
 algparse -fips -v2 'ike=aes-sha2_256+sha1_96-sha2_512' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
 	AES_CBC-HMAC_SHA2_256_128+HMAC_SHA1_96-HMAC_SHA2_512-DH19+DH20+DH21+DH31+MODP4096+MODP3072+MODP2048+MODP8192
 algparse -fips -v2 'ike=aes-sha2_256+sha1_96-sha2_512-ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
 	AES_CBC-HMAC_SHA2_256_128+HMAC_SHA1_96-HMAC_SHA2_512-DH21
 algparse -fips -v2 'ike=aes-sha2_256+sha1_96-sha2_512;ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
 	AES_CBC-HMAC_SHA2_256_128+HMAC_SHA1_96-HMAC_SHA2_512-DH21
 algparse -fips -v2 'ike=aes+aes-sha1+sha1-modp8192+modp8192' (expect SUCCESS)
 ipsec algparse: discarding duplicate IKE Encryption Algorithm (cipher) AES_CBC
@@ -1634,6 +1675,8 @@ algparse -fips -v2 'ike=aes_gcm-sha1-none-modp2048' (expect ERROR)
 	ERROR: IKE proposal contains unexpected '-modp2048', expecting ';<transform>=...'
 algparse -fips -v2 'ike=aes_gcm-sha1-none;modp2048' (expect ERROR)
 	ERROR: IKE proposal contains unexpected ';modp2048', expecting ';<transform>=...'
+algparse -fips -v2 'ike=aes_gcm-sha2-none-modp2048' (expect ERROR)
+	ERROR: IKE proposal contains unexpected '-modp2048', expecting ';<transform>=...'
 algparse -fips -v2 'ike=aes+aes_gcm' (expect ERROR)
 	ERROR: AEAD and non-AEAD IKE encryption algorithm cannot be combined
 algparse -fips -v2 'ike=,' (expect ERROR)
@@ -2076,19 +2119,36 @@ algparse -fips -v2 -pfs 'ike=aes_ccm' (expect ERROR)
 	ERROR: IKE Encryption Algorithm (cipher) 'aes_ccm' is not supported
 algparse -fips -v2 -pfs 'ike=aes-sha1-sha2-ecp_521' (expect ERROR)
 	ERROR: IKE Key Exchange Method (DH) 'sha2' is not recognized
+algparse -fips -v2 -pfs 'ike=aes-sha2-sha1-ecp_521' (expect ERROR)
+	ERROR: IKE Key Exchange Method (DH) 'sha1' is not recognized
 algparse -fips -v2 -pfs 'ike=aes-sha2-sha2;ecp_521' (expect ERROR)
 	ERROR: IKE Key Exchange Method (DH) 'sha2' is not recognized
+algparse -fips -v2 -pfs 'ike=aes-sha1_96-sha2_256_128-ecp_521' (expect ERROR)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
+	ERROR: IKE Pseudorandom Function (KDF) 'sha2_256_128' is not recognized
+algparse -fips -v2 -pfs 'ike=aes-sha1_96-sha1-ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
+	AES_CBC-HMAC_SHA1-DH21
 algparse -fips -v2 -pfs 'ike=aes-sha1_96-sha2-ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
 	AES_CBC-HMAC_SHA1_96-HMAC_SHA2_256-DH21
 algparse -fips -v2 -pfs 'ike=aes-sha1_96-sha2;ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
+	AES_CBC-HMAC_SHA1_96-HMAC_SHA2_256-DH21
+algparse -fips -v2 -pfs 'ike=aes-sha1-sha1_96-ecp_521' (expect SUCCESS)
+	AES_CBC-HMAC_SHA1-DH21
+algparse -fips -v2 -pfs 'ike=aes-sha2-sha1_96-ecp_521' (expect SUCCESS)
 	AES_CBC-HMAC_SHA1_96-HMAC_SHA2_256-DH21
 algparse -fips -v2 -pfs 'ike=aes-sha2_256+sha1_96' (expect SUCCESS)
 	AES_CBC-HMAC_SHA2_256_128+HMAC_SHA1_96-HMAC_SHA2_512+HMAC_SHA2_256-DH19+DH20+DH21+DH31+MODP4096+MODP3072+MODP2048+MODP8192
 algparse -fips -v2 -pfs 'ike=aes-sha2_256+sha1_96-sha2_512' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
 	AES_CBC-HMAC_SHA2_256_128+HMAC_SHA1_96-HMAC_SHA2_512-DH19+DH20+DH21+DH31+MODP4096+MODP3072+MODP2048+MODP8192
 algparse -fips -v2 -pfs 'ike=aes-sha2_256+sha1_96-sha2_512-ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
 	AES_CBC-HMAC_SHA2_256_128+HMAC_SHA1_96-HMAC_SHA2_512-DH21
 algparse -fips -v2 -pfs 'ike=aes-sha2_256+sha1_96-sha2_512;ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
 	AES_CBC-HMAC_SHA2_256_128+HMAC_SHA1_96-HMAC_SHA2_512-DH21
 algparse -fips -v2 -pfs 'ike=aes+aes-sha1+sha1-modp8192+modp8192' (expect SUCCESS)
 ipsec algparse: discarding duplicate IKE Encryption Algorithm (cipher) AES_CBC
@@ -2152,6 +2212,8 @@ algparse -fips -v2 -pfs 'ike=aes_gcm-sha1-none-modp2048' (expect ERROR)
 	ERROR: IKE proposal contains unexpected '-modp2048', expecting ';<transform>=...'
 algparse -fips -v2 -pfs 'ike=aes_gcm-sha1-none;modp2048' (expect ERROR)
 	ERROR: IKE proposal contains unexpected ';modp2048', expecting ';<transform>=...'
+algparse -fips -v2 -pfs 'ike=aes_gcm-sha2-none-modp2048' (expect ERROR)
+	ERROR: IKE proposal contains unexpected '-modp2048', expecting ';<transform>=...'
 algparse -fips -v2 -pfs 'ike=aes+aes_gcm' (expect ERROR)
 	ERROR: AEAD and non-AEAD IKE encryption algorithm cannot be combined
 algparse -fips -v2 -pfs 'ike=,' (expect ERROR)
@@ -2594,19 +2656,36 @@ algparse -fips -addke -v2 -pfs 'ike=aes_ccm' (expect ERROR)
 	ERROR: IKE Encryption Algorithm (cipher) 'aes_ccm' is not supported
 algparse -fips -addke -v2 -pfs 'ike=aes-sha1-sha2-ecp_521' (expect ERROR)
 	ERROR: IKE Key Exchange Method (DH) 'sha2' is not recognized
+algparse -fips -addke -v2 -pfs 'ike=aes-sha2-sha1-ecp_521' (expect ERROR)
+	ERROR: IKE Key Exchange Method (DH) 'sha1' is not recognized
 algparse -fips -addke -v2 -pfs 'ike=aes-sha2-sha2;ecp_521' (expect ERROR)
 	ERROR: IKE Key Exchange Method (DH) 'sha2' is not recognized
+algparse -fips -addke -v2 -pfs 'ike=aes-sha1_96-sha2_256_128-ecp_521' (expect ERROR)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
+	ERROR: IKE Pseudorandom Function (KDF) 'sha2_256_128' is not recognized
+algparse -fips -addke -v2 -pfs 'ike=aes-sha1_96-sha1-ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
+	AES_CBC-HMAC_SHA1-DH21
 algparse -fips -addke -v2 -pfs 'ike=aes-sha1_96-sha2-ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
 	AES_CBC-HMAC_SHA1_96-HMAC_SHA2_256-DH21
 algparse -fips -addke -v2 -pfs 'ike=aes-sha1_96-sha2;ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
+	AES_CBC-HMAC_SHA1_96-HMAC_SHA2_256-DH21
+algparse -fips -addke -v2 -pfs 'ike=aes-sha1-sha1_96-ecp_521' (expect SUCCESS)
+	AES_CBC-HMAC_SHA1-DH21
+algparse -fips -addke -v2 -pfs 'ike=aes-sha2-sha1_96-ecp_521' (expect SUCCESS)
 	AES_CBC-HMAC_SHA1_96-HMAC_SHA2_256-DH21
 algparse -fips -addke -v2 -pfs 'ike=aes-sha2_256+sha1_96' (expect SUCCESS)
 	AES_CBC-HMAC_SHA2_256_128+HMAC_SHA1_96-HMAC_SHA2_512+HMAC_SHA2_256-DH19+DH20+DH21+DH31+MODP4096+MODP3072+MODP2048+MODP8192
 algparse -fips -addke -v2 -pfs 'ike=aes-sha2_256+sha1_96-sha2_512' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
 	AES_CBC-HMAC_SHA2_256_128+HMAC_SHA1_96-HMAC_SHA2_512-DH19+DH20+DH21+DH31+MODP4096+MODP3072+MODP2048+MODP8192
 algparse -fips -addke -v2 -pfs 'ike=aes-sha2_256+sha1_96-sha2_512-ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
 	AES_CBC-HMAC_SHA2_256_128+HMAC_SHA1_96-HMAC_SHA2_512-DH21
 algparse -fips -addke -v2 -pfs 'ike=aes-sha2_256+sha1_96-sha2_512;ecp_521' (expect SUCCESS)
+ipsec algparse: WARNING: IKE proposal has integ specified before prf; use encrypt-prf-integ-kem order
 	AES_CBC-HMAC_SHA2_256_128+HMAC_SHA1_96-HMAC_SHA2_512-DH21
 algparse -fips -addke -v2 -pfs 'ike=aes+aes-sha1+sha1-modp8192+modp8192' (expect SUCCESS)
 ipsec algparse: discarding duplicate IKE Encryption Algorithm (cipher) AES_CBC
@@ -2670,6 +2749,8 @@ algparse -fips -addke -v2 -pfs 'ike=aes_gcm-sha1-none-modp2048' (expect ERROR)
 	ERROR: IKE Key Exchange algorithm 'NONE' not permitted
 algparse -fips -addke -v2 -pfs 'ike=aes_gcm-sha1-none;modp2048' (expect ERROR)
 	ERROR: IKE proposal contains unexpected ';modp2048', expecting ';<transform>=...'
+algparse -fips -addke -v2 -pfs 'ike=aes_gcm-sha2-none-modp2048' (expect ERROR)
+	ERROR: IKE Key Exchange algorithm 'NONE' not permitted
 algparse -fips -addke -v2 -pfs 'ike=aes+aes_gcm' (expect ERROR)
 	ERROR: AEAD and non-AEAD IKE encryption algorithm cannot be combined
 algparse -fips -addke -v2 -pfs 'ike=,' (expect ERROR)


### PR DESCRIPTION
Reference Issue #2729 

Adds warnings to the parser when integ precedes prf.
Updated the testcases as well.