### PR TITLE
pluto: log default proposals at startup 

### DIFF
--- a/include/ike_alg.h
+++ b/include/ike_alg.h
@@ -903,5 +903,19 @@ const struct encrypt_desc *encrypt_desc_by_sadb_ealg_id(unsigned id);
 const struct integ_desc *integ_desc_by_sadb_aalg_id(unsigned id);
 const struct ipcomp_desc *ipcomp_desc_by_sadb_calg_id(unsigned id);
 const struct sn_desc *sn_desc_by_sadb_calg_id(unsigned id);
+/*
+ * Protocol table shared by algparse and pluto.
+ */
 
+struct proposal_policy;
+struct proposal_parser;
+
+struct ike_alg_protocol {
+	const char *name;
+	struct proposal_parser *(*parser)(const struct proposal_policy *policy);
+	bool pfs_vs_dh;
+	bool (*alg_is_ok)(const struct ike_alg *alg, const struct logger *logger);
+};
+
+extern const struct ike_alg_protocol *ike_alg_protocols[];
 #endif /* _IKE_ALG_H */

--- a/lib/libswan/ike_alg.c
+++ b/lib/libswan/ike_alg.c
@@ -1425,3 +1425,48 @@ void init_ike_alg(struct logger *logger)
 	 */
 	log_ike_algs(logger);
 }
+/*
+ * Shared protocol table for IKE, ESP, and AH.
+ * Pluto can override alg_is_ok
+ * in the proposal_policy with the real kernel_alg_is_ok.
+ */
+
+static bool default_alg_is_ok(const struct ike_alg *alg,
+			      const struct logger *logger)
+{
+	if (alg->type == &ike_alg_kem) {
+		/* require an in-process/ike implementation of DH */
+		return ike_alg_is_ike(alg, logger);
+	} else {
+		/* no kernel to ask! */
+		return true;
+	}
+}
+
+static const struct ike_alg_protocol ike_alg_ike_protocol = {
+	.name = "ike",
+	.parser = ike_proposal_parser,
+	.pfs_vs_dh = false,
+	.alg_is_ok = ike_alg_is_ike,
+};
+
+static const struct ike_alg_protocol ike_alg_esp_protocol = {
+	.name = "esp",
+	.parser = esp_proposal_parser,
+	.pfs_vs_dh = true,
+	.alg_is_ok = default_alg_is_ok,
+};
+
+static const struct ike_alg_protocol ike_alg_ah_protocol = {
+	.name = "ah",
+	.parser = ah_proposal_parser,
+	.pfs_vs_dh = true,
+	.alg_is_ok = default_alg_is_ok,
+};
+
+const struct ike_alg_protocol *ike_alg_protocols[] = {
+	&ike_alg_ike_protocol,
+	&ike_alg_esp_protocol,
+	&ike_alg_ah_protocol,
+	NULL,
+};

--- a/programs/algparse/algparse.c
+++ b/programs/algparse/algparse.c
@@ -25,49 +25,10 @@ static int failures = 0;
 
 enum expect { FAIL = false, PASS = true, COUNT, };
 
-/*
- * Kernel not available so fake it.
- */
-static bool kernel_alg_is_ok(const struct ike_alg *alg,
-			     const struct logger *logger)
-{
-	if (alg->type == &ike_alg_kem) {
-		/* require an in-process/ike implementation of DH */
-		return ike_alg_is_ike(alg, logger);
-	} else {
-		/* no kernel to ask! */
-		return true;
-	}
-}
-
 typedef void (protocol_t)(enum expect expected, const char *, struct logger *logger);
 
-struct protocol {
-	const char *name;
-	struct proposal_parser *(*parser)(const struct proposal_policy *policy);
-	bool pfs_vs_dh;
-	bool (*alg_is_ok)(const struct ike_alg *alg, const struct logger *logger);
-};
 
-const struct protocol ike_protocol = {
-	"ike", ike_proposal_parser, .pfs_vs_dh = false, .alg_is_ok = ike_alg_is_ike,
-};
-
-const struct protocol ah_protocol = {
-	"ah", ah_proposal_parser, .pfs_vs_dh = true, .alg_is_ok = kernel_alg_is_ok,
-};
-
-const struct protocol esp_protocol = {
-	"esp", esp_proposal_parser, .pfs_vs_dh = true, .alg_is_ok = kernel_alg_is_ok,
-};
-
-const struct protocol *protocols[] = {
-	&ike_protocol,
-	&ah_protocol,
-	&esp_protocol,
-};
-
-static void check(const struct protocol *protocol,
+static void check(const struct ike_alg_protocol *protocol,
 		  enum expect expected,
 		  const char *algstr,
 		  struct logger *logger)
@@ -155,17 +116,18 @@ static void check(const struct protocol *protocol,
 
 static void all(const char *algstr, struct logger *logger)
 {
-	FOR_EACH_ELEMENT(protocolp, protocols) {
-		const struct protocol *protocol = (*protocolp);
-		check(protocol, COUNT, algstr, logger);
+	for (const struct ike_alg_protocol **protocolp = ike_alg_protocols;
+	     *protocolp != NULL; protocolp++) {
+		check(*protocolp, COUNT, algstr, logger);
 	}
 }
 
 static void test_proposal(const char *arg, struct logger *logger)
 {
 	const char *eq = strchr(arg, '=');
-	FOR_EACH_ELEMENT(protocolp, protocols) {
-		const struct protocol *protocol = (*protocolp);
+	for (const struct ike_alg_protocol **protocolp = ike_alg_protocols;
+	     *protocolp != NULL; protocolp++) {
+		const struct ike_alg_protocol *protocol = *protocolp;
 		if (streq(arg, protocol->name)) {
 			check(protocol, COUNT, NULL, logger);
 			return;
@@ -185,7 +147,7 @@ static void test_proposal(const char *arg, struct logger *logger)
 
 static void test_esp(struct logger *logger)
 {
-#define esp(EXPECTED, ALGSTR) check(&esp_protocol, EXPECTED, ALGSTR, logger)
+#define esp(EXPECTED, ALGSTR) check(ike_alg_protocols[1], EXPECTED, ALGSTR, logger)
 
 	esp(true, NULL);
 	esp(false, "");
@@ -424,7 +386,7 @@ static void test_esp(struct logger *logger)
 
 static void test_ah(struct logger *logger)
 {
-#define ah(EXPECTED, ALGSTR) check(&ah_protocol, EXPECTED, ALGSTR, logger)
+#define ah(EXPECTED, ALGSTR) check(ike_alg_protocols[2], EXPECTED, ALGSTR, logger)
 
 	ah(true, NULL);
 	ah(false, "");
@@ -483,7 +445,7 @@ static void test_ah(struct logger *logger)
 static void test_ike(struct logger *logger)
 {
 
-#define ike(EXPECTED, ALGSTR) check(&ike_protocol, EXPECTED, ALGSTR, logger)
+#define ike(EXPECTED, ALGSTR) check(ike_alg_protocols[0], EXPECTED, ALGSTR, logger)
 
 	ike(true, NULL);
 	ike(false, "");

--- a/programs/pluto/plutomain.c
+++ b/programs/pluto/plutomain.c
@@ -86,6 +86,7 @@
 #include "ddos.h"
 #include "helper.h"
 #include "resolve_helper.h"	/* for init_resolve_helper() */
+#include "kernel_alg.h"	
 
 #ifndef IPSECDIR
 #define IPSECDIR "/etc/ipsec.d"
@@ -586,6 +587,55 @@ static deltatime_t check_config_deltatime(enum config_setup_keyword kw,
 	return time;
 }
 
+/*
+ * Dump expanded default proposals at startup when debugging.
+ */
+static void log_default_proposals(struct logger *logger)
+{
+	static const enum ike_version versions[] = {
+		IKEv2,
+#ifdef USE_IKEv1
+		IKEv1,
+#endif
+	};
+
+	for (const struct ike_alg_protocol **pp = ike_alg_protocols;
+	     *pp != NULL; pp++) {
+		const struct ike_alg_protocol *protocol = *pp;
+
+		for (unsigned v = 0; v < elemsof(versions); v++) {
+
+			const struct proposal_policy policy = {
+				.version = versions[v],
+				.alg_is_ok = protocol->pfs_vs_dh
+					? kernel_alg_is_ok
+					: protocol->alg_is_ok,
+				.pfs = true,
+				.check_pfs_vs_ke = false,
+				.logger = logger,
+				.stream = LOG_STREAM,
+				.ignore_transform_lookup_error = true,
+			};
+
+			struct proposal_parser *parser = protocol->parser(&policy);
+			struct proposals *proposals = proposals_from_str(parser, NULL);
+			if (proposals != NULL) {
+				llog(RC_LOG, logger, "%sdefault IKEv%d %s proposals:",
+				     (is_fips_mode() ? "FIPS " : ""),
+				     versions[v],
+				     protocol->name);
+				FOR_EACH_PROPOSAL(proposals, proposal) {
+					LLOG_JAMBUF(RC_LOG, logger, buf) {
+						jam_string(buf, "  ");
+						jam_proposal(buf, proposal);
+					}
+				}
+				free_proposals(&proposals);
+			}
+			free_proposal_parser(&parser);
+		}
+	}
+}
 #ifdef USE_EFENCE
 extern int EF_PROTECT_BELOW;
 extern int EF_PROTECT_FREE;
@@ -1535,6 +1585,7 @@ int main(int argc, char **argv)
 	start_helpers(nhelpers, logger);
 
 	init_kernel(logger);
+	log_default_proposals(logger);
 
 #if defined(USE_LIBCURL) || defined(USE_LDAP)
 	bool crl_enabled = init_x509_crl_queue(logger);

--- a/testing/pluto/algparse-02-fips/west.console.txt
+++ b/testing/pluto/algparse-02-fips/west.console.txt
@@ -2820,6 +2820,12 @@ FIPS Integrity Algorithm:
 FIPS Key Exchange Method (DH):
 FIPS IP Compression:
 FIPS Sequence Number:
+FIPS default IKEv2 ike proposals:
+FIPS default IKEv1 ike proposals:
+FIPS default IKEv2 esp proposals:
+FIPS default IKEv1 esp proposals:
+FIPS default IKEv2 ah proposals:
+FIPS default IKEv1 ah proposals:
 west #
  # Check pluto algorithm list.
 west #


### PR DESCRIPTION
added a patch to print the default proposals on startup.
Fixes: #2753 


<img width="904" height="569" alt="image" src="https://github.com/user-attachments/assets/eb8f2948-b13e-457a-bcff-bb983b35e853" />