### PR TITLE
feat(pluto): plant connection reqid in trap XFRMA_TMPL; capture from ACQUIRE

### DIFF
--- a/programs/pluto/kernel_policy.c
+++ b/programs/pluto/kernel_policy.c
@@ -359,6 +359,14 @@ bool add_spd_kernel_policy(const struct spd *spd,
 					&nic_offload,
 					where);
 
+	/*
+	 * Plant the  reqid into the policy template so the kernel
+	 * echoes it back in XFRMA_TMPL.
+	 */
+	if (kernel_policy.nr_rules > 0) {
+		kernel_policy.rule[0].reqid = c->child.reqid;
+	}
+
 	if (!kernel_ops_policy_add(op, direction,
 				   &kernel_policy.src.client,
 				   &kernel_policy.dst.client,
@@ -450,6 +458,9 @@ bool replace_spd_kernel_policy(const struct spd *spd,
 					HUNK_AS_SHUNK(&c->config->sec_label),
 					&nic_offload,
 					where);
+	if (kernel_policy.nr_rules > 0) {
+		kernel_policy.rule[0].reqid = c->child.reqid;
+	}
 	return add_kernel_policy(KERNEL_POLICY_OP_REPLACE, direction,
 				 &spd->local->client,
 				 &spd->remote->client,
@@ -485,6 +496,9 @@ static bool restore_spd_kernel_policy(const struct spd *spd,
 					HUNK_AS_SHUNK(&c->config->sec_label),
 					&nic_offload,
 					where);
+	if (kernel_policy.nr_rules > 0) {
+		kernel_policy.rule[0].reqid = c->child.reqid;
+	}
 	return add_kernel_policy(KERNEL_POLICY_OP_REPLACE, direction,
 				 &spd->local->client,
 				 &spd->remote->client,

--- a/programs/pluto/kernel_xfrm.c
+++ b/programs/pluto/kernel_xfrm.c
@@ -2277,7 +2277,11 @@ static void netlink_acquire(struct nlmsghdr *n, struct logger *logger)
 	 * Run through rtattributes looking for XFRMA_SEC_CTX
 	 * Instead, it should loop through all (known rtattributes
 	 * and use/log them.
+	 *
+	 * Also capture the first tmpl reqid: add_spd_kernel_policy()
+	 * planted reqid here.
 	 */
+	reqid_t acquire_reqid = 0;
 	struct rtattr *attr = (struct rtattr *)
 		((char*) NLMSG_DATA(n) +
 			NLMSG_ALIGN(sizeof(struct xfrm_user_acquire)));
@@ -2303,6 +2307,11 @@ static void netlink_acquire(struct nlmsghdr *n, struct logger *logger)
 				jam(buf, " ealgos: %ju", (uintmax_t) tmpl->ealgos);
 				jam(buf, " calgos: %ju", (uintmax_t) tmpl->calgos);
 				jam(buf, "}");
+			}
+			if (acquire_reqid == 0) {
+				acquire_reqid = tmpl->reqid;
+				ldbg(logger, "netlink_acquire: captured reqid %ju from XFRMA_TMPL",
+				     (uintmax_t) acquire_reqid);
 			}
 			break;
 		}
@@ -2377,7 +2386,8 @@ static void netlink_acquire(struct nlmsghdr *n, struct logger *logger)
 		.background = true, /* no whack so doesn't matter */
 		.sec_label = sec_label,
 		.state_id = acquire->seq,
-		.policy_id = acquire->policy.index,
+		.policy_id = (acquire_reqid != 0 ? acquire_reqid
+						 : acquire->policy.index),
 	};
 
 	initiate_ondemand(&b);

--- a/testing/pluto/auto-keep-01-revival-through-nat-down-ikev2/east.console.txt
+++ b/testing/pluto/auto-keep-01-revival-through-nat-down-ikev2/east.console.txt
@@ -44,7 +44,7 @@ east #
 src 192.0.2.0/24 dst 192.1.3.209/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #
  # Now trigger the revival.  Since ROAD is down it will fail.  And
 east #

--- a/testing/pluto/auto-keep-02-revival-through-nat-cleanfail-ikev2/east.console.txt
+++ b/testing/pluto/auto-keep-02-revival-through-nat-cleanfail-ikev2/east.console.txt
@@ -52,7 +52,7 @@ east #
 src 192.0.2.0/24 dst 192.1.3.209/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #
  # Now trigger the revival.  Since ROAD is down it will fail.  And
 east #

--- a/testing/pluto/basic-pluto-13-xfrm-ondemand/west.console.txt
+++ b/testing/pluto/basic-pluto-13-xfrm-ondemand/west.console.txt
@@ -69,7 +69,7 @@ src 192.1.2.23 dst 192.1.2.45
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.0.1.254 dst 192.0.2.254
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.0.1.254/32 dst 192.0.2.254/32 proto icmp type 8 code 0 dev eth1 
@@ -96,7 +96,7 @@ west #
 west #
  ipsec _kernel state
 src 192.0.1.254 dst 192.0.2.254
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.0.1.254/32 dst 192.0.2.254/32 proto icmp type 8 code 0 dev eth1 
@@ -105,5 +105,5 @@ west #
 src 192.0.1.0/24 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #

--- a/testing/pluto/certoe-02-whack-otherca/west.console.txt
+++ b/testing/pluto/certoe-02-whack-otherca/west.console.txt
@@ -85,5 +85,5 @@ src 192.1.3.253/32 dst 192.1.2.45/32
 src 192.1.2.45/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #

--- a/testing/pluto/certoe-03-cop-whack/road.console.txt
+++ b/testing/pluto/certoe-03-cop-whack/road.console.txt
@@ -119,7 +119,7 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  killall ip > /dev/null 2> /dev/null
 road #

--- a/testing/pluto/certoe-03-poc-whack/road.console.txt
+++ b/testing/pluto/certoe-03-poc-whack/road.console.txt
@@ -119,7 +119,7 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  killall ip > /dev/null 2> /dev/null
 road #
@@ -197,7 +197,7 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  hostname | grep nic > /dev/null || ipsec whack --trafficstatus
 #2: "private-or-clear#192.1.2.0/24"[1] ...192.1.2.23, type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org'

--- a/testing/pluto/certoe-05-poc-reverse/road.console.txt
+++ b/testing/pluto/certoe-05-poc-reverse/road.console.txt
@@ -70,7 +70,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -115,7 +115,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  killall ip > /dev/null 2> /dev/null
 road #

--- a/testing/pluto/certoe-10-symmetric-cert-whack/road.console.txt
+++ b/testing/pluto/certoe-10-symmetric-cert-whack/road.console.txt
@@ -94,19 +94,19 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.0.2.0/24 dst 192.1.3.209/32
 	dir fwd action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.0.2.0/24 dst 192.1.3.209/32
 	dir in action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.0.2.0/24
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  killall ip > /dev/null 2> /dev/null
 road #

--- a/testing/pluto/certoe-11-symmetric-cert-nat/road.console.txt
+++ b/testing/pluto/certoe-11-symmetric-cert-nat/road.console.txt
@@ -107,7 +107,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  killall ip > /dev/null 2> /dev/null
 road #

--- a/testing/pluto/certoe-12-nat-server/road.console.txt
+++ b/testing/pluto/certoe-12-nat-server/road.console.txt
@@ -87,7 +87,7 @@ src 192.1.3.130 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.3.130
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.3.130/32 proto icmp type 8 code 0 dev eth0 
@@ -132,7 +132,7 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.1.3.128/27
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # you should see both RSA and NULL
 road #

--- a/testing/pluto/certoe-14-poc-del-slash32/road.console.txt
+++ b/testing/pluto/certoe-14-poc-del-slash32/road.console.txt
@@ -106,7 +106,7 @@ src 192.1.3.254/32 dst 10.11.12.13/32
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ../../guestbin/ping-once.sh --forget -I 192.1.3.209 192.1.2.23
 fired and forgotten

--- a/testing/pluto/certoe-15-poc-east-west/west.console.txt
+++ b/testing/pluto/certoe-15-poc-east-west/west.console.txt
@@ -81,7 +81,7 @@ west #
 src 192.1.2.45/32 dst 192.1.2.23/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.45/32 dst 192.1.2.253/32
 	dir out priority PRIORITY ptype main
 src 192.1.2.45/32 dst 192.1.2.254/32

--- a/testing/pluto/certoe-17-asymmetric-cert-nat/road.console.txt
+++ b/testing/pluto/certoe-17-asymmetric-cert-nat/road.console.txt
@@ -104,7 +104,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ipsec whack --trafficstatus
 #2: "private-or-clear#192.1.2.0/24"[1] 10.0.10.1/32=== ...192.1.2.23, type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org', lease=10.0.10.1/32

--- a/testing/pluto/certoe-18-pass-then-go-slash24-keyingtries1/east.console.txt
+++ b/testing/pluto/certoe-18-pass-then-go-slash24-keyingtries1/east.console.txt
@@ -87,7 +87,7 @@ src 192.1.3.209 dst 192.1.2.23
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.2.23 dst 192.1.3.209
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.2.23/32 dst 192.1.3.209/32 proto icmp type 8 code 0 dev eth1 
@@ -132,5 +132,5 @@ src 192.1.3.254/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #

--- a/testing/pluto/certoe-18-pass-then-go-slash24-keyingtries1/road.console.txt
+++ b/testing/pluto/certoe-18-pass-then-go-slash24-keyingtries1/road.console.txt
@@ -44,7 +44,7 @@ road #
 road #
  ipsec _kernel state
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -79,7 +79,7 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  echo "waiting on east to start ipsec and OE initiate to us"
 waiting on east to start ipsec and OE initiate to us
@@ -121,7 +121,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -166,7 +166,7 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # letting 60s shunt expire
 road #
@@ -223,7 +223,7 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # nic blocks cleartext, so confirm tunnel is working
 road #

--- a/testing/pluto/certoe-19-bareshunts-expire/road.console.txt
+++ b/testing/pluto/certoe-19-bareshunts-expire/road.console.txt
@@ -106,7 +106,7 @@ road #
 src 192.1.3.209/32 dst 192.1.3.46/32
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # wait for OE to fail: should show pass in shuntstatus and xfrm policy
 road #

--- a/testing/pluto/crossing-streams-20-peer-restarts-ondemand-ike-auth/west.console.txt
+++ b/testing/pluto/crossing-streams-20-peer-restarts-ondemand-ike-auth/west.console.txt
@@ -31,7 +31,7 @@ west #
 src 192.0.1.0/24 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  # west gets an acquire; negotiates up to IKE_AUTH
 west #
@@ -62,7 +62,7 @@ west #
 src 192.0.1.0/24 dst 192.0.2.0/24
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  # west receives IKE_SA_INIT request
 west #
@@ -102,7 +102,7 @@ src 192.1.2.23 dst 192.1.2.45
 	dir in
 	sel src 192.1.2.23/32 dst 192.1.2.45/32 
 src 192.0.1.254 dst 192.0.2.254
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.0.1.254/32 dst 192.0.2.254/32 proto icmp type 8 code 0 dev eth1 

--- a/testing/pluto/crossing-streams-20-peer-restarts-ondemand-ike-sa-init/west.console.txt
+++ b/testing/pluto/crossing-streams-20-peer-restarts-ondemand-ike-sa-init/west.console.txt
@@ -31,7 +31,7 @@ west #
 src 192.0.1.0/24 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  # west gets an acquire; negotiates up to IKE_AUTH
 west #
@@ -53,7 +53,7 @@ west #
 src 192.0.1.0/24 dst 192.0.2.0/24
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  # west receives IKE_SA_INIT request
 west #
@@ -88,7 +88,7 @@ src 192.1.2.23 dst 192.1.2.45
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.0.1.254 dst 192.0.2.254
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.0.1.254/32 dst 192.0.2.254/32 proto icmp type 8 code 0 dev eth1 

--- a/testing/pluto/crossing-streams-24-ikev2-delete-connswitch-github-2101/east.console.txt
+++ b/testing/pluto/crossing-streams-24-ikev2-delete-connswitch-github-2101/east.console.txt
@@ -43,5 +43,5 @@ east #
 src 192.0.20.0/24 dst 192.0.3.254/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #

--- a/testing/pluto/dpd-04/west.console.txt
+++ b/testing/pluto/dpd-04/west.console.txt
@@ -112,15 +112,15 @@ west #
 src 192.1.2.45/32 dst 192.1.2.23/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.45/32 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.0.1.0/24 dst 192.1.2.23/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  # remove the block
 west #
@@ -207,7 +207,7 @@ src 192.1.2.23 dst 192.1.2.45
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.0.1.254 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.0.1.254/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth1 
@@ -230,7 +230,7 @@ src 192.1.2.23 dst 192.1.2.45
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.2.45 dst 192.0.2.254
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.2.45/32 dst 192.0.2.254/32 proto icmp type 8 code 0 dev eth1 
@@ -253,7 +253,7 @@ src 192.1.2.23 dst 192.1.2.45
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.2.45 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.2.45/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth1 

--- a/testing/pluto/ikev2-29-no-rekey/west.console.txt
+++ b/testing/pluto/ikev2-29-no-rekey/west.console.txt
@@ -334,5 +334,5 @@ west #
 src 192.0.1.0/24 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #

--- a/testing/pluto/ikev2-30-rw-no-rekey/road.console.txt
+++ b/testing/pluto/ikev2-30-rw-no-rekey/road.console.txt
@@ -55,5 +55,5 @@ road #
 src 192.0.2.100/32 dst 0.0.0.0/0
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #

--- a/testing/pluto/ikev2-33-clearport-01/west.console.txt
+++ b/testing/pluto/ikev2-33-clearport-01/west.console.txt
@@ -23,7 +23,7 @@ west #
 src 192.1.2.45/32 dst 192.1.2.23/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  # poke a hole to port 7, those packets will be allowed cleartext
 west #
@@ -39,7 +39,7 @@ src 192.1.2.45/32 dst 192.1.2.23/32 proto tcp dport 7
 src 192.1.2.45/32 dst 192.1.2.23/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  # send packet over the clear exception - should return connection
 west #

--- a/testing/pluto/ikev2-delete-01/west.console.txt
+++ b/testing/pluto/ikev2-delete-01/west.console.txt
@@ -313,5 +313,5 @@ west #
 src 192.0.1.0/24 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #

--- a/testing/pluto/ikev2-delete-02/west.console.txt
+++ b/testing/pluto/ikev2-delete-02/west.console.txt
@@ -83,7 +83,7 @@ west #
 src 192.0.1.0/24 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  ipsec whack --showstates
 #1: "west-east-delete1":500 established IKE SA; REKEY in XXs; REPLACE in XXs; newest; idle;
@@ -103,7 +103,7 @@ west #
 src 192.0.1.0/24 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  ipsec auto --showstates
 west #

--- a/testing/pluto/ikev2-liveness-09-revival/west.console.txt
+++ b/testing/pluto/ikev2-liveness-09-revival/west.console.txt
@@ -109,7 +109,7 @@ west #
 src 192.0.1.0/24 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  # now let the revival kick in; the trap should be replaced by a %hold(block)
 west #
@@ -144,7 +144,7 @@ west #
 src 192.0.1.0/24 dst 192.0.2.0/24
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  # Remove the null route; things should recover (after a few
 west #

--- a/testing/pluto/ikev2-oe-09-transport-ipv4/east.console.txt
+++ b/testing/pluto/ikev2-oe-09-transport-ipv4/east.console.txt
@@ -75,17 +75,17 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.23/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.23/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.23/32 dst 7.0.0.0/8
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #

--- a/testing/pluto/ikev2-oe-09-transport-ipv4/road.console.txt
+++ b/testing/pluto/ikev2-oe-09-transport-ipv4/road.console.txt
@@ -38,7 +38,7 @@ road #
  ipsec _kernel state | grep mode
 	proto esp spi 0xSPISPI reqid REQID mode transport
 	proto esp spi 0xSPISPI reqid REQID mode transport
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 road #
  echo done
 done
@@ -66,7 +66,7 @@ src 192.1.2.23 dst 192.1.3.209
 	dir in
 	sel src 192.1.2.23/32 dst 192.1.3.209/32 
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -107,17 +107,17 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 7.0.0.0/8
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #

--- a/testing/pluto/ikev2-oe-09-transport-ipv6/east.console.txt
+++ b/testing/pluto/ikev2-oe-09-transport-ipv6/east.console.txt
@@ -88,5 +88,5 @@ src 2001:db8:1:3::209/128 dst 2001:db8:1:2::23/128
 src 2001:db8:1:2::23/128 dst 2001:db8:1:3::/64
 	dir out priority PRIORITY ptype main
 	tmpl src :: dst ::
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #

--- a/testing/pluto/ikev2-oe-09-transport-ipv6/road.console.txt
+++ b/testing/pluto/ikev2-oe-09-transport-ipv6/road.console.txt
@@ -45,7 +45,7 @@ road #
  ipsec _kernel state | grep mode
 	proto esp spi 0xSPISPI reqid REQID mode transport
 	proto esp spi 0xSPISPI reqid REQID mode transport
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 road #
  echo done
 done
@@ -73,7 +73,7 @@ src 2001:db8:1:2::23 dst 2001:db8:1:3::209
 	dir in
 	sel src 2001:db8:1:2::23/128 dst 2001:db8:1:3::209/128 
 src 2001:db8:1:3::209 dst 2001:db8:1:2::23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 2001:db8:1:3::209/128 dst 2001:db8:1:2::23/128 proto ipv6-icmp type 128 code 0 
@@ -120,5 +120,5 @@ src 2001:db8:1:3::209/128 dst 2001:db8:1:2::23/128
 src 2001:db8:1:3::209/128 dst 2001:db8:1:2::/64
 	dir out priority PRIORITY ptype main
 	tmpl src :: dst ::
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #

--- a/testing/pluto/ikev2-ondemand-01-instance-auto/north.console.txt
+++ b/testing/pluto/ikev2-ondemand-01-instance-auto/north.console.txt
@@ -17,7 +17,7 @@ north #
 src 192.0.3.254/32 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 north #
  # one ping to trigger IKE
 north #
@@ -86,7 +86,7 @@ north #
 src 192.0.3.254/32 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 north #
  ipsec _kernel state
 north #

--- a/testing/pluto/ikev2-ondemand-01-instance-route/north.console.txt
+++ b/testing/pluto/ikev2-ondemand-01-instance-route/north.console.txt
@@ -20,7 +20,7 @@ north #
 src 192.0.3.254/32 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 north #
  ipsec unroute initiator
 north #
@@ -34,7 +34,7 @@ north #
 src 192.0.3.254/32 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 north #
  # one ping to trigger IKE
 north #
@@ -103,7 +103,7 @@ north #
 src 192.0.3.254/32 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 north #
  ipsec _kernel state
 north #

--- a/testing/pluto/ikev2-ondemand-02-permanent-auto-transport/west.console.txt
+++ b/testing/pluto/ikev2-ondemand-02-permanent-auto-transport/west.console.txt
@@ -15,7 +15,7 @@ west #
 src 192.1.2.45/32 dst 192.1.2.23/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  ../../guestbin/ping-once.sh --forget -I 192.1.2.45 192.1.2.23
 fired and forgotten
@@ -80,7 +80,7 @@ west #
 src 192.1.2.45/32 dst 192.1.2.23/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  # everything cleared out
 west #

--- a/testing/pluto/ikev2-ondemand-02-permanent-auto-tunnel/west.console.txt
+++ b/testing/pluto/ikev2-ondemand-02-permanent-auto-tunnel/west.console.txt
@@ -17,7 +17,7 @@ west #
 src 192.1.2.45/32 dst 192.1.2.23/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  ../../guestbin/ping-once.sh --forget -I 192.1.2.45 192.1.2.23
 fired and forgotten
@@ -84,7 +84,7 @@ west #
 src 192.1.2.45/32 dst 192.1.2.23/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  # everything cleared out
 west #

--- a/testing/pluto/ikev2-ondemand-02-permanent-route-transport/west.console.txt
+++ b/testing/pluto/ikev2-ondemand-02-permanent-route-transport/west.console.txt
@@ -20,7 +20,7 @@ west #
 src 192.1.2.45/32 dst 192.1.2.23/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  ipsec unroute initiator
 west #
@@ -34,7 +34,7 @@ west #
 src 192.1.2.45/32 dst 192.1.2.23/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  # one ping to trigger IKE
 west #
@@ -101,7 +101,7 @@ west #
 src 192.1.2.45/32 dst 192.1.2.23/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  ipsec _kernel state
 west #

--- a/testing/pluto/ikev2-ondemand-02-permanent-route-tunnel/west.console.txt
+++ b/testing/pluto/ikev2-ondemand-02-permanent-route-tunnel/west.console.txt
@@ -20,7 +20,7 @@ west #
 src 192.1.2.45/32 dst 192.1.2.23/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  ipsec unroute initiator
 west #
@@ -34,7 +34,7 @@ west #
 src 192.1.2.45/32 dst 192.1.2.23/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  # one ping to trigger IKE
 west #
@@ -103,7 +103,7 @@ west #
 src 192.1.2.45/32 dst 192.1.2.23/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  ipsec _kernel state
 west #

--- a/testing/pluto/ikev2-ondemand-04-timeout-instance/north.console.txt
+++ b/testing/pluto/ikev2-ondemand-04-timeout-instance/north.console.txt
@@ -20,7 +20,7 @@ north #
 src 192.0.3.254/32 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 north #
  # initiate a connection
 north #
@@ -34,7 +34,7 @@ north #
 src 192.0.3.254/32 dst 192.0.2.0/24
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 north #
  # wait for it to fail
 north #
@@ -45,7 +45,7 @@ north #
 src 192.0.3.254/32 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 north #
  # let larval state expire
 north #
@@ -116,7 +116,7 @@ north #
 src 192.0.3.254/32 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 north #
  ipsec _kernel state
 north #

--- a/testing/pluto/ikev2-ondemand-04-timeout-permanent-transport/west.console.txt
+++ b/testing/pluto/ikev2-ondemand-04-timeout-permanent-transport/west.console.txt
@@ -20,7 +20,7 @@ west #
 src 192.1.2.45/32 dst 192.1.2.23/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  # initiate a connection
 west #
@@ -34,7 +34,7 @@ west #
 src 192.1.2.45/32 dst 192.1.2.23/32
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  # wait for it to fail
 west #
@@ -45,7 +45,7 @@ west #
 src 192.1.2.45/32 dst 192.1.2.23/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  # let larval state expire
 west #
@@ -114,7 +114,7 @@ west #
 src 192.1.2.45/32 dst 192.1.2.23/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  ipsec _kernel state
 west #

--- a/testing/pluto/ikev2-ondemand-04-timeout-permanent-tunnel/west.console.txt
+++ b/testing/pluto/ikev2-ondemand-04-timeout-permanent-tunnel/west.console.txt
@@ -20,7 +20,7 @@ west #
 src 192.1.2.45/32 dst 192.1.2.23/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  # initiate a connection
 west #
@@ -34,7 +34,7 @@ west #
 src 192.1.2.45/32 dst 192.1.2.23/32
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  # wait for it to fail
 west #
@@ -45,7 +45,7 @@ west #
 src 192.1.2.45/32 dst 192.1.2.23/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  # let larval state expire
 west #
@@ -116,7 +116,7 @@ west #
 src 192.1.2.45/32 dst 192.1.2.23/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  ipsec _kernel state
 west #

--- a/testing/pluto/ikev2-tcp-28-ondemand/west.console.txt
+++ b/testing/pluto/ikev2-tcp-28-ondemand/west.console.txt
@@ -46,7 +46,7 @@ src 192.1.2.23 dst 192.1.2.45
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.2.45 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.2.45/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth1 
@@ -91,7 +91,7 @@ src 192.1.2.23 dst 192.1.2.45
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.2.45 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.2.45/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth1 

--- a/testing/pluto/ipv6-transport-mode-04-ondemand-xfrm/west.console.txt
+++ b/testing/pluto/ipv6-transport-mode-04-ondemand-xfrm/west.console.txt
@@ -61,7 +61,7 @@ src 2001:db8:1:2::23 dst 2001:db8:1:2::45
 	dir in
 	sel src 2001:db8:1:2::23/128 dst 2001:db8:1:2::45/128 
 src 2001:db8:1:2::45 dst 2001:db8:1:2::23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 2001:db8:1:2::45/128 dst 2001:db8:1:2::23/128 proto ipv6-icmp type 128 code 0 
@@ -113,7 +113,7 @@ src 2001:db8:1:2::23 dst 2001:db8:1:2::45
 	dir in
 	sel src 2001:db8:1:2::23/128 dst 2001:db8:1:2::45/128 
 src 2001:db8:1:2::45 dst 2001:db8:1:2::23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 2001:db8:1:2::45/128 dst 2001:db8:1:2::23/128 proto ipv6-icmp type 128 code 0 

--- a/testing/pluto/newoe-01-whack/east.console.txt
+++ b/testing/pluto/newoe-01-whack/east.console.txt
@@ -79,5 +79,5 @@ src 192.1.2.45/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #

--- a/testing/pluto/newoe-01-whack/west.console.txt
+++ b/testing/pluto/newoe-01-whack/west.console.txt
@@ -102,5 +102,5 @@ src 192.1.2.45/32 dst 192.1.2.23/32
 src 192.1.2.45/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #

--- a/testing/pluto/newoe-02-whack-wrong-mode-initiator/east.console.txt
+++ b/testing/pluto/newoe-02-whack-wrong-mode-initiator/east.console.txt
@@ -48,5 +48,5 @@ src 192.1.3.253/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #

--- a/testing/pluto/newoe-02-whack-wrong-mode-initiator/west.console.txt
+++ b/testing/pluto/newoe-02-whack-wrong-mode-initiator/west.console.txt
@@ -64,5 +64,5 @@ src 192.1.3.253/32 dst 192.1.2.45/32
 src 192.1.2.45/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #

--- a/testing/pluto/newoe-02-whack-wrong-mode-responder/east.console.txt
+++ b/testing/pluto/newoe-02-whack-wrong-mode-responder/east.console.txt
@@ -48,5 +48,5 @@ src 192.1.3.253/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #

--- a/testing/pluto/newoe-02-whack-wrong-mode-responder/west.console.txt
+++ b/testing/pluto/newoe-02-whack-wrong-mode-responder/west.console.txt
@@ -65,5 +65,5 @@ src 192.1.3.253/32 dst 192.1.2.45/32
 src 192.1.2.45/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #

--- a/testing/pluto/newoe-03-oeself/east.console.txt
+++ b/testing/pluto/newoe-03-oeself/east.console.txt
@@ -46,9 +46,9 @@ src 192.1.3.254/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.23/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #

--- a/testing/pluto/newoe-03-oeself/road.console.txt
+++ b/testing/pluto/newoe-03-oeself/road.console.txt
@@ -72,9 +72,9 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #

--- a/testing/pluto/newoe-04-pass-pass/east.console.txt
+++ b/testing/pluto/newoe-04-pass-pass/east.console.txt
@@ -77,13 +77,13 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.23/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.23/32 dst 7.0.0.0/8
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #

--- a/testing/pluto/newoe-04-pass-pass/road.console.txt
+++ b/testing/pluto/newoe-04-pass-pass/road.console.txt
@@ -67,7 +67,7 @@ up
 road #
  ipsec _kernel state
 src 192.1.3.209 dst 7.7.7.7
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 7.7.7.7/32 proto icmp type 8 code 0 dev eth0 
@@ -91,7 +91,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -138,15 +138,15 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 7.0.0.0/8
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # letting acquire and shunt exire
 road #
@@ -215,15 +215,15 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 7.0.0.0/8
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  sleep 60
 road #
@@ -290,15 +290,15 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 7.0.0.0/8
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  sleep 60
 road #
@@ -363,15 +363,15 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 7.0.0.0/8
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  killall ip > /dev/null 2> /dev/null
 road #
@@ -441,13 +441,13 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 7.0.0.0/8
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #

--- a/testing/pluto/newoe-05-hold-pass/east.console.txt
+++ b/testing/pluto/newoe-05-hold-pass/east.console.txt
@@ -77,13 +77,13 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.23/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.23/32 dst 7.0.0.0/8
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #

--- a/testing/pluto/newoe-05-hold-pass/road.console.txt
+++ b/testing/pluto/newoe-05-hold-pass/road.console.txt
@@ -135,15 +135,15 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 7.0.0.0/8
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # let failureshunt expire - both from bare shunt list as as kernel policy
 road #
@@ -214,15 +214,15 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 7.0.0.0/8
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ipsec whack --shuntstatus
 Bare Shunt list:
@@ -292,15 +292,15 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 7.0.0.0/8
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ipsec whack --shuntstatus
 Bare Shunt list:
@@ -369,15 +369,15 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 7.0.0.0/8
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ipsec whack --shuntstatus
 Bare Shunt list:
@@ -451,13 +451,13 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 7.0.0.0/8
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #

--- a/testing/pluto/newoe-07-ike-replace-initiator/east.console.txt
+++ b/testing/pluto/newoe-07-ike-replace-initiator/east.console.txt
@@ -75,9 +75,9 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.23/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #

--- a/testing/pluto/newoe-07-ike-replace-initiator/road.console.txt
+++ b/testing/pluto/newoe-07-ike-replace-initiator/road.console.txt
@@ -72,7 +72,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -117,9 +117,9 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #

--- a/testing/pluto/newoe-08-restart/east.console.txt
+++ b/testing/pluto/newoe-08-restart/east.console.txt
@@ -77,9 +77,9 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.23/32 dst 7.0.0.0/8
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #

--- a/testing/pluto/newoe-08-restart/road.console.txt
+++ b/testing/pluto/newoe-08-restart/road.console.txt
@@ -76,7 +76,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -121,13 +121,13 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 7.0.0.0/8
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #

--- a/testing/pluto/newoe-09-mutual/east.console.txt
+++ b/testing/pluto/newoe-09-mutual/east.console.txt
@@ -77,17 +77,17 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.23/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.23/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.23/32 dst 7.0.0.0/8
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #

--- a/testing/pluto/newoe-09-mutual/road.console.txt
+++ b/testing/pluto/newoe-09-mutual/road.console.txt
@@ -130,17 +130,17 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 7.0.0.0/8
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #

--- a/testing/pluto/newoe-10-expire-inactive-ike/east.console.txt
+++ b/testing/pluto/newoe-10-expire-inactive-ike/east.console.txt
@@ -77,9 +77,9 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.23/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #

--- a/testing/pluto/newoe-10-expire-inactive-ike/road.console.txt
+++ b/testing/pluto/newoe-10-expire-inactive-ike/road.console.txt
@@ -68,11 +68,11 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # establish a new one
 road #
@@ -112,7 +112,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -157,11 +157,11 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  echo done
 done
@@ -187,7 +187,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -232,9 +232,9 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #

--- a/testing/pluto/newoe-10-expire-inactive/east.console.txt
+++ b/testing/pluto/newoe-10-expire-inactive/east.console.txt
@@ -77,9 +77,9 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.23/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #

--- a/testing/pluto/newoe-10-expire-inactive/road.console.txt
+++ b/testing/pluto/newoe-10-expire-inactive/road.console.txt
@@ -70,11 +70,11 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  #establish a new one
 road #
@@ -111,7 +111,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -156,11 +156,11 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  echo done
 done
@@ -186,7 +186,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -231,9 +231,9 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #

--- a/testing/pluto/newoe-11-failike/road.console.txt
+++ b/testing/pluto/newoe-11-failike/road.console.txt
@@ -29,7 +29,7 @@ road #
  # shunt status
 road #
  ../../guestbin/wait-for.sh --match ' spi 0x00000000 ' -- ipsec _kernel state
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 road #
  ../../guestbin/ping-once.sh --up -I 192.1.3.209 192.1.2.23
 up
@@ -57,7 +57,7 @@ done
 road #
  ipsec _kernel state
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -92,9 +92,9 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #

--- a/testing/pluto/newoe-12-clear/road.console.txt
+++ b/testing/pluto/newoe-12-clear/road.console.txt
@@ -70,7 +70,7 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  killall ip > /dev/null 2> /dev/null
 road #

--- a/testing/pluto/newoe-13-block/road.console.txt
+++ b/testing/pluto/newoe-13-block/road.console.txt
@@ -44,11 +44,11 @@ road #
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir fwd action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir in action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.253/32 dst 192.1.3.209/32
 	dir fwd priority PRIORITY ptype main
 src 192.1.2.253/32 dst 192.1.3.209/32
@@ -60,7 +60,7 @@ src 192.1.2.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.2.253/32
 	dir out priority PRIORITY ptype main
 src 192.1.3.209/32 dst 192.1.2.254/32
@@ -80,7 +80,7 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  killall ip > /dev/null 2> /dev/null
 road #

--- a/testing/pluto/newoe-14-clear-in-block-clear/road.console.txt
+++ b/testing/pluto/newoe-14-clear-in-block-clear/road.console.txt
@@ -74,15 +74,15 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.2.0/24 dst 192.1.3.209/32
 	dir fwd action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.0/24 dst 192.1.3.209/32
 	dir in action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  killall ip > /dev/null 2> /dev/null
 road #
@@ -132,15 +132,15 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.2.0/24 dst 192.1.3.209/32
 	dir fwd action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.0/24 dst 192.1.3.209/32
 	dir in action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # should not show any hits
 road #

--- a/testing/pluto/newoe-15-portpass/east.console.txt
+++ b/testing/pluto/newoe-15-portpass/east.console.txt
@@ -104,7 +104,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #
  # A tunnel should have established
 east #

--- a/testing/pluto/newoe-15-portpass/road.console.txt
+++ b/testing/pluto/newoe-15-portpass/road.console.txt
@@ -78,7 +78,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -135,7 +135,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # A tunnel should have established
 road #

--- a/testing/pluto/newoe-17-block-in-clear-clear/road.console.txt
+++ b/testing/pluto/newoe-17-block-in-clear-clear/road.console.txt
@@ -41,11 +41,11 @@ road #
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir fwd action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir in action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.253/32 dst 192.1.3.209/32
 	dir fwd priority PRIORITY ptype main
 src 192.1.2.253/32 dst 192.1.3.209/32
@@ -57,7 +57,7 @@ src 192.1.2.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.2.253/32
 	dir out priority PRIORITY ptype main
 src 192.1.3.209/32 dst 192.1.2.254/32

--- a/testing/pluto/newoe-18-block-block/east.console.txt
+++ b/testing/pluto/newoe-18-block-block/east.console.txt
@@ -48,15 +48,15 @@ src 192.1.3.254/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.3.0/24
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.0/24 dst 192.1.2.23/32
 	dir fwd action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.0/24 dst 192.1.2.23/32
 	dir in action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #
  # should not show any hits
 east #

--- a/testing/pluto/newoe-18-block-block/road.console.txt
+++ b/testing/pluto/newoe-18-block-block/road.console.txt
@@ -68,15 +68,15 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.2.0/24 dst 192.1.3.209/32
 	dir fwd action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.0/24 dst 192.1.3.209/32
 	dir in action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  killall ip > /dev/null 2> /dev/null
 road #
@@ -120,15 +120,15 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.2.0/24 dst 192.1.3.209/32
 	dir fwd action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.0/24 dst 192.1.3.209/32
 	dir in action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # should not show any hits
 road #

--- a/testing/pluto/newoe-18-block-clear/road.console.txt
+++ b/testing/pluto/newoe-18-block-clear/road.console.txt
@@ -68,15 +68,15 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.2.0/24 dst 192.1.3.209/32
 	dir fwd action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.0/24 dst 192.1.3.209/32
 	dir in action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  killall ip > /dev/null 2> /dev/null
 road #
@@ -120,15 +120,15 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.2.0/24 dst 192.1.3.209/32
 	dir fwd action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.0/24 dst 192.1.3.209/32
 	dir in action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # should not show any hits
 road #

--- a/testing/pluto/newoe-18-block-cop/road.console.txt
+++ b/testing/pluto/newoe-18-block-cop/road.console.txt
@@ -66,15 +66,15 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.2.0/24 dst 192.1.3.209/32
 	dir fwd action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.0/24 dst 192.1.3.209/32
 	dir in action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  killall ip > /dev/null 2> /dev/null
 road #
@@ -118,15 +118,15 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.2.0/24 dst 192.1.3.209/32
 	dir fwd action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.0/24 dst 192.1.3.209/32
 	dir in action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # should not show any hits
 road #

--- a/testing/pluto/newoe-18-block-poc/east.console.txt
+++ b/testing/pluto/newoe-18-block-poc/east.console.txt
@@ -48,7 +48,7 @@ src 192.1.3.254/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #
  # should not show any hits because block prevents poc from seeing traffic
 east #

--- a/testing/pluto/newoe-18-block-poc/road.console.txt
+++ b/testing/pluto/newoe-18-block-poc/road.console.txt
@@ -68,15 +68,15 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.2.0/24 dst 192.1.3.209/32
 	dir fwd action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.0/24 dst 192.1.3.209/32
 	dir in action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  killall ip > /dev/null 2> /dev/null
 road #
@@ -120,15 +120,15 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.2.0/24 dst 192.1.3.209/32
 	dir fwd action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.0/24 dst 192.1.3.209/32
 	dir in action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # should not show any hits because block prevents poc from seeing traffic
 road #

--- a/testing/pluto/newoe-18-block-private/east.console.txt
+++ b/testing/pluto/newoe-18-block-private/east.console.txt
@@ -48,7 +48,7 @@ src 192.1.3.254/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #
  # should not show any hits because block prevents trigger
 east #

--- a/testing/pluto/newoe-18-block-private/road.console.txt
+++ b/testing/pluto/newoe-18-block-private/road.console.txt
@@ -68,15 +68,15 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.2.0/24 dst 192.1.3.209/32
 	dir fwd action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.0/24 dst 192.1.3.209/32
 	dir in action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  killall ip > /dev/null 2> /dev/null
 road #
@@ -120,15 +120,15 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.2.0/24 dst 192.1.3.209/32
 	dir fwd action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.0/24 dst 192.1.3.209/32
 	dir in action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # should not show any hits because block prevents trigger
 road #

--- a/testing/pluto/newoe-18-clear-block/east.console.txt
+++ b/testing/pluto/newoe-18-clear-block/east.console.txt
@@ -48,15 +48,15 @@ src 192.1.3.254/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.3.0/24
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.0/24 dst 192.1.2.23/32
 	dir fwd action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.0/24 dst 192.1.2.23/32
 	dir in action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #
  # should not show any hits
 east #

--- a/testing/pluto/newoe-18-clear-poc/east.console.txt
+++ b/testing/pluto/newoe-18-clear-poc/east.console.txt
@@ -24,7 +24,7 @@ Bare Shunt list:
 east #
  ipsec _kernel state
 src 192.1.2.23 dst 192.1.3.209
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.2.23/32 dst 192.1.3.209/32 proto icmp type 0 code 0 dev eth1 
@@ -59,7 +59,7 @@ src 192.1.2.23/32 dst 192.1.3.209/32
 src 192.1.2.23/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #
  # should not show any hits
 east #

--- a/testing/pluto/newoe-18-clear-private/east.console.txt
+++ b/testing/pluto/newoe-18-clear-private/east.console.txt
@@ -20,7 +20,7 @@ initdone
 east #
  ipsec _kernel state
 src 192.1.2.23 dst 192.1.3.209
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.2.23/32 dst 192.1.3.209/32 proto icmp type 0 code 0 dev eth1 
@@ -53,11 +53,11 @@ src 192.1.3.254/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.23/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #
  # should not show any hits
 east #

--- a/testing/pluto/newoe-18-cop-block/east.console.txt
+++ b/testing/pluto/newoe-18-cop-block/east.console.txt
@@ -48,15 +48,15 @@ src 192.1.3.254/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.3.0/24
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.0/24 dst 192.1.2.23/32
 	dir fwd action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.0/24 dst 192.1.2.23/32
 	dir in action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #
  # should not show any hits
 east #

--- a/testing/pluto/newoe-18-cop-poc/east.console.txt
+++ b/testing/pluto/newoe-18-cop-poc/east.console.txt
@@ -39,7 +39,7 @@ src 192.1.3.209 dst 192.1.2.23
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.2.23 dst 192.1.3.209
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.2.23/32 dst 192.1.3.209/32 proto icmp type 0 code 0 dev eth1 
@@ -84,7 +84,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #
  # a tunnel should show up here
 east #

--- a/testing/pluto/newoe-18-cop-private/east.console.txt
+++ b/testing/pluto/newoe-18-cop-private/east.console.txt
@@ -39,7 +39,7 @@ src 192.1.3.209 dst 192.1.2.23
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.2.23 dst 192.1.3.209
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.2.23/32 dst 192.1.3.209/32 proto icmp type 0 code 0 dev eth1 
@@ -84,7 +84,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #
  # a tunnel should show up here
 east #

--- a/testing/pluto/newoe-18-poc-block/east.console.txt
+++ b/testing/pluto/newoe-18-poc-block/east.console.txt
@@ -48,15 +48,15 @@ src 192.1.3.254/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.3.0/24
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.0/24 dst 192.1.2.23/32
 	dir fwd action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.0/24 dst 192.1.2.23/32
 	dir in action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #
  # should not show any hits
 east #

--- a/testing/pluto/newoe-18-poc-block/road.console.txt
+++ b/testing/pluto/newoe-18-poc-block/road.console.txt
@@ -55,7 +55,7 @@ done
 road #
  ipsec _kernel state
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -90,7 +90,7 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # should not show any hits
 road #

--- a/testing/pluto/newoe-18-poc-blockall/east.console.txt
+++ b/testing/pluto/newoe-18-poc-blockall/east.console.txt
@@ -48,15 +48,15 @@ src 192.1.3.254/32 dst 192.1.2.23/32
 src 0.0.0.0/0 dst 192.1.2.23/32
 	dir fwd action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 0.0.0.0/0 dst 192.1.2.23/32
 	dir in action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.2.23/32 dst 0.0.0.0/0
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #
  # should not show any hits
 east #

--- a/testing/pluto/newoe-18-poc-blockall/road.console.txt
+++ b/testing/pluto/newoe-18-poc-blockall/road.console.txt
@@ -41,7 +41,7 @@ road #
 road #
  ipsec _kernel state
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -76,7 +76,7 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # ping should fail due to remote block rule
 road #
@@ -94,7 +94,7 @@ done
 road #
  ipsec _kernel state
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -129,7 +129,7 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # should not show any hits
 road #

--- a/testing/pluto/newoe-18-poc-clear/road.console.txt
+++ b/testing/pluto/newoe-18-poc-clear/road.console.txt
@@ -31,7 +31,7 @@ road #
 road #
  ipsec _kernel state
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -80,7 +80,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # ping should succeed in the clear
 road #
@@ -133,7 +133,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # should not show any hits
 road #

--- a/testing/pluto/newoe-18-poc-cop-port-7-transport/road.console.txt
+++ b/testing/pluto/newoe-18-poc-cop-port-7-transport/road.console.txt
@@ -62,7 +62,7 @@ src 192.1.2.23 dst 192.1.3.209
 	dir in
 	sel src 192.1.2.23/32 dst 192.1.3.209/32 proto tcp sport 7 
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto tcp sport EPHEM dport 7 dev eth0 
@@ -103,7 +103,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32 proto tcp dport 7
 src 192.1.3.209/32 dst 192.1.2.0/24 proto tcp dport 7
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # a tunnel should have established
 road #

--- a/testing/pluto/newoe-18-poc-cop-port-7-whack/road.console.txt
+++ b/testing/pluto/newoe-18-poc-cop-port-7-whack/road.console.txt
@@ -115,7 +115,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32 proto tcp dport 7
 src 192.1.3.209/32 dst 192.1.2.0/24 proto tcp dport 7
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # a tunnel should have established
 road #

--- a/testing/pluto/newoe-18-poc-cop-port-7/road.console.txt
+++ b/testing/pluto/newoe-18-poc-cop-port-7/road.console.txt
@@ -60,7 +60,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto tcp sport EPHEM dport 7 dev eth0 
@@ -105,7 +105,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32 proto tcp dport 7
 src 192.1.3.209/32 dst 192.1.2.0/24 proto tcp dport 7
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # a tunnel should have established
 road #

--- a/testing/pluto/newoe-18-poc-cop/road.console.txt
+++ b/testing/pluto/newoe-18-poc-cop/road.console.txt
@@ -56,7 +56,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -101,7 +101,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  killall ip > /dev/null 2> /dev/null
 road #
@@ -136,7 +136,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -181,7 +181,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # a tunnel should have established
 road #

--- a/testing/pluto/newoe-18-poc-poc/road.console.txt
+++ b/testing/pluto/newoe-18-poc-poc/road.console.txt
@@ -52,7 +52,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -97,7 +97,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  killall ip > /dev/null 2> /dev/null
 road #

--- a/testing/pluto/newoe-18-poc-private/east.console.txt
+++ b/testing/pluto/newoe-18-poc-private/east.console.txt
@@ -79,7 +79,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #
  # A tunnel should have established
 east #

--- a/testing/pluto/newoe-18-poc-private/road.console.txt
+++ b/testing/pluto/newoe-18-poc-private/road.console.txt
@@ -56,7 +56,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -101,7 +101,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  killall ip > /dev/null 2> /dev/null
 road #
@@ -136,7 +136,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -181,7 +181,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # A tunnel should have established
 road #

--- a/testing/pluto/newoe-18-private-block/east.console.txt
+++ b/testing/pluto/newoe-18-private-block/east.console.txt
@@ -48,15 +48,15 @@ src 192.1.3.254/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.3.0/24
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.0/24 dst 192.1.2.23/32
 	dir fwd action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.0/24 dst 192.1.2.23/32
 	dir in action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #
  # should not show any hits
 east #

--- a/testing/pluto/newoe-18-private-block/road.console.txt
+++ b/testing/pluto/newoe-18-private-block/road.console.txt
@@ -33,7 +33,7 @@ road #
 road #
  ipsec _kernel state
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -70,7 +70,7 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  killall ip > /dev/null 2> /dev/null
 road #
@@ -86,7 +86,7 @@ done
 road #
  ipsec _kernel state
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -123,7 +123,7 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # should not show any hits
 road #

--- a/testing/pluto/newoe-18-private-clear/road.console.txt
+++ b/testing/pluto/newoe-18-private-clear/road.console.txt
@@ -33,7 +33,7 @@ road #
 road #
  ipsec _kernel state
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -70,7 +70,7 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  killall ip > /dev/null 2> /dev/null
 road #
@@ -86,7 +86,7 @@ done
 road #
  ipsec _kernel state
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -123,7 +123,7 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # should not show any hits
 road #

--- a/testing/pluto/newoe-18-private-clearall/road.console.txt
+++ b/testing/pluto/newoe-18-private-clearall/road.console.txt
@@ -37,7 +37,7 @@ road #
 road #
  ipsec _kernel state
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -74,7 +74,7 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  killall ip > /dev/null 2> /dev/null
 road #
@@ -90,7 +90,7 @@ done
 road #
  ipsec _kernel state
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -127,7 +127,7 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # should not show any hits
 road #

--- a/testing/pluto/newoe-18-private-cop/road.console.txt
+++ b/testing/pluto/newoe-18-private-cop/road.console.txt
@@ -56,7 +56,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -101,7 +101,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  killall ip > /dev/null 2> /dev/null
 road #
@@ -136,7 +136,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -181,7 +181,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # a tunnel should have established
 road #

--- a/testing/pluto/newoe-18-private-copall/road.console.txt
+++ b/testing/pluto/newoe-18-private-copall/road.console.txt
@@ -56,7 +56,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -101,7 +101,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  killall ip > /dev/null 2> /dev/null
 road #
@@ -136,7 +136,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -181,7 +181,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # should show tunnel
 road #

--- a/testing/pluto/newoe-18-private-poc/east.console.txt
+++ b/testing/pluto/newoe-18-private-poc/east.console.txt
@@ -79,7 +79,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #
  # tunnel should have been established
 east #

--- a/testing/pluto/newoe-18-private-poc/road.console.txt
+++ b/testing/pluto/newoe-18-private-poc/road.console.txt
@@ -56,7 +56,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -101,7 +101,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  killall ip > /dev/null 2> /dev/null
 road #
@@ -136,7 +136,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -181,7 +181,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # tunnel should have been established
 road #

--- a/testing/pluto/newoe-18-private-pocall/east.console.txt
+++ b/testing/pluto/newoe-18-private-pocall/east.console.txt
@@ -83,7 +83,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 0.0.0.0/0
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #
  # should show tunnel
 east #

--- a/testing/pluto/newoe-18-private-pocall/road.console.txt
+++ b/testing/pluto/newoe-18-private-pocall/road.console.txt
@@ -56,7 +56,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -101,7 +101,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  killall ip > /dev/null 2> /dev/null
 road #
@@ -136,7 +136,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -181,7 +181,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # should show tunnel
 road #

--- a/testing/pluto/newoe-18-private-private-32/east.console.txt
+++ b/testing/pluto/newoe-18-private-private-32/east.console.txt
@@ -48,7 +48,7 @@ src 192.1.3.254/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #
  # tunnel should have been established once - idleness check should prevent rekeying for OE
 east #

--- a/testing/pluto/newoe-18-private-private-32/road.console.txt
+++ b/testing/pluto/newoe-18-private-private-32/road.console.txt
@@ -56,7 +56,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -156,7 +156,7 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  echo done
 done
@@ -191,7 +191,7 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # tunnel should have been established once - idleness check should prevent rekeying for OE
 road #

--- a/testing/pluto/newoe-18-private-private/east.console.txt
+++ b/testing/pluto/newoe-18-private-private/east.console.txt
@@ -79,7 +79,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #
  # tunnel should have been established
 east #

--- a/testing/pluto/newoe-18-private-private/road.console.txt
+++ b/testing/pluto/newoe-18-private-private/road.console.txt
@@ -56,7 +56,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -101,7 +101,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  killall ip > /dev/null 2> /dev/null
 road #
@@ -136,7 +136,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -181,7 +181,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # tunnel should have been established
 road #

--- a/testing/pluto/newoe-19-poc-poc-clear/east.console.txt
+++ b/testing/pluto/newoe-19-poc-poc-clear/east.console.txt
@@ -86,7 +86,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #
  # A tunnel should have established
 east #

--- a/testing/pluto/newoe-19-poc-poc-clear/road.console.txt
+++ b/testing/pluto/newoe-19-poc-poc-clear/road.console.txt
@@ -56,7 +56,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -101,7 +101,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  killall ip > /dev/null 2> /dev/null
 road #
@@ -135,7 +135,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -180,7 +180,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # A tunnel should have established
 road #

--- a/testing/pluto/newoe-20-ipv6/east.console.txt
+++ b/testing/pluto/newoe-20-ipv6/east.console.txt
@@ -90,5 +90,5 @@ src 2001:db8:1:3::209/128 dst 2001:db8:1:2::23/128
 src 2001:db8:1:2::23/128 dst 2001:db8:1:3::/64
 	dir out priority PRIORITY ptype main
 	tmpl src :: dst ::
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #

--- a/testing/pluto/newoe-20-ipv6/road.console.txt
+++ b/testing/pluto/newoe-20-ipv6/road.console.txt
@@ -70,7 +70,7 @@ src 2001:db8:1:2::23 dst 2001:db8:1:3::209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 2001:db8:1:3::209 dst 2001:db8:1:2::23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 2001:db8:1:3::209/128 dst 2001:db8:1:2::23/128 proto ipv6-icmp type 128 code 0 
@@ -121,5 +121,5 @@ src 2001:db8:1:3::209/128 dst 2001:db8:1:2::23/128
 src 2001:db8:1:3::209/128 dst 2001:db8:1:2::/64
 	dir out priority PRIORITY ptype main
 	tmpl src :: dst ::
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #

--- a/testing/pluto/newoe-22-nat-poc-cop/road.console.txt
+++ b/testing/pluto/newoe-22-nat-poc-cop/road.console.txt
@@ -49,7 +49,7 @@ done
 road #
  ipsec _kernel state
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -78,7 +78,7 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # a tunnel should have established
 road #

--- a/testing/pluto/newoe-27-replace-sa-auth-authnull/road.console.txt
+++ b/testing/pluto/newoe-27-replace-sa-auth-authnull/road.console.txt
@@ -107,7 +107,7 @@ src 192.1.3.254/32 dst 192.1.3.209/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  # now delete the authenticated sa
 road #

--- a/testing/pluto/newoe-28-dual-source/east.console.txt
+++ b/testing/pluto/newoe-28-dual-source/east.console.txt
@@ -109,7 +109,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.2.23/32 dst 192.1.3.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 east #
  grep "^[^|].* established Child SA" /tmp/pluto.log
 "private#192.1.3.0/24"[1] ...192.1.3.208 #2: responder established Child SA using #1; IPsec tunnel [192.1.2.23/32===192.1.3.208/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}

--- a/testing/pluto/newoe-28-dual-source/road.console.txt
+++ b/testing/pluto/newoe-28-dual-source/road.console.txt
@@ -78,7 +78,7 @@ src 192.1.2.23 dst 192.1.3.209
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.209 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.209/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -102,7 +102,7 @@ src 192.1.2.23 dst 192.1.3.208
 	 00000000 00000000 00000000 XXXXXXXX 
 	dir in
 src 192.1.3.208 dst 192.1.2.23
-	proto esp spi 0x00000000 reqid 0 mode transport
+	proto esp spi 0x00000000 reqid REQID mode transport
 	replay-window 0 
 	dir out
 	sel src 192.1.3.208/32 dst 192.1.2.23/32 proto icmp type 8 code 0 dev eth0 
@@ -159,11 +159,11 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.208/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  grep "^[^|].* established Child SA" /tmp/pluto.log
 "private#192.1.2.0/24"[1] ...192.1.2.23 #2: initiator established Child SA using #1; IPsec tunnel [192.1.3.208/32===192.1.2.23/32] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}

--- a/testing/pluto/newoe-30-shunt-slash24/road.console.txt
+++ b/testing/pluto/newoe-30-shunt-slash24/road.console.txt
@@ -38,7 +38,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.failnone.pass TRIGGERING OE
 fired and forgotten
 "road#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -50,19 +50,19 @@ up
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir fwd priority 3850432 ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.209
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir in priority 3850432 ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.209
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850432 ptype main
 	tmpl src 192.1.3.209 dst 192.1.2.23
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.failnone.pass EXPECT ONE PACKET
 #2: "road#192.1.2.0/24"[1] ...192.1.2.23, type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='ID_NULL'
 : oe.negopass.failnone.pass EXPECT NO SHUNTS
@@ -81,7 +81,7 @@ Bare Shunt list:
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-fail-ike.sh    --negopass --failnone
 :
@@ -110,7 +110,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.failnone.fail-ike TRIGGERING OE
 fired and forgotten
 "road#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -120,7 +120,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.failnone.fail-ike TRY NEGOTIATION PING
 up
 : oe.negopass.failnone.fail-ike WAIT FOR IKE_SA_INIT TO FAIL
@@ -131,7 +131,7 @@ up
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.failnone.fail-ike FAILURE SHUNT - WHEN failpass OR faildrop
 Bare Shunt list:
  
@@ -142,7 +142,7 @@ Bare Shunt list:
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-fail-child.sh  --negopass --failnone
 :
@@ -171,7 +171,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.failnone.fail-child TRIGGERING OE
 fired and forgotten
 "road#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -179,7 +179,7 @@ fired and forgotten
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.failnone.fail-child WAIT FOR IKE_AUTH TO FAIL
 "road#192.1.2.0/24"[1] ...192.1.2.23 #1: initiator established IKE SA; authenticated peer using authby=null and NULL 'ID_NULL'
 "road#192.1.2.0/24"[1] ...192.1.2.23 #2: IKE_AUTH response rejected Child SA with NO_PROPOSAL_CHOSEN
@@ -189,7 +189,7 @@ src 192.1.3.209/32 dst 192.1.2.0/24
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.failnone.fail-child FAILURE SHUNT - WHEN failpass OR faildrop
 Bare Shunt list:
  
@@ -200,7 +200,7 @@ Bare Shunt list:
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-pass.sh        --negopass --faildrop
 :
@@ -229,7 +229,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.faildrop.pass TRIGGERING OE
 fired and forgotten
 "road#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -241,19 +241,19 @@ up
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir fwd priority 3850432 ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.209
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir in priority 3850432 ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.209
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850432 ptype main
 	tmpl src 192.1.3.209 dst 192.1.2.23
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.faildrop.pass EXPECT ONE PACKET
 #2: "road#192.1.2.0/24"[1] ...192.1.2.23, type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='ID_NULL'
 : oe.negopass.faildrop.pass EXPECT NO SHUNTS
@@ -272,7 +272,7 @@ Bare Shunt list:
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-fail-ike.sh    --negopass --faildrop
 :
@@ -301,7 +301,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.faildrop.fail-ike TRIGGERING OE
 fired and forgotten
 "road#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -311,7 +311,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.faildrop.fail-ike TRY NEGOTIATION PING
 up
 : oe.negopass.faildrop.fail-ike WAIT FOR IKE_SA_INIT TO FAIL
@@ -326,7 +326,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.faildrop.fail-ike FAILURE SHUNT - WHEN failpass OR faildrop
 Bare Shunt list:
  
@@ -339,7 +339,7 @@ down
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-fail-child.sh  --negopass --faildrop
 :
@@ -368,7 +368,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.faildrop.fail-child TRIGGERING OE
 fired and forgotten
 "road#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -380,7 +380,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.faildrop.fail-child WAIT FOR IKE_AUTH TO FAIL
 "road#192.1.2.0/24"[1] ...192.1.2.23 #1: initiator established IKE SA; authenticated peer using authby=null and NULL 'ID_NULL'
 "road#192.1.2.0/24"[1] ...192.1.2.23 #2: IKE_AUTH response rejected Child SA with NO_PROPOSAL_CHOSEN
@@ -394,7 +394,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.faildrop.fail-child FAILURE SHUNT - WHEN failpass OR faildrop
 Bare Shunt list:
  
@@ -407,7 +407,7 @@ down
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-pass.sh        --negopass --failpass
 :
@@ -436,7 +436,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.failpass.pass TRIGGERING OE
 fired and forgotten
 "road#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -448,19 +448,19 @@ up
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir fwd priority 3850432 ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.209
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir in priority 3850432 ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.209
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850432 ptype main
 	tmpl src 192.1.3.209 dst 192.1.2.23
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.failpass.pass EXPECT ONE PACKET
 #2: "road#192.1.2.0/24"[1] ...192.1.2.23, type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='ID_NULL'
 : oe.negopass.failpass.pass EXPECT NO SHUNTS
@@ -479,7 +479,7 @@ Bare Shunt list:
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-fail-ike.sh    --negopass --failpass
 :
@@ -508,7 +508,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.failpass.fail-ike TRIGGERING OE
 fired and forgotten
 "road#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -518,7 +518,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.failpass.fail-ike TRY NEGOTIATION PING
 up
 : oe.negopass.failpass.fail-ike WAIT FOR IKE_SA_INIT TO FAIL
@@ -531,7 +531,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.failpass.fail-ike FAILURE SHUNT - WHEN failpass OR faildrop
 Bare Shunt list:
  
@@ -544,7 +544,7 @@ up
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-fail-child.sh  --negopass --failpass
 :
@@ -573,7 +573,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.failpass.fail-child TRIGGERING OE
 fired and forgotten
 "road#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -583,7 +583,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.failpass.fail-child WAIT FOR IKE_AUTH TO FAIL
 "road#192.1.2.0/24"[1] ...192.1.2.23 #1: initiator established IKE SA; authenticated peer using authby=null and NULL 'ID_NULL'
 "road#192.1.2.0/24"[1] ...192.1.2.23 #2: IKE_AUTH response rejected Child SA with NO_PROPOSAL_CHOSEN
@@ -595,7 +595,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.failpass.fail-child FAILURE SHUNT - WHEN failpass OR faildrop
 Bare Shunt list:
  
@@ -608,7 +608,7 @@ up
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-pass.sh        --negodrop --failnone
 :
@@ -637,7 +637,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.failnone.pass TRIGGERING OE
 fired and forgotten
 "road#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -649,19 +649,19 @@ up
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir fwd priority 3850432 ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.209
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir in priority 3850432 ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.209
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850432 ptype main
 	tmpl src 192.1.3.209 dst 192.1.2.23
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.failnone.pass EXPECT ONE PACKET
 #2: "road#192.1.2.0/24"[1] ...192.1.2.23, type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='ID_NULL'
 : oe.negodrop.failnone.pass EXPECT NO SHUNTS
@@ -680,7 +680,7 @@ Bare Shunt list:
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-fail-ike.sh    --negodrop --failnone
 :
@@ -709,7 +709,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.failnone.fail-ike TRIGGERING OE
 fired and forgotten
 "road#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -717,11 +717,11 @@ fired and forgotten
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out action block priority 3850432 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.failnone.fail-ike TRY NEGOTIATION PING
 down
 : oe.negodrop.failnone.fail-ike WAIT FOR IKE_SA_INIT TO FAIL
@@ -732,7 +732,7 @@ down
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.failnone.fail-ike FAILURE SHUNT - WHEN failpass OR faildrop
 Bare Shunt list:
  
@@ -743,7 +743,7 @@ Bare Shunt list:
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-fail-child.sh  --negodrop --failnone
 :
@@ -772,7 +772,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.failnone.fail-child TRIGGERING OE
 fired and forgotten
 "road#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -780,7 +780,7 @@ fired and forgotten
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.failnone.fail-child WAIT FOR IKE_AUTH TO FAIL
 "road#192.1.2.0/24"[1] ...192.1.2.23 #1: initiator established IKE SA; authenticated peer using authby=null and NULL 'ID_NULL'
 "road#192.1.2.0/24"[1] ...192.1.2.23 #2: IKE_AUTH response rejected Child SA with NO_PROPOSAL_CHOSEN
@@ -790,7 +790,7 @@ src 192.1.3.209/32 dst 192.1.2.0/24
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.failnone.fail-child FAILURE SHUNT - WHEN failpass OR faildrop
 Bare Shunt list:
  
@@ -801,7 +801,7 @@ Bare Shunt list:
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-pass.sh        --negodrop --faildrop
 :
@@ -830,7 +830,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.faildrop.pass TRIGGERING OE
 fired and forgotten
 "road#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -842,19 +842,19 @@ up
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir fwd priority 3850432 ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.209
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir in priority 3850432 ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.209
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850432 ptype main
 	tmpl src 192.1.3.209 dst 192.1.2.23
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.faildrop.pass EXPECT ONE PACKET
 #2: "road#192.1.2.0/24"[1] ...192.1.2.23, type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='ID_NULL'
 : oe.negodrop.faildrop.pass EXPECT NO SHUNTS
@@ -873,7 +873,7 @@ Bare Shunt list:
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-fail-ike.sh    --negodrop --faildrop
 :
@@ -902,7 +902,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.faildrop.fail-ike TRIGGERING OE
 fired and forgotten
 "road#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -910,11 +910,11 @@ fired and forgotten
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out action block priority 3850432 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.faildrop.fail-ike TRY NEGOTIATION PING
 down
 : oe.negodrop.faildrop.fail-ike WAIT FOR IKE_SA_INIT TO FAIL
@@ -929,7 +929,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.faildrop.fail-ike FAILURE SHUNT - WHEN failpass OR faildrop
 Bare Shunt list:
  
@@ -942,7 +942,7 @@ down
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-fail-child.sh  --negodrop --faildrop
 :
@@ -971,7 +971,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.faildrop.fail-child TRIGGERING OE
 fired and forgotten
 "road#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -983,7 +983,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.faildrop.fail-child WAIT FOR IKE_AUTH TO FAIL
 "road#192.1.2.0/24"[1] ...192.1.2.23 #1: initiator established IKE SA; authenticated peer using authby=null and NULL 'ID_NULL'
 "road#192.1.2.0/24"[1] ...192.1.2.23 #2: IKE_AUTH response rejected Child SA with NO_PROPOSAL_CHOSEN
@@ -997,7 +997,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.faildrop.fail-child FAILURE SHUNT - WHEN failpass OR faildrop
 Bare Shunt list:
  
@@ -1010,7 +1010,7 @@ down
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-pass.sh        --negodrop --failpass
 :
@@ -1039,7 +1039,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.failpass.pass TRIGGERING OE
 fired and forgotten
 "road#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -1051,19 +1051,19 @@ up
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir fwd priority 3850432 ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.209
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir in priority 3850432 ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.209
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850432 ptype main
 	tmpl src 192.1.3.209 dst 192.1.2.23
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.failpass.pass EXPECT ONE PACKET
 #2: "road#192.1.2.0/24"[1] ...192.1.2.23, type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='ID_NULL'
 : oe.negodrop.failpass.pass EXPECT NO SHUNTS
@@ -1082,7 +1082,7 @@ Bare Shunt list:
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-fail-ike.sh    --negodrop --failpass
 :
@@ -1111,7 +1111,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.failpass.fail-ike TRIGGERING OE
 fired and forgotten
 "road#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -1119,11 +1119,11 @@ fired and forgotten
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out action block priority 3850432 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.failpass.fail-ike TRY NEGOTIATION PING
 down
 : oe.negodrop.failpass.fail-ike WAIT FOR IKE_SA_INIT TO FAIL
@@ -1136,7 +1136,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.failpass.fail-ike FAILURE SHUNT - WHEN failpass OR faildrop
 Bare Shunt list:
  
@@ -1149,7 +1149,7 @@ up
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-fail-child.sh  --negodrop --failpass
 :
@@ -1178,7 +1178,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.failpass.fail-child TRIGGERING OE
 fired and forgotten
 "road#192.1.2.0/24"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -1188,7 +1188,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.failpass.fail-child WAIT FOR IKE_AUTH TO FAIL
 "road#192.1.2.0/24"[1] ...192.1.2.23 #1: initiator established IKE SA; authenticated peer using authby=null and NULL 'ID_NULL'
 "road#192.1.2.0/24"[1] ...192.1.2.23 #2: IKE_AUTH response rejected Child SA with NO_PROPOSAL_CHOSEN
@@ -1200,7 +1200,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.failpass.fail-child FAILURE SHUNT - WHEN failpass OR faildrop
 Bare Shunt list:
  
@@ -1213,5 +1213,5 @@ up
 src 192.1.3.209/32 dst 192.1.2.0/24
 	dir out priority 3850449 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #

--- a/testing/pluto/newoe-30-shunt-slash32/road.console.txt
+++ b/testing/pluto/newoe-30-shunt-slash32/road.console.txt
@@ -40,7 +40,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.failnone.pass TRIGGERING OE
 fired and forgotten
 "road#192.1.2.23/32"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -52,15 +52,15 @@ up
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir fwd priority 3850432 ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.209
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir in priority 3850432 ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.209
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850432 ptype main
 	tmpl src 192.1.3.209 dst 192.1.2.23
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 : oe.negopass.failnone.pass EXPECT ONE PACKET
 #2: "road#192.1.2.23/32"[1] ...192.1.2.23, type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='ID_NULL'
 : oe.negopass.failnone.pass EXPECT NO SHUNTS
@@ -79,7 +79,7 @@ Bare Shunt list:
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-fail-ike.sh    --negopass --failnone
 :
@@ -108,7 +108,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.failnone.fail-ike TRIGGERING OE
 fired and forgotten
 "road#192.1.2.23/32"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -125,7 +125,7 @@ up
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.failnone.fail-ike FAILURE SHUNT - WHEN failpass OR faildrop
 Bare Shunt list:
  
@@ -136,7 +136,7 @@ Bare Shunt list:
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-fail-child.sh  --negopass --failnone
 :
@@ -165,7 +165,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.failnone.fail-child TRIGGERING OE
 fired and forgotten
 "road#192.1.2.23/32"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -173,7 +173,7 @@ fired and forgotten
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.failnone.fail-child WAIT FOR IKE_AUTH TO FAIL
 "road#192.1.2.23/32"[1] ...192.1.2.23 #1: initiator established IKE SA; authenticated peer using authby=null and NULL 'ID_NULL'
 "road#192.1.2.23/32"[1] ...192.1.2.23 #2: IKE_AUTH response rejected Child SA with NO_PROPOSAL_CHOSEN
@@ -183,7 +183,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.failnone.fail-child FAILURE SHUNT - WHEN failpass OR faildrop
 Bare Shunt list:
  
@@ -194,7 +194,7 @@ Bare Shunt list:
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-pass.sh        --negopass --faildrop
 :
@@ -223,7 +223,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.faildrop.pass TRIGGERING OE
 fired and forgotten
 "road#192.1.2.23/32"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -235,15 +235,15 @@ up
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir fwd priority 3850432 ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.209
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir in priority 3850432 ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.209
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850432 ptype main
 	tmpl src 192.1.3.209 dst 192.1.2.23
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 : oe.negopass.faildrop.pass EXPECT ONE PACKET
 #2: "road#192.1.2.23/32"[1] ...192.1.2.23, type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='ID_NULL'
 : oe.negopass.faildrop.pass EXPECT NO SHUNTS
@@ -262,7 +262,7 @@ Bare Shunt list:
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-fail-ike.sh    --negopass --faildrop
 :
@@ -291,7 +291,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.faildrop.fail-ike TRIGGERING OE
 fired and forgotten
 "road#192.1.2.23/32"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -321,7 +321,7 @@ down
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-fail-child.sh  --negopass --faildrop
 :
@@ -350,7 +350,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.faildrop.fail-child TRIGGERING OE
 fired and forgotten
 "road#192.1.2.23/32"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -381,7 +381,7 @@ down
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-pass.sh        --negopass --failpass
 :
@@ -410,7 +410,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.failpass.pass TRIGGERING OE
 fired and forgotten
 "road#192.1.2.23/32"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -422,15 +422,15 @@ up
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir fwd priority 3850432 ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.209
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir in priority 3850432 ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.209
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850432 ptype main
 	tmpl src 192.1.3.209 dst 192.1.2.23
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 : oe.negopass.failpass.pass EXPECT ONE PACKET
 #2: "road#192.1.2.23/32"[1] ...192.1.2.23, type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='ID_NULL'
 : oe.negopass.failpass.pass EXPECT NO SHUNTS
@@ -449,7 +449,7 @@ Bare Shunt list:
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-fail-ike.sh    --negopass --failpass
 :
@@ -478,7 +478,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.failpass.fail-ike TRIGGERING OE
 fired and forgotten
 "road#192.1.2.23/32"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -506,7 +506,7 @@ up
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-fail-child.sh  --negopass --failpass
 :
@@ -535,7 +535,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negopass.failpass.fail-child TRIGGERING OE
 fired and forgotten
 "road#192.1.2.23/32"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -562,7 +562,7 @@ up
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-pass.sh        --negodrop --failnone
 :
@@ -591,7 +591,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.failnone.pass TRIGGERING OE
 fired and forgotten
 "road#192.1.2.23/32"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -603,15 +603,15 @@ up
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir fwd priority 3850432 ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.209
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir in priority 3850432 ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.209
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850432 ptype main
 	tmpl src 192.1.3.209 dst 192.1.2.23
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 : oe.negodrop.failnone.pass EXPECT ONE PACKET
 #2: "road#192.1.2.23/32"[1] ...192.1.2.23, type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='ID_NULL'
 : oe.negodrop.failnone.pass EXPECT NO SHUNTS
@@ -630,7 +630,7 @@ Bare Shunt list:
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-fail-ike.sh    --negodrop --failnone
 :
@@ -659,7 +659,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.failnone.fail-ike TRIGGERING OE
 fired and forgotten
 "road#192.1.2.23/32"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -667,7 +667,7 @@ fired and forgotten
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out action block priority 3850432 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.failnone.fail-ike TRY NEGOTIATION PING
 down
 : oe.negodrop.failnone.fail-ike WAIT FOR IKE_SA_INIT TO FAIL
@@ -678,7 +678,7 @@ down
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.failnone.fail-ike FAILURE SHUNT - WHEN failpass OR faildrop
 Bare Shunt list:
  
@@ -689,7 +689,7 @@ Bare Shunt list:
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-fail-child.sh  --negodrop --failnone
 :
@@ -718,7 +718,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.failnone.fail-child TRIGGERING OE
 fired and forgotten
 "road#192.1.2.23/32"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -726,7 +726,7 @@ fired and forgotten
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.failnone.fail-child WAIT FOR IKE_AUTH TO FAIL
 "road#192.1.2.23/32"[1] ...192.1.2.23 #1: initiator established IKE SA; authenticated peer using authby=null and NULL 'ID_NULL'
 "road#192.1.2.23/32"[1] ...192.1.2.23 #2: IKE_AUTH response rejected Child SA with NO_PROPOSAL_CHOSEN
@@ -736,7 +736,7 @@ src 192.1.3.209/32 dst 192.1.2.23/32
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.failnone.fail-child FAILURE SHUNT - WHEN failpass OR faildrop
 Bare Shunt list:
  
@@ -747,7 +747,7 @@ Bare Shunt list:
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-pass.sh        --negodrop --faildrop
 :
@@ -776,7 +776,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.faildrop.pass TRIGGERING OE
 fired and forgotten
 "road#192.1.2.23/32"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -788,15 +788,15 @@ up
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir fwd priority 3850432 ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.209
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir in priority 3850432 ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.209
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850432 ptype main
 	tmpl src 192.1.3.209 dst 192.1.2.23
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 : oe.negodrop.faildrop.pass EXPECT ONE PACKET
 #2: "road#192.1.2.23/32"[1] ...192.1.2.23, type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='ID_NULL'
 : oe.negodrop.faildrop.pass EXPECT NO SHUNTS
@@ -815,7 +815,7 @@ Bare Shunt list:
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-fail-ike.sh    --negodrop --faildrop
 :
@@ -844,7 +844,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.faildrop.fail-ike TRIGGERING OE
 fired and forgotten
 "road#192.1.2.23/32"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -852,7 +852,7 @@ fired and forgotten
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out action block priority 3850432 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.faildrop.fail-ike TRY NEGOTIATION PING
 down
 : oe.negodrop.faildrop.fail-ike WAIT FOR IKE_SA_INIT TO FAIL
@@ -876,7 +876,7 @@ down
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-fail-child.sh  --negodrop --faildrop
 :
@@ -905,7 +905,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.faildrop.fail-child TRIGGERING OE
 fired and forgotten
 "road#192.1.2.23/32"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -936,7 +936,7 @@ down
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-pass.sh        --negodrop --failpass
 :
@@ -965,7 +965,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.failpass.pass TRIGGERING OE
 fired and forgotten
 "road#192.1.2.23/32"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -977,15 +977,15 @@ up
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir fwd priority 3850432 ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.209
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.2.23/32 dst 192.1.3.209/32
 	dir in priority 3850432 ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.209
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850432 ptype main
 	tmpl src 192.1.3.209 dst 192.1.2.23
-		proto esp reqid 16397 mode tunnel
+		proto esp reqid REQID mode tunnel
 : oe.negodrop.failpass.pass EXPECT ONE PACKET
 #2: "road#192.1.2.23/32"[1] ...192.1.2.23, type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='ID_NULL'
 : oe.negodrop.failpass.pass EXPECT NO SHUNTS
@@ -1004,7 +1004,7 @@ Bare Shunt list:
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-fail-ike.sh    --negodrop --failpass
 :
@@ -1033,7 +1033,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.failpass.fail-ike TRIGGERING OE
 fired and forgotten
 "road#192.1.2.23/32"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -1041,7 +1041,7 @@ fired and forgotten
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out action block priority 3850432 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.failpass.fail-ike TRY NEGOTIATION PING
 down
 : oe.negodrop.failpass.fail-ike WAIT FOR IKE_SA_INIT TO FAIL
@@ -1063,7 +1063,7 @@ up
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #
  ./oe-fail-child.sh  --negodrop --failpass
 :
@@ -1092,7 +1092,7 @@ loading group "/etc/ipsec.d/policies/road"
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 : oe.negodrop.failpass.fail-child TRIGGERING OE
 fired and forgotten
 "road#192.1.2.23/32"[1] ...192.1.2.23 #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
@@ -1119,5 +1119,5 @@ up
 src 192.1.3.209/32 dst 192.1.2.23/32
 	dir out priority 3850433 ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 road #

--- a/testing/pluto/nflog-01-global-nftables/west.console.txt
+++ b/testing/pluto/nflog-01-global-nftables/west.console.txt
@@ -69,7 +69,7 @@ west #
 src 192.0.1.0/24 dst 192.0.2.0/24
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  nft list ruleset
 table inet ipsec-log {

--- a/testing/pluto/nflog-01-global/west.console.txt
+++ b/testing/pluto/nflog-01-global/west.console.txt
@@ -90,7 +90,7 @@ west #
 src 192.0.1.0/24 dst 192.0.2.0/24
 	dir out action block priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid 0 mode transport
+		proto esp reqid REQID mode transport
 west #
  ipsec stop
 Redirecting to: [initsystem]

--- a/testing/sanitizers/misc-sanitize.sed
+++ b/testing/sanitizers/misc-sanitize.sed
@@ -44,3 +44,4 @@ s/\t seq-hi 0x0, seq [^,]*, oseq-hi 0x0, oseq .*$/\t seq-hi 0x0, seq 0xXX, oseq-
 
 # debug details aren't interesting
 s/^debug:.*/debug .../
+s/ reqid [1-9][0-9]* mode / reqid REQID mode /g


### PR DESCRIPTION
When installing a trap or shunt policy via add_spd_kernel_policy(), plant c->child.reqid into the XFRMA_TMPL attribute.
When the kernel fires the trap and sends ACQUIRE message , capture the reqid echoed back and store it in the policy_id.
This is groundwork to find the connection using hashtable.
Also update the existing tests where trap policies previously showed reqid 0.