### PR TITLE
plutomain: normalize audit and leak detective log format

### DIFF
--- a/programs/pluto/plutomain.c
+++ b/programs/pluto/plutomain.c
@@ -1445,11 +1445,11 @@ int main(int argc, char **argv)
 	llog(RC_LOG, logger, "Linux audit support [%s]",
 	     (audit_ok ? "enabled" : "disabled"));
 #else
-	llog(RC_LOG, logger, "Linux audit support [DISABLED]");
+	llog(RC_LOG, logger, "Linux audit support [disabled]");
 #endif
 
 	llog(RC_LOG, logger, leak_detective ?
-	     "leak-detective enabled" : "leak-detective disabled");
+	     "leak-detective [enabled]" : "leak-detective [disabled]");
 
 	llog(RC_LOG, logger, "NSS crypto [enabled]");
 

--- a/testing/guestbin/post-mortem.sh
+++ b/testing/guestbin/post-mortem.sh
@@ -106,7 +106,7 @@ elif ${core} ; then
     SKIP as pluto core dumped
 elif test ! -s /tmp/pluto.log ; then
     SKIP as pluto.log was empty
-elif grep 'leak-detective disabled' /tmp/pluto.log ; then
+elif grep 'leak-detective \[disabled\]' /tmp/pluto.log ; then
     SKIP as leak-detective was disabled
 elif grep 'leak detective found [0-9]* leaks' /tmp/pluto.log ; then
     FAIL


### PR DESCRIPTION
Fixes #2745

**Before**
Linux audit support [DISABLED]
leak-detective enabled / leak-detective disabled

**After**
Linux audit support [disabled]
leak-detective [enabled] / leak-detective [disabled]
        
= Also updated testing/guestbin/post-mortem.sh to grep for the new "leak-detective [disabled]" form (dead otherwise)