### PR TITLE
cavp: fix LTO build failure triggered by leak-detective being default

### DIFF
--- a/programs/cavp/Makefile
+++ b/programs/cavp/Makefile
@@ -35,6 +35,11 @@ OBJS += test_ikev1_psk.o
 OBJS += test_ikev1_dsa.o
 USERLAND_CFLAGS += -DUSE_IKEv1
 endif
+
+# With LTO and leak-detective (now default), the compiler gets confused
+# about the bounds in clone_bytes_as_hunk() with flexible array members.
+# This should suppress the false positive.
+USERLAND_CFLAGS += -Wno-stringop-overflow
 OBJS += test_ikev2.o
 OBJS += test_sha.o
 OBJS += test_hmac.o


### PR DESCRIPTION
fixes #2756 


**Summary of Changes**

Fix LTO build failure in CAVP test programs introduced after enabling leak-detective by default ( #2743 )

The failure occurs in test_ikev1_psk.c via clone_bytes_as_hunk() and involves struct secret_preshared_stuff combined with the leak-detective allocation path.

As noted in discussion in #2756 , this appears to be an existing issue that became visible under LTO, where the compiler’s bounds analysis results in a -Wstringop-overflow error.

This change suppresses this warning specifically for cavp test programs using -Wno-stringop-overflow.