### PR TITLE
default {left,right}updown= to the full path of the final script

### DIFF
--- a/configs/d.ipsec.conf/conn/updown.xml
+++ b/configs/d.ipsec.conf/conn/updown.xml
@@ -42,7 +42,9 @@
       option <option>updown-config=</option>.
     </para>
     <para>
-      The default is <command>ipsec _updown</command>.
+      On &Linux; the default is
+      <command>@@LIBEXECDIR@@/_updown.xfrm</command>, and on BSD
+      variants it is <command>@@LIBEXECDIR@@/_updown.bsd</command>.
     </para>
     <para>
       Relevant only locally, other end need not agree on it.

--- a/include/pluto_constants.h
+++ b/include/pluto_constants.h
@@ -37,7 +37,6 @@
  */
 #define STATE_TABLE_SIZE 499
 
-#define DEFAULT_UPDOWN "ipsec _updown"
 #define UPDOWN_DISABLED "%disabled"
 
 enum ike_version {

--- a/programs/pluto/extract.c
+++ b/programs/pluto/extract.c
@@ -651,7 +651,11 @@ static diag_t extract_updown(const struct whack_message *wm,
 		vdbg("never-negotiate updown");
 		updown_argv = NULL;
 	} else if (updown_kv.value == NULL) {
-		updown_argv = argv_from_sh_command(DEFAULT_UPDOWN, verbose);
+		char *updown = alloc_printf("%s/_updown.%s",
+					    IPSEC_EXECDIR,
+					    kernel_ops->updown_name);
+		updown_argv = argv_from_sh_command(updown, verbose);
+		pfreeany(updown);
 	} else if (streq(updown_kv.value, UPDOWN_DISABLED) ||
 		   streq(updown_kv.value, "")) {
 		/* disabled */

--- a/testing/pluto/addconn-04-config-path/west.console.txt
+++ b/testing/pluto/addconn-04-config-path/west.console.txt
@@ -14,7 +14,7 @@ west #
  ipsec connectionstatus tmp
 "tmp": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "tmp":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"tmp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"tmp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "tmp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "tmp":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "tmp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -47,7 +47,7 @@ west #
  ipsec connectionstatus path
 "path": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "path":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"path":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"path":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "path":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "path":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "path":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/addconn-08-ordering/west.console.txt
+++ b/testing/pluto/addconn-08-ordering/west.console.txt
@@ -11,8 +11,8 @@ west #
  ipsec whack --connectionstatus --name order-test
 "order-test": fe80::1/128===1.2.3.4[@foo]...2.3.4.5[@bar]===fe80::2/128; unoriented; my_ip=unset; their_ip=unset;
 "order-test":   host: unoriented; left: 1.2.3.4; right: 2.3.4.5;
-"order-test":   leftupdown=ipsec _updown; leftupdown-config=noasync,noexec;
-"order-test":   rightupdown=ipsec _updown; rightupdown-config=noasync,noexec;
+"order-test":   leftupdown=PATH/libexec/ipsec/_updown.xfrm; leftupdown-config=noasync,noexec;
+"order-test":   rightupdown=PATH/libexec/ipsec/_updown.xfrm; rightupdown-config=noasync,noexec;
 "order-test":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "order-test":   our auth:rsasig(RSASIG+ECDSA+RSASIG_v1_5), their auth:rsasig(RSASIG+ECDSA+RSASIG_v1_5), our autheap:none, their autheap:none;
 "order-test":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/addconn-39-updown/west.console.txt
+++ b/testing/pluto/addconn-39-updown/west.console.txt
@@ -54,26 +54,26 @@ west #
  ipsec connectionstatus | sed -n -e '/: .*updown=/ s/  */ /gp' | sort
 "addconn--leftupdown=%disabled": leftupdown=<disabled>; leftupdown-config=noasync,noexec;
 "addconn--leftupdown=%disabled": rightupdown=<disabled>; rightupdown-config=noasync,noexec;
-"addconn": leftupdown=ipsec _updown; leftupdown-config=noasync,noexec;
 "addconn--leftupdown=left": leftupdown=left; leftupdown-config=noasync,noexec;
 "addconn--leftupdown=left": rightupdown=left; rightupdown-config=noasync,noexec;
 "addconn--leftupdown=": leftupdown=<disabled>; leftupdown-config=noasync,noexec;
 "addconn--leftupdown=quotes": leftupdown=<disabled>; leftupdown-config=noasync,noexec;
 "addconn--leftupdown=quotes": rightupdown=<disabled>; rightupdown-config=noasync,noexec;
 "addconn--leftupdown=": rightupdown=<disabled>; rightupdown-config=noasync,noexec;
-"addconn": rightupdown=ipsec _updown; rightupdown-config=noasync,noexec;
-"addconn--rightupdown=right": leftupdown=ipsec _updown; leftupdown-config=noasync,noexec;
-"addconn--rightupdown=right": rightupdown=ipsec _updown; rightupdown-config=noasync,noexec;
+"addconn": leftupdown=PATH/libexec/ipsec/_updown.xfrm; leftupdown-config=noasync,noexec;
+"addconn--rightupdown=right": leftupdown=PATH/libexec/ipsec/_updown.xfrm; leftupdown-config=noasync,noexec;
+"addconn--rightupdown=right": rightupdown=PATH/libexec/ipsec/_updown.xfrm; rightupdown-config=noasync,noexec;
+"addconn": rightupdown=PATH/libexec/ipsec/_updown.xfrm; rightupdown-config=noasync,noexec;
 "addconn--type=passthrough": leftupdown=<disabled>; leftupdown-config=noasync,noexec;
 "addconn--type=passthrough--leftupdown=left": leftupdown=<disabled>; leftupdown-config=noasync,noexec;
 "addconn--type=passthrough--leftupdown=left": rightupdown=<disabled>; rightupdown-config=noasync,noexec;
 "addconn--type=passthrough": rightupdown=<disabled>; rightupdown-config=noasync,noexec;
-"whack": leftupdown=ipsec _updown; leftupdown-config=noasync,noexec;
+"whack": leftupdown=PATH/libexec/ipsec/_updown.xfrm; leftupdown-config=noasync,noexec;
 "whack--pass": leftupdown=<disabled>; leftupdown-config=noasync,noexec;
 "whack--pass": rightupdown=<disabled>; rightupdown-config=noasync,noexec;
 "whack--pass--updown=from": leftupdown=<disabled>; leftupdown-config=noasync,noexec;
 "whack--pass--updown=from": rightupdown=<disabled>; rightupdown-config=noasync,noexec;
-"whack": rightupdown=ipsec _updown; rightupdown-config=noasync,noexec;
+"whack": rightupdown=PATH/libexec/ipsec/_updown.xfrm; rightupdown-config=noasync,noexec;
 "whack--updown=from": leftupdown=from; leftupdown-config=noasync,noexec;
 "whack--updown=from": rightupdown=from; rightupdown-config=noasync,noexec;
 west #

--- a/testing/pluto/addresspool-6in6-6in-6in-ikev2/east.console.txt
+++ b/testing/pluto/addresspool-6in6-6in-6in-ikev2/east.console.txt
@@ -11,7 +11,7 @@ east #
  ipsec status | grep east
 "east": 2001:db8:0:2::/64===2001:db8:1:2::23[@east]...%any==={2001:db8:0:3:1::/97}; unrouted; my_ip=unset; their_ip=unset;
 "east":   host: oriented; local: 2001:db8:1:2::23; remote: %any;
-"east":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"east":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "east":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "east":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "east":   modecfg info: us:server, them:client, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/addresspool-6in6-strongswan-initiator-ikev2/east.console.txt
+++ b/testing/pluto/addresspool-6in6-strongswan-initiator-ikev2/east.console.txt
@@ -104,7 +104,7 @@ Connection list:
  
 "rw-eastnet-ipv6": 2001:db8:0:2::/64===2001:db8:1:2::23[@east]...%any==={2001:db8:0:3:1::/97}; unrouted; my_ip=unset; their_ip=unset;
 "rw-eastnet-ipv6":   host: oriented; local: 2001:db8:1:2::23; remote: %any;
-"rw-eastnet-ipv6":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"rw-eastnet-ipv6":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "rw-eastnet-ipv6":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "rw-eastnet-ipv6":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "rw-eastnet-ipv6":   modecfg info: us:server, them:client, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ah-pluto-13/east.console.txt
+++ b/testing/pluto/ah-pluto-13/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec status | grep westnet-eastnet-ah-sha1-pfs
 "westnet-eastnet-ah-sha1-pfs": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ah-sha1-pfs":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ah-sha1-pfs":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ah-sha1-pfs":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ah-sha1-pfs":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ah-sha1-pfs":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-ah-sha1-pfs":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ah-pluto-13/west.console.txt
+++ b/testing/pluto/ah-pluto-13/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec status | grep westnet-eastnet-ah-sha1-pfs
 "westnet-eastnet-ah-sha1-pfs": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ah-sha1-pfs":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ah-sha1-pfs":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ah-sha1-pfs":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ah-sha1-pfs":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ah-sha1-pfs":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-ah-sha1-pfs":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/algo-pluto-01/east.console.txt
+++ b/testing/pluto/algo-pluto-01/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-aes256
 "westnet-eastnet-aes256": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-aes256":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-aes256":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-aes256":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-aes256":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-aes256":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-aes256":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/algo-pluto-01/west.console.txt
+++ b/testing/pluto/algo-pluto-01/west.console.txt
@@ -30,7 +30,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-aes256
 "westnet-eastnet-aes256": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-aes256":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-aes256":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-aes256":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-aes256":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-aes256":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-aes256":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/algo-pluto-08/east.console.txt
+++ b/testing/pluto/algo-pluto-08/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-dh15
 "westnet-eastnet-dh15": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-dh15":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-dh15":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-dh15":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-dh15":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-dh15":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-dh15":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/algo-pluto-08/west.console.txt
+++ b/testing/pluto/algo-pluto-08/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-dh15
 "westnet-eastnet-dh15": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-dh15":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-dh15":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-dh15":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-dh15":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-dh15":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-dh15":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/algo-pluto-10/east.console.txt
+++ b/testing/pluto/algo-pluto-10/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-aes256
 "westnet-eastnet-aes256": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-aes256":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-aes256":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-aes256":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-aes256":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-aes256":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-aes256":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/algo-pluto-10/west.console.txt
+++ b/testing/pluto/algo-pluto-10/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-aes256
 "westnet-eastnet-aes256": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-aes256":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-aes256":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-aes256":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-aes256":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-aes256":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-aes256":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/algo-pluto-13-invalid-3des/east.console.txt
+++ b/testing/pluto/algo-pluto-13-invalid-3des/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-aes256
 "westnet-eastnet-aes256": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-aes256":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-aes256":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-aes256":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-aes256":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-aes256":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-aes256":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/algo-pluto-13-invalid-3des/west.console.txt
+++ b/testing/pluto/algo-pluto-13-invalid-3des/west.console.txt
@@ -21,7 +21,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-aes256
 "westnet-eastnet-aes256": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-aes256":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-aes256":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-aes256":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-aes256":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-aes256":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-aes256":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/basic-pluto-01-failtest/east.console.txt
+++ b/testing/pluto/basic-pluto-01-failtest/east.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-eastnet": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/basic-pluto-01-failtest/west.console.txt
+++ b/testing/pluto/basic-pluto-01-failtest/west.console.txt
@@ -104,7 +104,7 @@ Connection list:
  
 "westnet-eastnet": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/basic-pluto-01-nosecrets/east.console.txt
+++ b/testing/pluto/basic-pluto-01-nosecrets/east.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-eastnet": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/basic-pluto-01-nosecrets/west.console.txt
+++ b/testing/pluto/basic-pluto-01-nosecrets/west.console.txt
@@ -115,7 +115,7 @@ Connection list:
  
 "nosecrets": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "nosecrets":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"nosecrets":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nosecrets":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nosecrets":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nosecrets":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nosecrets":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/basic-pluto-01/east.console.txt
+++ b/testing/pluto/basic-pluto-01/east.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-eastnet": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/basic-pluto-01/west.console.txt
+++ b/testing/pluto/basic-pluto-01/west.console.txt
@@ -115,7 +115,7 @@ Connection list:
  
 "westnet-eastnet": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/basic-pluto-02/west.console.txt
+++ b/testing/pluto/basic-pluto-02/west.console.txt
@@ -112,7 +112,7 @@ west #
  ipsec auto --status |grep westnet
 "westnet-all": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===0.0.0.0/0; unrouted; my_ip=unset; their_ip=unset;
 "westnet-all":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-all":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-all":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-all":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-all":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-all":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/basic-pluto-03/north.console.txt
+++ b/testing/pluto/basic-pluto-03/north.console.txt
@@ -110,7 +110,7 @@ Connection list:
  
 "northnet-eastnet-nonat": 192.0.3.0/24===192.1.3.33[@north]---192.1.3.254...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "northnet-eastnet-nonat":   host: oriented; local: 192.1.3.33; nexthop: 192.1.3.254; remote: 192.1.2.23;
-"northnet-eastnet-nonat":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"northnet-eastnet-nonat":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "northnet-eastnet-nonat":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "northnet-eastnet-nonat":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "northnet-eastnet-nonat":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/basic-pluto-10-nm-configured/east.console.txt
+++ b/testing/pluto/basic-pluto-10-nm-configured/east.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-eastnet": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/basic-pluto-10-nm-configured/west.console.txt
+++ b/testing/pluto/basic-pluto-10-nm-configured/west.console.txt
@@ -115,7 +115,7 @@ Connection list:
  
 "westnet-eastnet": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/basic-pluto-13-xfrm-ondemand/west.console.txt
+++ b/testing/pluto/basic-pluto-13-xfrm-ondemand/west.console.txt
@@ -14,7 +14,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-route
 "westnet-eastnet-route": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; routed-ondemand; my_ip=unset; their_ip=unset;
 "westnet-eastnet-route":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-route":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-route":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-route":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-route":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-route":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/compress-01-ikev1/east.console.txt
+++ b/testing/pluto/compress-01-ikev1/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec status | grep westnet-eastnet-compress
 "westnet-eastnet-compress": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-compress":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-compress":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-compress":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-compress":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-compress":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-compress":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/compress-01-ikev1/west.console.txt
+++ b/testing/pluto/compress-01-ikev1/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec status | grep westnet-eastnet-compress
 "westnet-eastnet-compress": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-compress":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-compress":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-compress":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-compress":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-compress":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-compress":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/compress-01-ikev2/east.console.txt
+++ b/testing/pluto/compress-01-ikev2/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec status | grep westnet-eastnet-ipcomp
 "westnet-eastnet-ipcomp": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipcomp":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipcomp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipcomp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipcomp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipcomp":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ipcomp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/compress-01-ikev2/west.console.txt
+++ b/testing/pluto/compress-01-ikev2/west.console.txt
@@ -30,7 +30,7 @@ west #
  ipsec status | grep westnet-eastnet-ipcomp
 "westnet-eastnet-ipcomp": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipcomp":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipcomp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipcomp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipcomp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipcomp":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ipcomp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/compress-02-cleanup-ikev1/east.console.txt
+++ b/testing/pluto/compress-02-cleanup-ikev1/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec status | grep westnet-eastnet-compress
 "westnet-eastnet-compress": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-compress":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-compress":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-compress":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-compress":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-compress":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-compress":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/compress-02-cleanup-ikev1/west.console.txt
+++ b/testing/pluto/compress-02-cleanup-ikev1/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec whack --connectionstatus --name westnet-eastnet-compress
 "westnet-eastnet-compress": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-compress":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-compress":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-compress":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-compress":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-compress":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-compress":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/compress-03-mismatch-ikev1/east.console.txt
+++ b/testing/pluto/compress-03-mismatch-ikev1/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec status | grep westnet-eastnet-compress
 "westnet-eastnet-compress": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-compress":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-compress":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-compress":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-compress":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-compress":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-compress":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/compress-03-mismatch-ikev1/west.console.txt
+++ b/testing/pluto/compress-03-mismatch-ikev1/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec status | grep westnet-eastnet-compress
 "westnet-eastnet-compress": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-compress":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-compress":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-compress":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-compress":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-compress":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-compress":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/compress-03-mismatch-ikev2/east.console.txt
+++ b/testing/pluto/compress-03-mismatch-ikev2/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec status | grep westnet-eastnet-ipcomp
 "westnet-eastnet-ipcomp": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipcomp":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipcomp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipcomp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipcomp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipcomp":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ipcomp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/compress-03-mismatch-ikev2/west.console.txt
+++ b/testing/pluto/compress-03-mismatch-ikev2/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec status | grep westnet-eastnet-ipcomp
 "westnet-eastnet-ipcomp": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipcomp":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipcomp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipcomp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipcomp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipcomp":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ipcomp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/compress-05-3des-ikev1/east.console.txt
+++ b/testing/pluto/compress-05-3des-ikev1/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec status | grep westnet-eastnet-esp-3des-alg
 "westnet-eastnet-esp-3des-alg": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-esp-3des-alg":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-esp-3des-alg":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-esp-3des-alg":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-esp-3des-alg":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-esp-3des-alg":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-esp-3des-alg":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/compress-05-3des-ikev1/west.console.txt
+++ b/testing/pluto/compress-05-3des-ikev1/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec status | grep westnet-eastnet-esp-3des-alg
 "westnet-eastnet-esp-3des-alg": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-esp-3des-alg":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-esp-3des-alg":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-esp-3des-alg":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-esp-3des-alg":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-esp-3des-alg":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-esp-3des-alg":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/connalias-01-conflict/west.console.txt
+++ b/testing/pluto/connalias-01-conflict/west.console.txt
@@ -31,7 +31,7 @@ west #
  ipsec whack --status | grep westnet-eastnet
 "westnet-eastnet-alias": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-alias":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-alias":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-alias":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-alias":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-alias":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-alias":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -53,7 +53,7 @@ west #
 "westnet-eastnet-alias":   aliases: franklin
 "westnet-eastnet-second": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-second":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-second":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-second":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-second":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-second":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-second":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/crossing-streams-24-ikev2-delete-connswitch-github-2101/west.console.txt
+++ b/testing/pluto/crossing-streams-24-ikev2-delete-connswitch-github-2101/west.console.txt
@@ -30,7 +30,7 @@ Connection list:
  
 "a": 192.0.3.253/32===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; routed-tunnel; my_ip=192.0.3.253; their_ip=unset;
 "a":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23; established IKE SA: #3;
-"a":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"a":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "a":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "a":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "a":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -54,7 +54,7 @@ Connection list:
 "a":   ESP algorithm newest: AES_GCM_16_256; pfsgroup=<Phase1>
 "b": 192.0.3.254/32===192.1.2.45[@west]...192.1.2.23[@east]===192.0.20.0/24; routed-tunnel; my_ip=192.0.3.254; their_ip=unset;
 "b":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"b":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"b":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "b":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "b":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "b":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/dpd-09-shared/north.console.txt
+++ b/testing/pluto/dpd-09-shared/north.console.txt
@@ -60,7 +60,7 @@ north #
 "north-a-dpd": 192.0.3.0/24===192.1.3.33[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org]---192.1.3.254...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===192.0.22.0/24; routed-ondemand; my_ip=unset; their_ip=unset;
 "north-a-dpd":   host: oriented; local: 192.1.3.33; remote: 192.1.2.23;
 "north-a-dpd":   mycert=north; peercert=east;
-"north-a-dpd":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"north-a-dpd":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "north-a-dpd":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "north-a-dpd":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "north-a-dpd":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/dpd-10-alias/east.console.txt
+++ b/testing/pluto/dpd-10-alias/east.console.txt
@@ -14,7 +14,7 @@ east #
 "northnet-eastnets/0x1": 192.0.2.0/24===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]---192.1.2.254...192.1.3.33[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org]===192.0.3.0/24; unrouted; my_ip=unset; their_ip=unset;
 "northnet-eastnets/0x1":   host: oriented; local: 192.1.2.23; remote: 192.1.3.33;
 "northnet-eastnets/0x1":   mycert=east; peercert=north;
-"northnet-eastnets/0x1":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"northnet-eastnets/0x1":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "northnet-eastnets/0x1":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "northnet-eastnets/0x1":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "northnet-eastnets/0x1":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -37,7 +37,7 @@ east #
 "northnet-eastnets/0x2": 192.0.22.0/24===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]---192.1.2.254...192.1.3.33[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org]===192.0.3.0/24; unrouted; eroute owner: #0
 "northnet-eastnets/0x2":     oriented; my_ip=unset; their_ip=unset;
 "northnet-eastnets/0x2":   mycert=east; peercert=north;
-"northnet-eastnets/0x2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"northnet-eastnets/0x2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "northnet-eastnets/0x2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "northnet-eastnets/0x2":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "northnet-eastnets/0x2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/dpd-10-alias/north.console.txt
+++ b/testing/pluto/dpd-10-alias/north.console.txt
@@ -60,7 +60,7 @@ north #
 "north-dpd/0x1": 192.0.3.0/24===192.1.3.33[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org]---192.1.3.254...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===192.0.2.0/24; routed-ondemand; my_ip=unset; their_ip=unset;
 "north-dpd/0x1":   host: oriented; local: 192.1.3.33; remote: 192.1.2.23;
 "north-dpd/0x1":   mycert=north; peercert=east;
-"north-dpd/0x1":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"north-dpd/0x1":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "north-dpd/0x1":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "north-dpd/0x1":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "north-dpd/0x1":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -83,7 +83,7 @@ north #
 "north-dpd/0x2": 192.0.3.0/24===192.1.3.33[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org]---192.1.3.254...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===192.0.22.0/24; prospective erouted; eroute owner: #0
 "north-dpd/0x2":     oriented; my_ip=unset; their_ip=unset;
 "north-dpd/0x2":   mycert=north; peercert=east;
-"north-dpd/0x2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"north-dpd/0x2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "north-dpd/0x2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "north-dpd/0x2":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "north-dpd/0x2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-28-huge-lifetime/east.console.txt
+++ b/testing/pluto/ikev1-28-huge-lifetime/east.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-eastnet": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-28-huge-lifetime/west.console.txt
+++ b/testing/pluto/ikev1-28-huge-lifetime/west.console.txt
@@ -115,7 +115,7 @@ Connection list:
  
 "westnet-eastnet": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-aggr-01-authby-default-rsasig/east.console.txt
+++ b/testing/pluto/ikev1-aggr-01-authby-default-rsasig/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-aggr
 "westnet-eastnet-aggr": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-aggr":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-aggr":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-aggr":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-aggr":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-aggr":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-aggr":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-aggr-01-authby-default-rsasig/west.console.txt
+++ b/testing/pluto/ikev1-aggr-01-authby-default-rsasig/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-aggr
 "westnet-eastnet-aggr": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-aggr":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-aggr":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-aggr":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-aggr":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-aggr":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-aggr":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-aggr-02-authby-secret/east.console.txt
+++ b/testing/pluto/ikev1-aggr-02-authby-secret/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-aggr
 "westnet-eastnet-aggr": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-aggr":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-aggr":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-aggr":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-aggr":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-aggr":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-aggr":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-aggr-02-authby-secret/west.console.txt
+++ b/testing/pluto/ikev1-aggr-02-authby-secret/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-aggr
 "westnet-eastnet-aggr": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-aggr":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-aggr":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-aggr":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-aggr":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-aggr":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-aggr":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-aggr-03-authby-rsasig/east.console.txt
+++ b/testing/pluto/ikev1-aggr-03-authby-rsasig/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-aggr
 "westnet-eastnet-aggr": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-aggr":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-aggr":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-aggr":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-aggr":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-aggr":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-aggr":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-aggr-03-authby-rsasig/west.console.txt
+++ b/testing/pluto/ikev1-aggr-03-authby-rsasig/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-aggr
 "westnet-eastnet-aggr": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-aggr":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-aggr":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-aggr":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-aggr":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-aggr":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-aggr":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-aggr-06-use-last-ike-dh/east.console.txt
+++ b/testing/pluto/ikev1-aggr-06-use-last-ike-dh/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status |grep westnet-eastnet-aggr
 "westnet-eastnet-aggr": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-aggr":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-aggr":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-aggr":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-aggr":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-aggr":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-aggr":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-aggr-06-use-last-ike-dh/west.console.txt
+++ b/testing/pluto/ikev1-aggr-06-use-last-ike-dh/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-aggr
 "westnet-eastnet-aggr": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-aggr":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-aggr":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-aggr":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-aggr":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-aggr":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-aggr":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-algo-esp-null-01/east.console.txt
+++ b/testing/pluto/ikev1-algo-esp-null-01/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-null
 "westnet-eastnet-null": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-null":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-null":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-null":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-null":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-null":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-null":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-algo-esp-null-01/west.console.txt
+++ b/testing/pluto/ikev1-algo-esp-null-01/west.console.txt
@@ -30,7 +30,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-null
 "westnet-eastnet-null": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-null":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-null":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-null":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-null":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-null":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-null":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-algo-esp-sha2-05/east.console.txt
+++ b/testing/pluto/ikev1-algo-esp-sha2-05/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec status | grep westnet-eastnet-ipv4-psk-ikev1
 "westnet-eastnet-ipv4-psk-ikev1": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev1":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ikev1":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev1":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev1":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev1":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev1":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-algo-esp-sha2-05/west.console.txt
+++ b/testing/pluto/ikev1-algo-esp-sha2-05/west.console.txt
@@ -14,7 +14,7 @@ west #
  ipsec status |grep westnet-eastnet-ipv4-psk-ikev1
 "westnet-eastnet-ipv4-psk-ikev1": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev1":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ikev1":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev1":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev1":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev1":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev1":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-algo-ike-aes-01/east.console.txt
+++ b/testing/pluto/ikev1-algo-ike-aes-01/east.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-eastnet-aes128": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-aes128":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-aes128":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-aes128":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-aes128":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-aes128":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-aes128":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-algo-ike-aes-01/west.console.txt
+++ b/testing/pluto/ikev1-algo-ike-aes-01/west.console.txt
@@ -115,7 +115,7 @@ Connection list:
  
 "westnet-eastnet-aes128": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-aes128":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-aes128":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-aes128":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-aes128":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-aes128":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-aes128":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-algo-ike-aes-02/east.console.txt
+++ b/testing/pluto/ikev1-algo-ike-aes-02/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status |grep westnet-eastnet-3des
 "westnet-eastnet-3des": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-3des":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-3des":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-3des":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-3des":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-3des":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-3des":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-algo-ike-aes-02/west.console.txt
+++ b/testing/pluto/ikev1-algo-ike-aes-02/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec auto --status |grep westnet-eastnet-3des
 "westnet-eastnet-3des": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-3des":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-3des":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-3des":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-3des":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-3des":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-3des":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-algo-ike-sha2-01/east.console.txt
+++ b/testing/pluto/ikev1-algo-ike-sha2-01/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-sha2
 "westnet-eastnet-sha2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-sha2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-sha2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-sha2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-sha2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-sha2":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-sha2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-algo-ike-sha2-01/west.console.txt
+++ b/testing/pluto/ikev1-algo-ike-sha2-01/west.console.txt
@@ -30,7 +30,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-sha2
 "westnet-eastnet-sha2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-sha2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-sha2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-sha2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-sha2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-sha2":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-sha2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-algo-ike-sha2-02/east.console.txt
+++ b/testing/pluto/ikev1-algo-ike-sha2-02/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-sha2
 "westnet-eastnet-sha2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-sha2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-sha2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-sha2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-sha2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-sha2":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-sha2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-algo-ike-sha2-02/west.console.txt
+++ b/testing/pluto/ikev1-algo-ike-sha2-02/west.console.txt
@@ -30,7 +30,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-sha2
 "westnet-eastnet-sha2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-sha2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-sha2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-sha2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-sha2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-sha2":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-sha2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-algo-ike-sha2-03/east.console.txt
+++ b/testing/pluto/ikev1-algo-ike-sha2-03/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-sha2
 "westnet-eastnet-sha2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-sha2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-sha2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-sha2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-sha2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-sha2":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-sha2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-algo-ike-sha2-03/west.console.txt
+++ b/testing/pluto/ikev1-algo-ike-sha2-03/west.console.txt
@@ -30,7 +30,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-sha2
 "westnet-eastnet-sha2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-sha2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-sha2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-sha2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-sha2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-sha2":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-sha2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-algo-sha2-variant-bug/east.console.txt
+++ b/testing/pluto/ikev1-algo-sha2-variant-bug/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec status | grep westnet-eastnet-ipv4-psk-ikev1
 "westnet-eastnet-ipv4-psk-ikev1": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev1":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ikev1":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev1":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev1":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev1":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev1":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-algo-sha2-variant-bug/west.console.txt
+++ b/testing/pluto/ikev1-algo-sha2-variant-bug/west.console.txt
@@ -14,7 +14,7 @@ west #
  ipsec status |grep westnet-eastnet-ipv4-psk-ikev1
 "westnet-eastnet-ipv4-psk-ikev1": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev1":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ikev1":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev1":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev1":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev1":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev1":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-connswitch-01/east.console.txt
+++ b/testing/pluto/ikev1-connswitch-01/east.console.txt
@@ -25,7 +25,7 @@ east #
 "westnet-eastnet": 192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]---192.1.2.45...%any; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.45; remote: %any;
 "westnet-eastnet":   mycert=east;
-"westnet-eastnet":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-connswitch-01/west.console.txt
+++ b/testing/pluto/ikev1-connswitch-01/west.console.txt
@@ -26,7 +26,7 @@ west #
 "westnet-eastnet-ikev1": 192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[%fromcert]; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev1":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "westnet-eastnet-ikev1":   mycert=west;
-"westnet-eastnet-ikev1":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev1":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev1":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev1":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev1":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-connswitch-02/east.console.txt
+++ b/testing/pluto/ikev1-connswitch-02/east.console.txt
@@ -26,7 +26,7 @@ east #
 "westnet-eastnet": 192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]---192.1.2.45...%any; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.45; remote: %any;
 "westnet-eastnet":   mycert=east;
-"westnet-eastnet":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-connswitch-02/west.console.txt
+++ b/testing/pluto/ikev1-connswitch-02/west.console.txt
@@ -27,7 +27,7 @@ west #
 "westnet-eastnet-ikev1": 192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[%fromcert]; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev1":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "westnet-eastnet-ikev1":   mycert=west;
-"westnet-eastnet-ikev1":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev1":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev1":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev1":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev1":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-cryptoload-00/east.console.txt
+++ b/testing/pluto/ikev1-cryptoload-00/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet
 "westnet-eastnet": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-cryptoload-00/west.console.txt
+++ b/testing/pluto/ikev1-cryptoload-00/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec auto --status | grep westnet-eastnet
 "westnet-eastnet": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-hostpair-01/east.console.txt
+++ b/testing/pluto/ikev1-hostpair-01/east.console.txt
@@ -18,7 +18,7 @@ east #
 "roadnet-eastnet-ipv4-psk-ikev1": 192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...%any[%fromcert]==={192.0.2.1-192.0.2.200}; unrouted; my_ip=unset; their_ip=unset;
 "roadnet-eastnet-ipv4-psk-ikev1":   host: oriented; local: 192.1.2.23; remote: %any;
 "roadnet-eastnet-ipv4-psk-ikev1":   mycert=east;
-"roadnet-eastnet-ipv4-psk-ikev1":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"roadnet-eastnet-ipv4-psk-ikev1":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "roadnet-eastnet-ipv4-psk-ikev1":   xauth us:server, xauth them:server, xauthby:alwaysok; xauthfail:hard; my_username=[any]; their_username=[any]
 "roadnet-eastnet-ipv4-psk-ikev1":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "roadnet-eastnet-ipv4-psk-ikev1":   modecfg info: us:server, them:client, modecfg policy:push, dns:1.2.3.4, 8.8.8.8, domains:unset, cat:unset;
@@ -41,7 +41,7 @@ east #
 "roadnet-eastnet-ipv4-psk-ikev1"[1]: 192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.254[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org]==={192.0.2.1/32}; routed-tunnel; my_ip=unset; their_ip=192.0.2.1;
 "roadnet-eastnet-ipv4-psk-ikev1"[1]:   host: oriented; local: 192.1.2.23; remote: 192.1.2.254; established ISAKMP SA: #3;
 "roadnet-eastnet-ipv4-psk-ikev1"[1]:   mycert=east;
-"roadnet-eastnet-ipv4-psk-ikev1"[1]:   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"roadnet-eastnet-ipv4-psk-ikev1"[1]:   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "roadnet-eastnet-ipv4-psk-ikev1"[1]:   xauth us:server, xauth them:server, xauthby:alwaysok; xauthfail:hard; my_username=[any]; their_username=[any]
 "roadnet-eastnet-ipv4-psk-ikev1"[1]:   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "roadnet-eastnet-ipv4-psk-ikev1"[1]:   modecfg info: us:server, them:client, modecfg policy:push, dns:1.2.3.4, 8.8.8.8, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-hostpair-01/road.console.txt
+++ b/testing/pluto/ikev1-hostpair-01/road.console.txt
@@ -104,7 +104,7 @@ road #
 "westnet-eastnet-ipv4-psk-ikev1": 192.0.2.1/32===192.1.3.210[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org]---192.1.3.254...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]; routed-tunnel; my_ip=192.0.2.1; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev1":   host: oriented; local: 192.1.3.210; nexthop: 192.1.3.254; remote: 192.1.2.23; established ISAKMP SA: #1;
 "westnet-eastnet-ipv4-psk-ikev1":   mycert=road;
-"westnet-eastnet-ipv4-psk-ikev1":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev1":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev1":   xauth us:client, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev1":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev1":   modecfg info: us:client, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-hub-spoke/east.console.txt
+++ b/testing/pluto/ikev1-hub-spoke/east.console.txt
@@ -102,7 +102,7 @@ Connection list:
  
 "northnet-westnet-ipv4-psk": 192.0.1.0/24===192.1.2.23[@east]...192.1.3.33[@north]===192.0.3.0/24; unrouted; my_ip=unset; their_ip=unset;
 "northnet-westnet-ipv4-psk":   host: oriented; local: 192.1.2.23; remote: 192.1.3.33;
-"northnet-westnet-ipv4-psk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"northnet-westnet-ipv4-psk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "northnet-westnet-ipv4-psk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "northnet-westnet-ipv4-psk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "northnet-westnet-ipv4-psk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -123,7 +123,7 @@ Connection list:
 "northnet-westnet-ipv4-psk":   conn serial: $2;
 "westnet-northnet-ipv4-psk": 192.0.3.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-northnet-ipv4-psk":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-northnet-ipv4-psk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-northnet-ipv4-psk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-northnet-ipv4-psk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-northnet-ipv4-psk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-northnet-ipv4-psk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-hub-spoke/north.console.txt
+++ b/testing/pluto/ikev1-hub-spoke/north.console.txt
@@ -110,7 +110,7 @@ Connection list:
  
 "northnet-westnet-ipv4-psk": 192.0.3.0/24===192.1.3.33[@north]...192.1.2.23[@east]===192.0.1.0/24; routed-tunnel; my_ip=unset; their_ip=unset;
 "northnet-westnet-ipv4-psk":   host: oriented; local: 192.1.3.33; remote: 192.1.2.23; established ISAKMP SA: #1;
-"northnet-westnet-ipv4-psk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"northnet-westnet-ipv4-psk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "northnet-westnet-ipv4-psk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "northnet-westnet-ipv4-psk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "northnet-westnet-ipv4-psk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-hub-spoke/west.console.txt
+++ b/testing/pluto/ikev1-hub-spoke/west.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-northnet-ipv4-psk": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.3.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-northnet-ipv4-psk":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-northnet-ipv4-psk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-northnet-ipv4-psk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-northnet-ipv4-psk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-northnet-ipv4-psk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-northnet-ipv4-psk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-impair-01-replay-duplicates/west.console.txt
+++ b/testing/pluto/ikev1-impair-01-replay-duplicates/west.console.txt
@@ -115,7 +115,7 @@ Connection list:
  
 "westnet-eastnet": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-impair-02-replay-forward/west.console.txt
+++ b/testing/pluto/ikev1-impair-02-replay-forward/west.console.txt
@@ -115,7 +115,7 @@ Connection list:
  
 "westnet-eastnet": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-isakmp-reserved-flags-01/east.console.txt
+++ b/testing/pluto/ikev1-isakmp-reserved-flags-01/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet
 "westnet-eastnet": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-isakmp-reserved-flags-01/west.console.txt
+++ b/testing/pluto/ikev1-isakmp-reserved-flags-01/west.console.txt
@@ -30,7 +30,7 @@ west #
  ipsec auto --status | grep westnet-eastnet
 "westnet-eastnet": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-isakmp-reserved-flags-02/east.console.txt
+++ b/testing/pluto/ikev1-isakmp-reserved-flags-02/east.console.txt
@@ -14,7 +14,7 @@ east #
  ipsec auto --status | grep westnet-eastnet
 "westnet-eastnet": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-isakmp-reserved-flags-02/west.console.txt
+++ b/testing/pluto/ikev1-isakmp-reserved-flags-02/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec auto --status | grep westnet-eastnet
 "westnet-eastnet": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-rekey-connswitch/west.console.txt
+++ b/testing/pluto/ikev1-rekey-connswitch/west.console.txt
@@ -128,7 +128,7 @@ west #
 "TUNNEL-A": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===192.0.2.254/32; routed-tunnel; my_ip=unset; their_ip=unset;
 "TUNNEL-A":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "TUNNEL-A":   mycert=west;
-"TUNNEL-A":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"TUNNEL-A":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "TUNNEL-A":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "TUNNEL-A":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "TUNNEL-A":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -152,7 +152,7 @@ west #
 "TUNNEL-B": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===192.0.2.244/32; prospective erouted; eroute owner: #0
 "TUNNEL-B":     oriented; my_ip=unset; their_ip=unset;
 "TUNNEL-B":   mycert=west;
-"TUNNEL-B":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"TUNNEL-B":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "TUNNEL-B":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "TUNNEL-B":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "TUNNEL-B":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -175,7 +175,7 @@ west #
 "TUNNEL-C": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===192.0.2.234/32; erouted; eroute owner: #4
 "TUNNEL-C":     oriented; my_ip=unset; their_ip=unset;
 "TUNNEL-C":   mycert=west;
-"TUNNEL-C":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"TUNNEL-C":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "TUNNEL-C":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "TUNNEL-C":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "TUNNEL-C":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -210,7 +210,7 @@ west #
 "TUNNEL-A": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===192.0.2.254/32; erouted; eroute owner: #2
 "TUNNEL-A":     oriented; my_ip=unset; their_ip=unset;
 "TUNNEL-A":   mycert=west;
-"TUNNEL-A":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"TUNNEL-A":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "TUNNEL-A":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "TUNNEL-A":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "TUNNEL-A":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -234,7 +234,7 @@ west #
 "TUNNEL-C": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===192.0.2.234/32; erouted; eroute owner: #4
 "TUNNEL-C":     oriented; my_ip=unset; their_ip=unset;
 "TUNNEL-C":   mycert=west;
-"TUNNEL-C":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"TUNNEL-C":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "TUNNEL-C":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "TUNNEL-C":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "TUNNEL-C":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev1-x509-15-pkcs7/east.console.txt
+++ b/testing/pluto/ikev1-x509-15-pkcs7/east.console.txt
@@ -26,7 +26,7 @@ east #
 "westnet-eastnet-x509": 192.0.2.0/24===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-x509":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "westnet-eastnet-x509":   mycert=east; peercert=west;
-"westnet-eastnet-x509":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-x509":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-x509":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-x509":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-x509":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-03-basic-rawrsa-pem/east.console.txt
+++ b/testing/pluto/ikev2-03-basic-rawrsa-pem/east.console.txt
@@ -85,7 +85,7 @@ east #
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23...192.1.2.45===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "westnet-eastnet-ikev2":   mycert=east; peercert=west;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-03-basic-rawrsa-pem/west.console.txt
+++ b/testing/pluto/ikev2-03-basic-rawrsa-pem/west.console.txt
@@ -45,7 +45,7 @@ west #
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45...192.1.2.23===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "westnet-eastnet-ikev2":   mycert=west; peercert=east;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-03-basic-rawrsa-rsasigkey/east.console.txt
+++ b/testing/pluto/ikev2-03-basic-rawrsa-rsasigkey/east.console.txt
@@ -101,7 +101,7 @@ Connection list:
  
 "west-rsasigkey-east-rsasigkey": 192.0.2.0/24===192.1.2.23...192.1.2.45===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "west-rsasigkey-east-rsasigkey":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"west-rsasigkey-east-rsasigkey":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"west-rsasigkey-east-rsasigkey":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "west-rsasigkey-east-rsasigkey":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "west-rsasigkey-east-rsasigkey":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "west-rsasigkey-east-rsasigkey":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-03-basic-rawrsa/east.console.txt
+++ b/testing/pluto/ikev2-03-basic-rawrsa/east.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-03-basic-rawrsa/west.console.txt
+++ b/testing/pluto/ikev2-03-basic-rawrsa/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-04-basic-x509-ckaid/east.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-ckaid/east.console.txt
@@ -68,7 +68,7 @@ east #
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "westnet-eastnet-ikev2":   mycert=east; peercert=west;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-04-basic-x509-ckaid/west.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-ckaid/west.console.txt
@@ -45,7 +45,7 @@ west #
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "westnet-eastnet-ikev2":   mycert=west; peercert=east;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-04-basic-x509-nhelpers0/east.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-nhelpers0/east.console.txt
@@ -13,7 +13,7 @@ east #
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "westnet-eastnet-ikev2":   mycert=east;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-04-basic-x509-nhelpers0/west.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-nhelpers0/west.console.txt
@@ -29,7 +29,7 @@ west #
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "westnet-eastnet-ikev2":   mycert=west;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-04-basic-x509-no-ca-02/east.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-no-ca-02/east.console.txt
@@ -34,7 +34,7 @@ east #
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23...192.1.2.45===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "westnet-eastnet-ikev2":   mycert=east; peercert=west;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-04-basic-x509-no-ca-02/west.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-no-ca-02/west.console.txt
@@ -62,7 +62,7 @@ west #
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45...192.1.2.23===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "westnet-eastnet-ikev2":   mycert=west; peercert=east;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-04-basic-x509-no-ca-mismatch-02/east.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-no-ca-mismatch-02/east.console.txt
@@ -34,7 +34,7 @@ east #
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23...192.1.2.45===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "westnet-eastnet-ikev2":   mycert=east; peercert=west;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-04-basic-x509-no-ca-mismatch-02/west.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-no-ca-mismatch-02/west.console.txt
@@ -46,7 +46,7 @@ west #
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45...192.1.2.23===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "westnet-eastnet-ikev2":   mycert=north; peercert=east;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-04-basic-x509-no-ca-mismatch/east.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-no-ca-mismatch/east.console.txt
@@ -36,7 +36,7 @@ east #
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23...192.1.2.45===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "westnet-eastnet-ikev2":   mycert=east; peercert=west;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-04-basic-x509-no-ca-mismatch/west.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-no-ca-mismatch/west.console.txt
@@ -36,7 +36,7 @@ west #
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45...192.1.2.23===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "westnet-eastnet-ikev2":   mycert=north; peercert=east;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-04-basic-x509-no-ca/east.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-no-ca/east.console.txt
@@ -26,7 +26,7 @@ east #
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23...192.1.2.45===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "westnet-eastnet-ikev2":   mycert=east; peercert=west;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-04-basic-x509-no-ca/west.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-no-ca/west.console.txt
@@ -42,7 +42,7 @@ west #
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45...192.1.2.23===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "westnet-eastnet-ikev2":   mycert=west; peercert=east;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-04-basic-x509-nsspw/east.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-nsspw/east.console.txt
@@ -14,7 +14,7 @@ east #
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "westnet-eastnet-ikev2":   mycert=east;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-04-basic-x509-nsspw/west.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-nsspw/west.console.txt
@@ -30,7 +30,7 @@ west #
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "westnet-eastnet-ikev2":   mycert=west;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-04-basic-x509/east.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509/east.console.txt
@@ -16,7 +16,7 @@ east #
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "westnet-eastnet-ikev2":   mycert=east; peercert=west;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-04-basic-x509/west.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509/west.console.txt
@@ -29,7 +29,7 @@ west #
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "westnet-eastnet-ikev2":   mycert=west; peercert=east;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-09-rw-rsa/east.console.txt
+++ b/testing/pluto/ikev2-09-rw-rsa/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep road-eastnet-nonat
 "road-eastnet-nonat": 192.0.2.0/24===192.1.2.23[@east]---192.1.2.254...%any[@road]===192.0.2.219/32; unrouted; my_ip=unset; their_ip=192.0.2.219;
 "road-eastnet-nonat":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.254; remote: %any;
-"road-eastnet-nonat":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-eastnet-nonat":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-eastnet-nonat":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-eastnet-nonat":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "road-eastnet-nonat":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-09-rw-rsa/road.console.txt
+++ b/testing/pluto/ikev2-09-rw-rsa/road.console.txt
@@ -18,7 +18,7 @@ road #
  ipsec auto --status | grep road-eastnet-nonat
 "road-eastnet-nonat": 192.0.2.219/32===192.1.3.209[@road]---192.1.3.254...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=192.0.2.219; their_ip=unset;
 "road-eastnet-nonat":   host: oriented; local: 192.1.3.209; nexthop: 192.1.3.254; remote: 192.1.2.23;
-"road-eastnet-nonat":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-eastnet-nonat":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-eastnet-nonat":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-eastnet-nonat":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "road-eastnet-nonat":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-11-simple-psk/east.console.txt
+++ b/testing/pluto/ikev2-11-simple-psk/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-ipv4-psk-ikev2
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-11-simple-psk/west.console.txt
+++ b/testing/pluto/ikev2-11-simple-psk/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec auto --status |grep westnet-eastnet-ipv4-psk-ikev2
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-12-transport-psk/east.console.txt
+++ b/testing/pluto/ikev2-12-transport-psk/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep ipv4-psk-ikev2-transport
 "ipv4-psk-ikev2-transport": 192.1.2.23[@east]...192.1.2.45[@west]; unrouted; my_ip=unset; their_ip=unset;
 "ipv4-psk-ikev2-transport":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"ipv4-psk-ikev2-transport":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"ipv4-psk-ikev2-transport":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "ipv4-psk-ikev2-transport":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "ipv4-psk-ikev2-transport":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "ipv4-psk-ikev2-transport":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-12-transport-psk/west.console.txt
+++ b/testing/pluto/ikev2-12-transport-psk/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec auto --status | grep ipv4-psk-ikev2-transport
 "ipv4-psk-ikev2-transport": 192.1.2.45[@west]...192.1.2.23[@east]; unrouted; my_ip=unset; their_ip=unset;
 "ipv4-psk-ikev2-transport":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"ipv4-psk-ikev2-transport":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"ipv4-psk-ikev2-transport":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "ipv4-psk-ikev2-transport":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "ipv4-psk-ikev2-transport":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "ipv4-psk-ikev2-transport":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-12-x509-ikev1/east.console.txt
+++ b/testing/pluto/ikev2-12-x509-ikev1/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23[%fromcert]...192.1.2.45[%fromcert]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-12-x509-ikev1/west.console.txt
+++ b/testing/pluto/ikev2-12-x509-ikev1/west.console.txt
@@ -22,7 +22,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[%fromcert]...192.1.2.23[%fromcert]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-16-alias-whack-start/east.console.txt
+++ b/testing/pluto/ikev2-16-alias-whack-start/east.console.txt
@@ -16,7 +16,7 @@ east #
 "northnet-eastnets/0x1": 192.0.2.0/24===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]---192.1.2.254...192.1.3.33[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org]===192.0.3.0/24; unrouted; my_ip=unset; their_ip=unset;
 "northnet-eastnets/0x1":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.254; remote: 192.1.3.33;
 "northnet-eastnets/0x1":   mycert=east; peercert=north;
-"northnet-eastnets/0x1":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"northnet-eastnets/0x1":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "northnet-eastnets/0x1":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "northnet-eastnets/0x1":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "northnet-eastnets/0x1":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -41,7 +41,7 @@ east #
 "northnet-eastnets/0x2": 192.0.22.0/24===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]---192.1.2.254...192.1.3.33[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org]===192.0.3.0/24; unrouted; my_ip=unset; their_ip=unset;
 "northnet-eastnets/0x2":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.254; remote: 192.1.3.33;
 "northnet-eastnets/0x2":   mycert=east; peercert=north;
-"northnet-eastnets/0x2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"northnet-eastnets/0x2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "northnet-eastnets/0x2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "northnet-eastnets/0x2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "northnet-eastnets/0x2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-16-alias-whack-start/north.console.txt
+++ b/testing/pluto/ikev2-16-alias-whack-start/north.console.txt
@@ -32,7 +32,7 @@ north #
 "northnet-eastnets/0x1": 192.0.3.0/24===192.1.3.33[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org]---192.1.3.254...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===192.0.2.0/24; routed-tunnel; my_ip=unset; their_ip=unset;
 "northnet-eastnets/0x1":   host: oriented; local: 192.1.3.33; nexthop: 192.1.3.254; remote: 192.1.2.23; established IKE SA: #1;
 "northnet-eastnets/0x1":   mycert=north; peercert=east;
-"northnet-eastnets/0x1":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"northnet-eastnets/0x1":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "northnet-eastnets/0x1":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "northnet-eastnets/0x1":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "northnet-eastnets/0x1":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -59,7 +59,7 @@ north #
 "northnet-eastnets/0x2": 192.0.3.0/24===192.1.3.33[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org]---192.1.3.254...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===192.0.22.0/24; routed-tunnel; my_ip=unset; their_ip=unset;
 "northnet-eastnets/0x2":   host: oriented; local: 192.1.3.33; nexthop: 192.1.3.254; remote: 192.1.2.23;
 "northnet-eastnets/0x2":   mycert=north; peercert=east;
-"northnet-eastnets/0x2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"northnet-eastnets/0x2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "northnet-eastnets/0x2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "northnet-eastnets/0x2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "northnet-eastnets/0x2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-16-alias-whack-up/east.console.txt
+++ b/testing/pluto/ikev2-16-alias-whack-up/east.console.txt
@@ -16,7 +16,7 @@ east #
 "northnet-eastnets/0x1": 192.0.2.0/24===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]---192.1.2.254...192.1.3.33[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org]===192.0.3.0/24; unrouted; my_ip=unset; their_ip=unset;
 "northnet-eastnets/0x1":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.254; remote: 192.1.3.33;
 "northnet-eastnets/0x1":   mycert=east; peercert=north;
-"northnet-eastnets/0x1":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"northnet-eastnets/0x1":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "northnet-eastnets/0x1":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "northnet-eastnets/0x1":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "northnet-eastnets/0x1":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -41,7 +41,7 @@ east #
 "northnet-eastnets/0x2": 192.0.22.0/24===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]---192.1.2.254...192.1.3.33[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org]===192.0.3.0/24; unrouted; my_ip=unset; their_ip=unset;
 "northnet-eastnets/0x2":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.254; remote: 192.1.3.33;
 "northnet-eastnets/0x2":   mycert=east; peercert=north;
-"northnet-eastnets/0x2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"northnet-eastnets/0x2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "northnet-eastnets/0x2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "northnet-eastnets/0x2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "northnet-eastnets/0x2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-16-alias-whack-up/north.console.txt
+++ b/testing/pluto/ikev2-16-alias-whack-up/north.console.txt
@@ -32,7 +32,7 @@ north #
 "northnet-eastnets/0x1": 192.0.3.0/24===192.1.3.33[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org]---192.1.3.254...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===192.0.2.0/24; routed-tunnel; my_ip=unset; their_ip=unset;
 "northnet-eastnets/0x1":   host: oriented; local: 192.1.3.33; nexthop: 192.1.3.254; remote: 192.1.2.23; established IKE SA: #1;
 "northnet-eastnets/0x1":   mycert=north; peercert=east;
-"northnet-eastnets/0x1":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"northnet-eastnets/0x1":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "northnet-eastnets/0x1":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "northnet-eastnets/0x1":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "northnet-eastnets/0x1":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -59,7 +59,7 @@ north #
 "northnet-eastnets/0x2": 192.0.3.0/24===192.1.3.33[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org]---192.1.3.254...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===192.0.22.0/24; routed-tunnel; my_ip=unset; their_ip=unset;
 "northnet-eastnets/0x2":   host: oriented; local: 192.1.3.33; nexthop: 192.1.3.254; remote: 192.1.2.23;
 "northnet-eastnets/0x2":   mycert=north; peercert=east;
-"northnet-eastnets/0x2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"northnet-eastnets/0x2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "northnet-eastnets/0x2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "northnet-eastnets/0x2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "northnet-eastnets/0x2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-17-rekey-ipsec/east.console.txt
+++ b/testing/pluto/ikev2-17-rekey-ipsec/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-17-rekey-ipsec/west.console.txt
+++ b/testing/pluto/ikev2-17-rekey-ipsec/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-21-mode-mismatch-01/east.console.txt
+++ b/testing/pluto/ikev2-21-mode-mismatch-01/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep ipv4-psk-ikev2-transport
 "ipv4-psk-ikev2-transport": 192.1.2.23[@east]...192.1.2.45[@west]; unrouted; my_ip=unset; their_ip=unset;
 "ipv4-psk-ikev2-transport":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"ipv4-psk-ikev2-transport":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"ipv4-psk-ikev2-transport":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "ipv4-psk-ikev2-transport":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "ipv4-psk-ikev2-transport":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "ipv4-psk-ikev2-transport":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-21-mode-mismatch-01/west.console.txt
+++ b/testing/pluto/ikev2-21-mode-mismatch-01/west.console.txt
@@ -17,7 +17,7 @@ west #
  ipsec auto --status | grep ipv4-psk-ikev2-transport
 "ipv4-psk-ikev2-transport": 192.1.2.45[@west]...192.1.2.23[@east]; unrouted; my_ip=unset; their_ip=unset;
 "ipv4-psk-ikev2-transport":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"ipv4-psk-ikev2-transport":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"ipv4-psk-ikev2-transport":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "ipv4-psk-ikev2-transport":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "ipv4-psk-ikev2-transport":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "ipv4-psk-ikev2-transport":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-21-mode-mismatch-02/east.console.txt
+++ b/testing/pluto/ikev2-21-mode-mismatch-02/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep ipv4-psk-ikev2-transport
 "ipv4-psk-ikev2-transport": 192.1.2.23[@east]...192.1.2.45[@west]; unrouted; my_ip=unset; their_ip=unset;
 "ipv4-psk-ikev2-transport":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"ipv4-psk-ikev2-transport":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"ipv4-psk-ikev2-transport":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "ipv4-psk-ikev2-transport":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "ipv4-psk-ikev2-transport":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "ipv4-psk-ikev2-transport":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-21-mode-mismatch-02/west.console.txt
+++ b/testing/pluto/ikev2-21-mode-mismatch-02/west.console.txt
@@ -17,7 +17,7 @@ west #
  ipsec auto --status | grep ipv4-psk-ikev2-transport
 "ipv4-psk-ikev2-transport": 192.1.2.45[@west]...192.1.2.23[@east]; unrouted; my_ip=unset; their_ip=unset;
 "ipv4-psk-ikev2-transport":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"ipv4-psk-ikev2-transport":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"ipv4-psk-ikev2-transport":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "ipv4-psk-ikev2-transport":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "ipv4-psk-ikev2-transport":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "ipv4-psk-ikev2-transport":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-28-rw-server-rekey/east.console.txt
+++ b/testing/pluto/ikev2-28-rw-server-rekey/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep road-eastnet-nonat
 "road-eastnet-nonat": 192.0.2.0/24===192.1.2.23[@east]---192.1.2.254...%any[@road]===192.0.2.219/32; unrouted; my_ip=unset; their_ip=192.0.2.219;
 "road-eastnet-nonat":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.254; remote: %any;
-"road-eastnet-nonat":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-eastnet-nonat":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-eastnet-nonat":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-eastnet-nonat":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "road-eastnet-nonat":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-28-rw-server-rekey/road.console.txt
+++ b/testing/pluto/ikev2-28-rw-server-rekey/road.console.txt
@@ -18,7 +18,7 @@ road #
  ipsec auto --status | grep road-eastnet-nonat
 "road-eastnet-nonat": 192.0.2.219/32===192.1.3.209[@road]---192.1.3.254...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=192.0.2.219; their_ip=unset;
 "road-eastnet-nonat":   host: oriented; local: 192.1.3.209; nexthop: 192.1.3.254; remote: 192.1.2.23;
-"road-eastnet-nonat":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-eastnet-nonat":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-eastnet-nonat":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-eastnet-nonat":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "road-eastnet-nonat":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-29-no-rekey/east.console.txt
+++ b/testing/pluto/ikev2-29-no-rekey/east.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-29-no-rekey/west.console.txt
+++ b/testing/pluto/ikev2-29-no-rekey/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -158,7 +158,7 @@ Connection list:
  
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; routed-tunnel; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23; established IKE SA: #1;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -291,7 +291,7 @@ Connection list:
  
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; routed-ondemand; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-37-docker-rw/east.console.txt
+++ b/testing/pluto/ikev2-37-docker-rw/east.console.txt
@@ -91,7 +91,7 @@ Connection list:
  
 "road-eastnet-nonat": 192.0.2.0/24===192.1.2.23[@east]...%any[@road]===192.0.2.219/32; unrouted; my_ip=unset; their_ip=192.0.2.219;
 "road-eastnet-nonat":   host: oriented; local: 192.1.2.23; remote: %any;
-"road-eastnet-nonat":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-eastnet-nonat":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-eastnet-nonat":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-eastnet-nonat":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
 "road-eastnet-nonat":   cisco-split: no; cisco-unity: no; cisco-peer: no; nm-configured: no;

--- a/testing/pluto/ikev2-37-docker-rw/road.console.txt
+++ b/testing/pluto/ikev2-37-docker-rw/road.console.txt
@@ -95,7 +95,7 @@ Connection list:
  
 "road-eastnet-nonat": 192.0.2.219/32===192.1.3.209[@road]---192.1.3.254...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=192.0.2.219; their_ip=unset;
 "road-eastnet-nonat":   host: oriented; local: 192.1.3.209; remote: 192.1.2.23;
-"road-eastnet-nonat":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-eastnet-nonat":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-eastnet-nonat":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-eastnet-nonat":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
 "road-eastnet-nonat":   cisco-split: no; cisco-unity: no; cisco-peer: no; nm-configured: no;

--- a/testing/pluto/ikev2-41-rw-replace/road.console.txt
+++ b/testing/pluto/ikev2-41-rw-replace/road.console.txt
@@ -119,7 +119,7 @@ Connection list:
 "road-east-x509-ipv4": 0.0.0.0/0===192.1.3.209[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org]---192.1.3.254...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===0.0.0.0/0; unrouted; my_ip=unset; their_ip=unset;
 "road-east-x509-ipv4":   host: oriented; local: 192.1.3.209; nexthop: 192.1.3.254; remote: 192.1.2.23;
 "road-east-x509-ipv4":   mycert=road; peercert=east;
-"road-east-x509-ipv4":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-east-x509-ipv4":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-east-x509-ipv4":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-east-x509-ipv4":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "road-east-x509-ipv4":   modecfg info: us:client, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -143,7 +143,7 @@ Connection list:
 "road-east-x509-ipv4"[1]: 192.0.2.100/32===192.1.3.209[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org]---192.1.3.254...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===0.0.0.0/0; routed-tunnel; my_ip=192.0.2.100; their_ip=unset;
 "road-east-x509-ipv4"[1]:   host: oriented; local: 192.1.3.209; nexthop: 192.1.3.254; remote: 192.1.2.23; established IKE SA: #1;
 "road-east-x509-ipv4"[1]:   mycert=road; peercert=east;
-"road-east-x509-ipv4"[1]:   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-east-x509-ipv4"[1]:   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-east-x509-ipv4"[1]:   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-east-x509-ipv4"[1]:   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "road-east-x509-ipv4"[1]:   modecfg info: us:client, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -292,7 +292,7 @@ Connection list:
 "road-east-x509-ipv4": 0.0.0.0/0===192.1.3.209[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org]---192.1.3.254...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===0.0.0.0/0; unrouted; my_ip=unset; their_ip=unset;
 "road-east-x509-ipv4":   host: oriented; local: 192.1.3.209; nexthop: 192.1.3.254; remote: 192.1.2.23;
 "road-east-x509-ipv4":   mycert=road; peercert=east;
-"road-east-x509-ipv4":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-east-x509-ipv4":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-east-x509-ipv4":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-east-x509-ipv4":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "road-east-x509-ipv4":   modecfg info: us:client, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -316,7 +316,7 @@ Connection list:
 "road-east-x509-ipv4"[1]: 192.0.2.100/32===192.1.3.209[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org]---192.1.3.254...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===0.0.0.0/0; routed-tunnel; my_ip=192.0.2.100; their_ip=unset;
 "road-east-x509-ipv4"[1]:   host: oriented; local: 192.1.3.209; nexthop: 192.1.3.254; remote: 192.1.2.23; established IKE SA: #3;
 "road-east-x509-ipv4"[1]:   mycert=road; peercert=east;
-"road-east-x509-ipv4"[1]:   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-east-x509-ipv4"[1]:   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-east-x509-ipv4"[1]:   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-east-x509-ipv4"[1]:   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "road-east-x509-ipv4"[1]:   modecfg info: us:client, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-42-rw-replace-responder/road.console.txt
+++ b/testing/pluto/ikev2-42-rw-replace-responder/road.console.txt
@@ -141,7 +141,7 @@ Connection list:
 "road-east-x509-ipv4": 0.0.0.0/0===192.1.3.209[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org]---192.1.3.254...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===0.0.0.0/0; unrouted; my_ip=unset; their_ip=unset;
 "road-east-x509-ipv4":   host: oriented; local: 192.1.3.209; nexthop: 192.1.3.254; remote: 192.1.2.23;
 "road-east-x509-ipv4":   mycert=road; peercert=east;
-"road-east-x509-ipv4":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-east-x509-ipv4":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-east-x509-ipv4":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-east-x509-ipv4":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "road-east-x509-ipv4":   modecfg info: us:client, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -165,7 +165,7 @@ Connection list:
 "road-east-x509-ipv4"[1]: 192.0.2.100/32===192.1.3.209[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org]---192.1.3.254...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===0.0.0.0/0; routed-tunnel; my_ip=192.0.2.100; their_ip=unset;
 "road-east-x509-ipv4"[1]:   host: oriented; local: 192.1.3.209; nexthop: 192.1.3.254; remote: 192.1.2.23; established IKE SA: #3;
 "road-east-x509-ipv4"[1]:   mycert=road; peercert=east;
-"road-east-x509-ipv4"[1]:   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-east-x509-ipv4"[1]:   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-east-x509-ipv4"[1]:   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-east-x509-ipv4"[1]:   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "road-east-x509-ipv4"[1]:   modecfg info: us:client, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-47-priority/east.console.txt
+++ b/testing/pluto/ikev2-47-priority/east.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-47-priority/west.console.txt
+++ b/testing/pluto/ikev2-47-priority/west.console.txt
@@ -115,7 +115,7 @@ Connection list:
  
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-49-hub-spoke/east.console.txt
+++ b/testing/pluto/ikev2-49-hub-spoke/east.console.txt
@@ -102,7 +102,7 @@ Connection list:
  
 "northnet-westnet-ipv4-psk": 192.0.1.0/24===192.1.2.23[@east]...192.1.3.33[@north]===192.0.3.0/24; unrouted; my_ip=unset; their_ip=unset;
 "northnet-westnet-ipv4-psk":   host: oriented; local: 192.1.2.23; remote: 192.1.3.33;
-"northnet-westnet-ipv4-psk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"northnet-westnet-ipv4-psk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "northnet-westnet-ipv4-psk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "northnet-westnet-ipv4-psk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "northnet-westnet-ipv4-psk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -124,7 +124,7 @@ Connection list:
 "northnet-westnet-ipv4-psk":   conn serial: $2;
 "westnet-northnet-ipv4-psk": 192.0.3.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-northnet-ipv4-psk":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-northnet-ipv4-psk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-northnet-ipv4-psk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-northnet-ipv4-psk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-northnet-ipv4-psk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-northnet-ipv4-psk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-49-hub-spoke/north.console.txt
+++ b/testing/pluto/ikev2-49-hub-spoke/north.console.txt
@@ -110,7 +110,7 @@ Connection list:
  
 "northnet-westnet-ipv4-psk": 192.0.3.0/24===192.1.3.33[@north]...192.1.2.23[@east]===192.0.1.0/24; routed-tunnel; my_ip=unset; their_ip=unset;
 "northnet-westnet-ipv4-psk":   host: oriented; local: 192.1.3.33; remote: 192.1.2.23; established IKE SA: #1;
-"northnet-westnet-ipv4-psk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"northnet-westnet-ipv4-psk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "northnet-westnet-ipv4-psk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "northnet-westnet-ipv4-psk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "northnet-westnet-ipv4-psk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-49-hub-spoke/west.console.txt
+++ b/testing/pluto/ikev2-49-hub-spoke/west.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-northnet-ipv4-psk": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.3.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-northnet-ipv4-psk":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-northnet-ipv4-psk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-northnet-ipv4-psk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-northnet-ipv4-psk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-northnet-ipv4-psk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-northnet-ipv4-psk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-53-clean-pending/west.console.txt
+++ b/testing/pluto/ikev2-53-clean-pending/west.console.txt
@@ -9,7 +9,7 @@ west #
  ipsec auto --status |grep westnet-eastnet-ipv4-psk-ikev2
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.0.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted-bare-negotiation; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23; negotiating IKE SA: #1;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -38,7 +38,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-ipv4-psk-ikev2
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.0.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted-bare-negotiation; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23; negotiating IKE SA: #1;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -69,7 +69,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-ipv4-psk-ikev2
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.0.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted-bare-negotiation; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23; negotiating IKE SA: #2;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-55-ipseckey-01/east.console.txt
+++ b/testing/pluto/ikev2-55-ipseckey-01/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep road-east-ikev2
 "road-east-ikev2": 192.1.2.23[@east]...192.1.3.209[@road.testing.libreswan.org]; unrouted; my_ip=unset; their_ip=unset;
 "road-east-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.3.209;
-"road-east-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-east-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-east-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-east-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "road-east-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-55-ipseckey-02/east.console.txt
+++ b/testing/pluto/ikev2-55-ipseckey-02/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep road-east
 "road-east": 192.1.2.23[@east]...192.1.3.209[@road.testing.libreswan.org]; unrouted; my_ip=unset; their_ip=unset;
 "road-east":   host: oriented; local: 192.1.2.23; remote: 192.1.3.209;
-"road-east":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-east":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-east":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-east":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "road-east":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-55-ipseckey-03/east.console.txt
+++ b/testing/pluto/ikev2-55-ipseckey-03/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep road-east-ikev2
 "road-east-ikev2": 192.1.2.23...192.1.3.209; unrouted; my_ip=unset; their_ip=unset;
 "road-east-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.3.209;
-"road-east-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-east-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-east-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-east-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "road-east-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-55-ipseckey-04/east.console.txt
+++ b/testing/pluto/ikev2-55-ipseckey-04/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep road-east-ikev2
 "road-east-ikev2": 192.1.2.23...192.1.3.209[@road.testing.libreswan.org]; unrouted; my_ip=unset; their_ip=unset;
 "road-east-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.3.209;
-"road-east-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-east-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-east-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-east-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "road-east-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-55-ipseckey-05/east.console.txt
+++ b/testing/pluto/ikev2-55-ipseckey-05/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep road-east-ikev2
 "road-east-ikev2": 192.1.2.23...192.1.3.209[@road.testing.libreswan.org]; unrouted; my_ip=unset; their_ip=unset;
 "road-east-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.3.209;
-"road-east-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-east-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-east-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-east-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "road-east-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-55-ipseckey-06/east.console.txt
+++ b/testing/pluto/ikev2-55-ipseckey-06/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep road-east-ikev2
 "road-east-ikev2": 192.1.2.23...192.1.3.209[@west.testing.libreswan.org]; unrouted; my_ip=unset; their_ip=unset;
 "road-east-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.3.209;
-"road-east-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-east-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-east-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-east-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "road-east-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-55-ipseckey-08/east.console.txt
+++ b/testing/pluto/ikev2-55-ipseckey-08/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep east-any
 "east-any": 192.1.2.23...%any; unrouted; my_ip=unset; their_ip=unset;
 "east-any":   host: oriented; local: 192.1.2.23; remote: %any;
-"east-any":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"east-any":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "east-any":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "east-any":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "east-any":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-55-ipseckey-09/east.console.txt
+++ b/testing/pluto/ikev2-55-ipseckey-09/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep road-east
 "road-east": 192.1.2.23[@east]...192.1.3.209[@road.testing.libreswan.org]; unrouted; my_ip=unset; their_ip=unset;
 "road-east":   host: oriented; local: 192.1.2.23; remote: 192.1.3.209;
-"road-east":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-east":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-east":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-east":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "road-east":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-55-ipseckey-10/east.console.txt
+++ b/testing/pluto/ikev2-55-ipseckey-10/east.console.txt
@@ -11,7 +11,7 @@ east #
  ipsec auto --status | grep road-east-ikev2
 "road-east-ikev2": 192.1.2.23[@east]...192.1.3.209[@road.testing.libreswan.org]; unrouted; eroute owner: #0
 "road-east-ikev2":     oriented; my_ip=unset; their_ip=unset;
-"road-east-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-east-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-east-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-east-ikev2":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "road-east-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-59-multiple-acquires-alias/east.console.txt
+++ b/testing/pluto/ikev2-59-multiple-acquires-alias/east.console.txt
@@ -26,7 +26,7 @@ east #
  ipsec auto --status | grep north-eastnets
 "north-eastnets/0x1": 192.0.2.0/24===192.1.2.23[@east]...192.1.3.33[@north]===192.0.3.0/24; unrouted; my_ip=unset; their_ip=unset;
 "north-eastnets/0x1":   host: oriented; local: 192.1.2.23; remote: 192.1.3.33;
-"north-eastnets/0x1":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"north-eastnets/0x1":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "north-eastnets/0x1":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "north-eastnets/0x1":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "north-eastnets/0x1":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -50,7 +50,7 @@ east #
 "north-eastnets/0x1":   ESP algorithms: AES_CBC_128-HMAC_SHA2_512_256-MODP3072
 "north-eastnets/0x2": 192.0.22.0/24===192.1.2.23[@east]...192.1.3.33[@north]===192.0.3.0/24; unrouted; eroute owner: #0
 "north-eastnets/0x2":     oriented; my_ip=unset; their_ip=unset;
-"north-eastnets/0x2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"north-eastnets/0x2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "north-eastnets/0x2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "north-eastnets/0x2":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "north-eastnets/0x2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-59-multiple-acquires-alias/north.console.txt
+++ b/testing/pluto/ikev2-59-multiple-acquires-alias/north.console.txt
@@ -42,7 +42,7 @@ north #
  ipsec auto --status | grep north-eastnets
 "north-eastnets/0x1": 192.0.3.0/24===192.1.3.33[@north]...192.1.2.23[@east]===192.0.2.0/24; routed-tunnel; my_ip=unset; their_ip=unset;
 "north-eastnets/0x1":   host: oriented; local: 192.1.3.33; remote: 192.1.2.23;
-"north-eastnets/0x1":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"north-eastnets/0x1":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "north-eastnets/0x1":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "north-eastnets/0x1":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "north-eastnets/0x1":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -67,7 +67,7 @@ north #
 "north-eastnets/0x1":   ESP algorithm newest: AES_CBC_128-HMAC_SHA2_512_256; pfsgroup=<Phase1>
 "north-eastnets/0x2": 192.0.3.0/24===192.1.3.33[@north]...192.1.2.23[@east]===192.0.22.0/24; erouted; eroute owner: #3
 "north-eastnets/0x2":     oriented; my_ip=unset; their_ip=unset;
-"north-eastnets/0x2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"north-eastnets/0x2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "north-eastnets/0x2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "north-eastnets/0x2":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "north-eastnets/0x2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-63-anyid-nat/road.console.txt
+++ b/testing/pluto/ikev2-63-anyid-nat/road.console.txt
@@ -12,7 +12,7 @@ road #
  ipsec auto --status |grep westnet-eastnet-ipv4-psk-ikev2
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.1.0/24===192.1.3.209---192.1.3.254...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.3.209; nexthop: 192.1.3.254; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-67-parallel-sa/east.console.txt
+++ b/testing/pluto/ikev2-67-parallel-sa/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep northnet-eastnet
 "northnet-eastnet/0x1": 192.0.2.0/24===192.1.2.23[@east]...192.1.3.33[@north]===192.0.3.0/24; unrouted; my_ip=unset; their_ip=unset;
 "northnet-eastnet/0x1":   host: oriented; local: 192.1.2.23; remote: 192.1.3.33;
-"northnet-eastnet/0x1":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"northnet-eastnet/0x1":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "northnet-eastnet/0x1":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "northnet-eastnet/0x1":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "northnet-eastnet/0x1":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -35,7 +35,7 @@ east #
 "northnet-eastnet/0x1":   aliases: northnet-eastnet
 "northnet-eastnet/0x2": 192.0.2.0/24===192.1.2.23[@east]...192.1.3.33[@north]===192.0.3.0/24; unrouted; my_ip=unset; their_ip=unset;
 "northnet-eastnet/0x2":   host: oriented; local: 192.1.2.23; remote: 192.1.3.33;
-"northnet-eastnet/0x2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"northnet-eastnet/0x2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "northnet-eastnet/0x2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "northnet-eastnet/0x2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "northnet-eastnet/0x2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-03-aes-ccm/east.console.txt
+++ b/testing/pluto/ikev2-algo-03-aes-ccm/east.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-eastnet-ipv4-psk-ikev2-ccm-a": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2-ccm-a":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ikev2-ccm-a":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2-ccm-a":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2-ccm-a":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2-ccm-a":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2-ccm-a":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-03-aes-ccm/west.console.txt
+++ b/testing/pluto/ikev2-algo-03-aes-ccm/west.console.txt
@@ -122,7 +122,7 @@ Connection list:
  
 "westnet-eastnet-ipv4-psk-ikev2-ccm-a": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2-ccm-a":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ikev2-ccm-a":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2-ccm-a":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2-ccm-a":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2-ccm-a":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2-ccm-a":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-04-aes-gcm256/east.console.txt
+++ b/testing/pluto/ikev2-algo-04-aes-gcm256/east.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ikev2-gcm-c":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2-gcm-c":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-04-aes-gcm256/west.console.txt
+++ b/testing/pluto/ikev2-algo-04-aes-gcm256/west.console.txt
@@ -117,7 +117,7 @@ Connection list:
  
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ikev2-gcm-c":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2-gcm-c":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-06-aes-aes_xcbc/east.console.txt
+++ b/testing/pluto/ikev2-algo-06-aes-aes_xcbc/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-ipv4-psk-ikev2
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-06-aes-aes_xcbc/west.console.txt
+++ b/testing/pluto/ikev2-algo-06-aes-aes_xcbc/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-ipv4-psk-ikev2
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-07-aes_ctr/east.console.txt
+++ b/testing/pluto/ikev2-algo-07-aes_ctr/east.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-07-aes_ctr/west.console.txt
+++ b/testing/pluto/ikev2-algo-07-aes_ctr/west.console.txt
@@ -115,7 +115,7 @@ Connection list:
  
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-10-aes-gcm128/east.console.txt
+++ b/testing/pluto/ikev2-algo-10-aes-gcm128/east.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ikev2-gcm-c":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2-gcm-c":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-10-aes-gcm128/west.console.txt
+++ b/testing/pluto/ikev2-algo-10-aes-gcm128/west.console.txt
@@ -117,7 +117,7 @@ Connection list:
  
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ikev2-gcm-c":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2-gcm-c":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-12-aes-aes_cmac/east.console.txt
+++ b/testing/pluto/ikev2-algo-12-aes-aes_cmac/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-ipv4-psk-ikev2
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-12-aes-aes_cmac/west.console.txt
+++ b/testing/pluto/ikev2-algo-12-aes-aes_cmac/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-ipv4-psk-ikev2
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-13-esp-null/east.console.txt
+++ b/testing/pluto/ikev2-algo-13-esp-null/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-esp-null
 "westnet-eastnet-esp-null": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-esp-null":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-esp-null":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-esp-null":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-esp-null":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-esp-null":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-esp-null":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-15-esp-null-none/east.console.txt
+++ b/testing/pluto/ikev2-algo-15-esp-null-none/east.console.txt
@@ -14,7 +14,7 @@ east #
  ipsec auto --status | grep esp=null-none
 "esp=null-none": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "esp=null-none":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"esp=null-none":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"esp=null-none":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "esp=null-none":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "esp=null-none":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "esp=null-none":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-17-no-sha1-01/east.console.txt
+++ b/testing/pluto/ikev2-algo-17-no-sha1-01/east.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-eastnet-no-sha1": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-no-sha1":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-no-sha1":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-no-sha1":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-no-sha1":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-no-sha1":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-no-sha1":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-17-no-sha1-01/west.console.txt
+++ b/testing/pluto/ikev2-algo-17-no-sha1-01/west.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-eastnet-no-sha1": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-no-sha1":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-no-sha1":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-no-sha1":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-no-sha1":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-no-sha1":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-no-sha1":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-ike-sha2-01/east.console.txt
+++ b/testing/pluto/ikev2-algo-ike-sha2-01/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-ipv4-psk-ikev2
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-ike-sha2-01/west.console.txt
+++ b/testing/pluto/ikev2-algo-ike-sha2-01/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-ipv4-psk-ikev2
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-ike-sha2-02/east.console.txt
+++ b/testing/pluto/ikev2-algo-ike-sha2-02/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-ipv4-psk-ikev2
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-ike-sha2-02/west.console.txt
+++ b/testing/pluto/ikev2-algo-ike-sha2-02/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-ipv4-psk-ikev2
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-ike-sha2-03/east.console.txt
+++ b/testing/pluto/ikev2-algo-ike-sha2-03/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-ipv4-psk-ikev2
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-ike-sha2-03/west.console.txt
+++ b/testing/pluto/ikev2-algo-ike-sha2-03/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-ipv4-psk-ikev2
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-pluto-09/east.console.txt
+++ b/testing/pluto/ikev2-algo-pluto-09/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-dh19
 "westnet-eastnet-dh19": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-dh19":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-dh19":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-dh19":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-dh19":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-dh19":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-dh19":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-pluto-09/west.console.txt
+++ b/testing/pluto/ikev2-algo-pluto-09/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-dh19
 "westnet-eastnet-dh19": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-dh19":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-dh19":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-dh19":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-dh19":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-dh19":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-dh19":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-sha2-01/east.console.txt
+++ b/testing/pluto/ikev2-algo-sha2-01/east.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-sha2-01/west.console.txt
+++ b/testing/pluto/ikev2-algo-sha2-01/west.console.txt
@@ -115,7 +115,7 @@ Connection list:
  
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-sha2-02/east.console.txt
+++ b/testing/pluto/ikev2-algo-sha2-02/east.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-sha2-02/west.console.txt
+++ b/testing/pluto/ikev2-algo-sha2-02/west.console.txt
@@ -115,7 +115,7 @@ Connection list:
  
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-sha2-03/east.console.txt
+++ b/testing/pluto/ikev2-algo-sha2-03/east.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-sha2-03/west.console.txt
+++ b/testing/pluto/ikev2-algo-sha2-03/west.console.txt
@@ -115,7 +115,7 @@ Connection list:
  
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-sha2-04/east.console.txt
+++ b/testing/pluto/ikev2-algo-sha2-04/east.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-sha2-04/west.console.txt
+++ b/testing/pluto/ikev2-algo-sha2-04/west.console.txt
@@ -115,7 +115,7 @@ Connection list:
  
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-sha2-05/east.console.txt
+++ b/testing/pluto/ikev2-algo-sha2-05/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status |grep westnet-eastnet-ipv4-psk-ikev2
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-algo-sha2-05/west.console.txt
+++ b/testing/pluto/ikev2-algo-sha2-05/west.console.txt
@@ -14,7 +14,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-ipv4-psk-ikev2
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-allow-narrow-01/east.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-01/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.2.0/24/UDP/1234===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24/UDP/1234; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-allow-narrow-01/west.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-01/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-allow-narrow-02/east.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-02/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.2.0/24/UDP/1234===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24/UDP/1234; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-allow-narrow-02/west.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-02/west.console.txt
@@ -14,7 +14,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-allow-narrow-03/east.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-03/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-allow-narrow-03/west.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-03/west.console.txt
@@ -19,7 +19,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.1.0/24/UDP/1234===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24/UDP/1234; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-allow-narrow-04/east.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-04/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.2.0/24/UDP/1234===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24/UDP/1234; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-allow-narrow-04/west.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-04/west.console.txt
@@ -17,7 +17,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-allow-narrow-05/east.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-05/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.2.0/24/TCP===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24/TCP; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-allow-narrow-05/west.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-05/west.console.txt
@@ -17,7 +17,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-allow-narrow-07/east.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-07/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.2.0/24/TCP/1234===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24/TCP/1234; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-allow-narrow-07/west.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-07/west.console.txt
@@ -17,7 +17,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-allow-narrow-10-protoport/east.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-10-protoport/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.2.0/24/TCP/1234===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24/TCP/1234; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-allow-narrow-10-protoport/west.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-10-protoport/west.console.txt
@@ -17,7 +17,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-allow-narrow-11-subnet/east.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-11-subnet/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.2.0/28===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/28; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-allow-narrow-11-subnet/west.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-11-subnet/west.console.txt
@@ -17,7 +17,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-allow-narrow-12-subnet-protoport/east.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-12-subnet-protoport/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.2.0/28/TCP/1234===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/28/TCP/1234; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-allow-narrow-12-subnet-protoport/west.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-12-subnet-protoport/west.console.txt
@@ -17,7 +17,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-asymmetric-03-null-rsacert/east.console.txt
+++ b/testing/pluto/ikev2-asymmetric-03-null-rsacert/east.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:null, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-asymmetric-03-null-rsacert/west.console.txt
+++ b/testing/pluto/ikev2-asymmetric-03-null-rsacert/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec connectionstatus westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:null, their auth:RSASIG+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-asymmetric-04-null-rsaraw/east.console.txt
+++ b/testing/pluto/ikev2-asymmetric-04-null-rsaraw/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec connectionstatus westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[ID_NULL]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:null, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-asymmetric-04-null-rsaraw/west.console.txt
+++ b/testing/pluto/ikev2-asymmetric-04-null-rsaraw/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec connectionstatus westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[ID_NULL]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:null, their auth:RSASIG+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-asymmetric-07-psk-rsaraw/east.console.txt
+++ b/testing/pluto/ikev2-asymmetric-07-psk-rsaraw/east.console.txt
@@ -18,7 +18,7 @@ east #
  ipsec connectionstatus westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-asymmetric-07-psk-rsaraw/west.console.txt
+++ b/testing/pluto/ikev2-asymmetric-07-psk-rsaraw/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec connectionstatus westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:secret, their auth:RSASIG+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-asymmetric-08-psk-rsacert/east.console.txt
+++ b/testing/pluto/ikev2-asymmetric-08-psk-rsacert/east.console.txt
@@ -23,7 +23,7 @@ east #
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "westnet-eastnet-ikev2":   mycert=east;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-asymmetric-08-psk-rsacert/west.console.txt
+++ b/testing/pluto/ikev2-asymmetric-08-psk-rsacert/west.console.txt
@@ -41,7 +41,7 @@ west #
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "westnet-eastnet-ikev2":   peercert=east;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:secret, their auth:RSASIG+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-asymmetric-09-rsaraw-null/east.console.txt
+++ b/testing/pluto/ikev2-asymmetric-09-rsaraw-null/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec connectionstatus westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23[ID_NULL]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:null, their auth:RSASIG+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-asymmetric-09-rsaraw-null/west.console.txt
+++ b/testing/pluto/ikev2-asymmetric-09-rsaraw-null/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec connectionstatus westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[ID_NULL]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:null, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-asymmetric-10-rsaraw-psk/east.console.txt
+++ b/testing/pluto/ikev2-asymmetric-10-rsaraw-psk/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec connectionstatus westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:secret, their auth:RSASIG+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-asymmetric-10-rsaraw-psk/west.console.txt
+++ b/testing/pluto/ikev2-asymmetric-10-rsaraw-psk/west.console.txt
@@ -32,7 +32,7 @@ west #
  ipsec connectionstatus westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-asymmetric-12-rsacert-null/east.console.txt
+++ b/testing/pluto/ikev2-asymmetric-12-rsacert-null/east.console.txt
@@ -24,7 +24,7 @@ east #
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23[ID_NULL]...192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "westnet-eastnet-ikev2":   peercert=west;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:null, their auth:RSASIG+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-asymmetric-12-rsacert-null/west.console.txt
+++ b/testing/pluto/ikev2-asymmetric-12-rsacert-null/west.console.txt
@@ -37,7 +37,7 @@ west #
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[ID_NULL]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "westnet-eastnet-ikev2":   mycert=west;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:null, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-asymmetric-13-rsacert-psk/east.console.txt
+++ b/testing/pluto/ikev2-asymmetric-13-rsacert-psk/east.console.txt
@@ -24,7 +24,7 @@ east #
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "westnet-eastnet-ikev2":   peercert=west;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:secret, their auth:RSASIG+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-asymmetric-13-rsacert-psk/west.console.txt
+++ b/testing/pluto/ikev2-asymmetric-13-rsacert-psk/west.console.txt
@@ -37,7 +37,7 @@ west #
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "westnet-eastnet-ikev2":   mycert=west;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-asymmetric-15-rsaraw-rsaraw/east.console.txt
+++ b/testing/pluto/ikev2-asymmetric-15-rsaraw-rsaraw/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec connectionstatus westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-asymmetric-15-rsaraw-rsaraw/west.console.txt
+++ b/testing/pluto/ikev2-asymmetric-15-rsaraw-rsaraw/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec connectionstatus westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-asymmetric-16-auth-mismatch/east.console.txt
+++ b/testing/pluto/ikev2-asymmetric-16-auth-mismatch/east.console.txt
@@ -13,7 +13,7 @@ east #
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[ID_NULL]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "westnet-eastnet-ikev2":   mycert=east;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:null, their auth:null, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-asymmetric-16-auth-mismatch/west.console.txt
+++ b/testing/pluto/ikev2-asymmetric-16-auth-mismatch/west.console.txt
@@ -35,7 +35,7 @@ west #
  ipsec connectionstatus westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[ID_NULL]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:null, their auth:RSASIG+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-asymmetric-17-auth-mismatch-reverse/east.console.txt
+++ b/testing/pluto/ikev2-asymmetric-17-auth-mismatch-reverse/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec connectionstatus westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23[ID_NULL]...192.1.2.45[@something]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:null, their auth:null, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-asymmetric-17-auth-mismatch-reverse/west.console.txt
+++ b/testing/pluto/ikev2-asymmetric-17-auth-mismatch-reverse/west.console.txt
@@ -26,7 +26,7 @@ west #
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[@something]...192.1.2.23[ID_NULL]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "westnet-eastnet-ikev2":   mycert=west;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:null, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-child-rekey-06-deadlock/east.console.txt
+++ b/testing/pluto/ikev2-child-rekey-06-deadlock/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep east
 "east": 192.1.2.23[@east]...192.1.2.45[@west]; unrouted; my_ip=unset; their_ip=unset;
 "east":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"east":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"east":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "east":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "east":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "east":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-child-rekey-06-deadlock/west.console.txt
+++ b/testing/pluto/ikev2-child-rekey-06-deadlock/west.console.txt
@@ -37,7 +37,7 @@ west #
  ipsec auto --status | grep west
 "west": 192.1.2.45[@west]...192.1.2.23[@east]; unrouted; my_ip=unset; their_ip=unset;
 "west":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"west":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"west":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "west":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "west":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "west":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-child-restart-mismatch/west.console.txt
+++ b/testing/pluto/ikev2-child-restart-mismatch/west.console.txt
@@ -78,7 +78,7 @@ west #
  ipsec status | grep westnet-eastnet
 "westnet-eastnet-ikev2b": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.200.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2b":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ikev2b":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2b":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2b":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2b":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2b":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -100,7 +100,7 @@ west #
 "westnet-eastnet-ikev2b":   conn serial: $2;
 "westnet-eastnet-ikev2c": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.201.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2c":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ikev2c":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2c":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2c":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2c":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2c":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-connswitch-01/west.console.txt
+++ b/testing/pluto/ikev2-connswitch-01/west.console.txt
@@ -26,7 +26,7 @@ west #
 "westnet-eastnet-ikev1": 192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[%fromcert]; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev1":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "westnet-eastnet-ikev1":   mycert=west;
-"westnet-eastnet-ikev1":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev1":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev1":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev1":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev1":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-delete-01/west.console.txt
+++ b/testing/pluto/ikev2-delete-01/west.console.txt
@@ -137,7 +137,7 @@ Connection list:
  
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; routed-tunnel; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23; established IKE SA: #1;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -272,7 +272,7 @@ Connection list:
  
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; routed-ondemand; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-delete-04/west.console.txt
+++ b/testing/pluto/ikev2-delete-04/west.console.txt
@@ -14,7 +14,7 @@ west #
  ipsec auto --status | grep west-east
 "west-east-delete1": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "west-east-delete1":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"west-east-delete1":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"west-east-delete1":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "west-east-delete1":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "west-east-delete1":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "west-east-delete1":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-hostpair-01/east.console.txt
+++ b/testing/pluto/ikev2-hostpair-01/east.console.txt
@@ -18,7 +18,7 @@ east #
 "roadnet-eastnet-ipv4-psk-ikev2": 192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...%any[%fromcert]==={192.0.2.1-192.0.2.200}; unrouted; my_ip=unset; their_ip=unset;
 "roadnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.23; remote: %any;
 "roadnet-eastnet-ipv4-psk-ikev2":   mycert=east;
-"roadnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"roadnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "roadnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "roadnet-eastnet-ipv4-psk-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "roadnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:server, them:client, modecfg policy:push, dns:1.2.3.4, 8.8.8.8, domains:unset, cat:unset;
@@ -42,7 +42,7 @@ east #
 "roadnet-eastnet-ipv4-psk-ikev2"[1]: 192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.254[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org]==={192.0.2.1/32}; routed-tunnel; my_ip=unset; their_ip=192.0.2.1;
 "roadnet-eastnet-ipv4-psk-ikev2"[1]:   host: oriented; local: 192.1.2.23; remote: 192.1.2.254; established IKE SA: #3;
 "roadnet-eastnet-ipv4-psk-ikev2"[1]:   mycert=east;
-"roadnet-eastnet-ipv4-psk-ikev2"[1]:   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"roadnet-eastnet-ipv4-psk-ikev2"[1]:   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "roadnet-eastnet-ipv4-psk-ikev2"[1]:   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "roadnet-eastnet-ipv4-psk-ikev2"[1]:   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "roadnet-eastnet-ipv4-psk-ikev2"[1]:   modecfg info: us:server, them:client, modecfg policy:push, dns:1.2.3.4, 8.8.8.8, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-hostpair-01/road.console.txt
+++ b/testing/pluto/ikev2-hostpair-01/road.console.txt
@@ -86,7 +86,7 @@ road #
 "westnet-eastnet-ipv4-psk-ikev2": 192.1.3.210[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org]---192.1.3.254...192.1.2.23[%fromcert]; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.3.210; nexthop: 192.1.3.254; remote: 192.1.2.23;
 "westnet-eastnet-ipv4-psk-ikev2":   mycert=road;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:client, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -110,7 +110,7 @@ road #
 "westnet-eastnet-ipv4-psk-ikev2"[1]: 192.0.2.1/32===192.1.3.210[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org]---192.1.3.254...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]; routed-tunnel; my_ip=192.0.2.1; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2"[1]:   host: oriented; local: 192.1.3.210; nexthop: 192.1.3.254; remote: 192.1.2.23; established IKE SA: #1;
 "westnet-eastnet-ipv4-psk-ikev2"[1]:   mycert=road;
-"westnet-eastnet-ipv4-psk-ikev2"[1]:   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2"[1]:   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2"[1]:   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2"[1]:   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2"[1]:   modecfg info: us:client, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ikeport-02-initiator/east.console.txt
+++ b/testing/pluto/ikev2-ikeport-02-initiator/east.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23:4500[@east]...192.1.2.45:2500[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23:4500; remote: 192.1.2.45:2500;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ikeport-02-initiator/west.console.txt
+++ b/testing/pluto/ikev2-ikeport-02-initiator/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45:2500[@west]...192.1.2.23:4500[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45:2500; remote: 192.1.2.23:4500;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ikeport-03-responder/east.console.txt
+++ b/testing/pluto/ikev2-ikeport-03-responder/east.console.txt
@@ -101,7 +101,7 @@ Connection list:
  
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23:2500[@east]...192.1.2.45:4500[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23:2500; remote: 192.1.2.45:4500;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ikeport-03-responder/west.console.txt
+++ b/testing/pluto/ikev2-ikeport-03-responder/west.console.txt
@@ -27,7 +27,7 @@ west #
  ipsec auto --status | grep westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45:4500[@west]...192.1.2.23:2500[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45:4500; remote: 192.1.2.23:2500;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ikeport-06-host-to-host/east.console.txt
+++ b/testing/pluto/ikev2-ikeport-06-host-to-host/east.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "west-east-ikev2": 192.1.2.23:4500[@east]...192.1.2.45:2500[@west]; unrouted; my_ip=unset; their_ip=unset;
 "west-east-ikev2":   host: oriented; local: 192.1.2.23:4500; remote: 192.1.2.45:2500;
-"west-east-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"west-east-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "west-east-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "west-east-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "west-east-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ikeport-06-host-to-host/west.console.txt
+++ b/testing/pluto/ikev2-ikeport-06-host-to-host/west.console.txt
@@ -13,7 +13,7 @@ west #
  ipsec auto --status | grep west-east-ikev2
 "west-east-ikev2": 192.1.2.45:2500[@west]...192.1.2.23:4500[@east]; unrouted; my_ip=unset; their_ip=unset;
 "west-east-ikev2":   host: oriented; local: 192.1.2.45:2500; remote: 192.1.2.23:4500;
-"west-east-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"west-east-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "west-east-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "west-east-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "west-east-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-impair-01-replay-duplicates/west.console.txt
+++ b/testing/pluto/ikev2-impair-01-replay-duplicates/west.console.txt
@@ -115,7 +115,7 @@ Connection list:
  
 "westnet-eastnet": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-impair-02-replay-forward/west.console.txt
+++ b/testing/pluto/ikev2-impair-02-replay-forward/west.console.txt
@@ -115,7 +115,7 @@ Connection list:
  
 "westnet-eastnet": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-intermediate-03-unsolicited/west.console.txt
+++ b/testing/pluto/ikev2-intermediate-03-unsolicited/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec auto --status |grep westnet-eastnet-ipv4-psk-ikev2
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ipv6-transport-mode-02-xfrm-xfrm/road.console.txt
+++ b/testing/pluto/ikev2-ipv6-transport-mode-02-xfrm-xfrm/road.console.txt
@@ -26,7 +26,7 @@ road #
  ipsec auto --status |grep v6-transport
 "v6-transport": 2001:db8:1:3::209[@road]---2001:db8:1:3::254...2001:db8:1:2::23[@east]; unrouted; my_ip=unset; their_ip=unset;
 "v6-transport":   host: oriented; local: 2001:db8:1:3::209; nexthop: 2001:db8:1:3::254; remote: 2001:db8:1:2::23;
-"v6-transport":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"v6-transport":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "v6-transport":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "v6-transport":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "v6-transport":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-liveness-09-revival/west.console.txt
+++ b/testing/pluto/ikev2-liveness-09-revival/west.console.txt
@@ -84,7 +84,7 @@ west #
  ipsec connectionstatus westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; routed-ondemand; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -119,7 +119,7 @@ west #
  ipsec connectionstatus westnet-eastnet-ikev2
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; routed-negotiation; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23; negotiating IKE SA: #3;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-mobike-07-unsolicited-response/west.console.txt
+++ b/testing/pluto/ikev2-mobike-07-unsolicited-response/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec auto --status |grep westnet-eastnet-ipv4-psk-ikev2
 "westnet-eastnet-ipv4-psk-ikev2": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-nss-cert-08-mismatch/east.console.txt
+++ b/testing/pluto/ikev2-nss-cert-08-mismatch/east.console.txt
@@ -21,7 +21,7 @@ east #
 "nss-cert": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]===192.0.1.254/32; unrouted; my_ip=unset; their_ip=unset;
 "nss-cert":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert":   mycert=east;
-"nss-cert":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ppk-intermediate-01-insist-yes/east.console.txt
+++ b/testing/pluto/ikev2-ppk-intermediate-01-insist-yes/east.console.txt
@@ -11,7 +11,7 @@ east #
  ipsec connectionstatus westnet-eastnet-ipv4-psk-ppk
 "westnet-eastnet-ipv4-psk-ppk": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ppk":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ppk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ppk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ppk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ppk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ppk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ppk-intermediate-01-insist-yes/west.console.txt
+++ b/testing/pluto/ikev2-ppk-intermediate-01-insist-yes/west.console.txt
@@ -27,7 +27,7 @@ west #
  ipsec connectionstatus westnet-eastnet-ipv4-psk-ppk
 "westnet-eastnet-ipv4-psk-ppk": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ppk":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ppk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ppk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ppk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ppk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ppk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ppk-static-01-insist-yes/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-01-insist-yes/east.console.txt
@@ -11,7 +11,7 @@ east #
  ipsec connectionstatus westnet-eastnet-ipv4-psk-ppk
 "westnet-eastnet-ipv4-psk-ppk": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ppk":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ppk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ppk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ppk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ppk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ppk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ppk-static-01-insist-yes/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-01-insist-yes/west.console.txt
@@ -27,7 +27,7 @@ west #
  ipsec connectionstatus westnet-eastnet-ipv4-psk-ppk
 "westnet-eastnet-ipv4-psk-ppk": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ppk":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ppk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ppk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ppk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ppk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ppk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ppk-static-02-insist-insist/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-02-insist-insist/east.console.txt
@@ -11,7 +11,7 @@ east #
  ipsec connectionstatus westnet-eastnet-ipv4-psk-ppk
 "westnet-eastnet-ipv4-psk-ppk": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ppk":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ppk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ppk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ppk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ppk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ppk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ppk-static-02-insist-insist/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-02-insist-insist/west.console.txt
@@ -27,7 +27,7 @@ west #
  ipsec connectionstatus westnet-eastnet-ipv4-psk-ppk
 "westnet-eastnet-ipv4-psk-ppk": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ppk":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ppk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ppk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ppk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ppk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ppk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ppk-static-03-no-insist-fail/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-03-no-insist-fail/east.console.txt
@@ -11,7 +11,7 @@ east #
  ipsec connectionstatus westnet-eastnet-ipv4-psk-ppk
 "westnet-eastnet-ipv4-psk-ppk": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ppk":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ppk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ppk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ppk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ppk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ppk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ppk-static-03-no-insist-fail/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-03-no-insist-fail/west.console.txt
@@ -16,7 +16,7 @@ west #
  ipsec connectionstatus westnet-eastnet-ipv4-psk-ppk
 "westnet-eastnet-ipv4-psk-ppk": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ppk":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ppk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ppk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ppk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ppk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ppk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ppk-static-04-insist-no-fail/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-04-insist-no-fail/east.console.txt
@@ -11,7 +11,7 @@ east #
  ipsec connectionstatus westnet-eastnet-ipv4-psk-ppk
 "westnet-eastnet-ipv4-psk-ppk": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ppk":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ppk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ppk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ppk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ppk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ppk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ppk-static-04-insist-no-fail/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-04-insist-no-fail/west.console.txt
@@ -16,7 +16,7 @@ west #
  ipsec connectionstatus westnet-eastnet-ipv4-psk-ppk
 "westnet-eastnet-ipv4-psk-ppk": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ppk":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ppk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ppk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ppk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ppk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ppk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ppk-static-05-insist-nokey-insist-fail/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-05-insist-nokey-insist-fail/east.console.txt
@@ -11,7 +11,7 @@ east #
  ipsec connectionstatus westnet-eastnet-ipv4-psk-ppk
 "westnet-eastnet-ipv4-psk-ppk": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ppk":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ppk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ppk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ppk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ppk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ppk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ppk-static-05-insist-nokey-insist-fail/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-05-insist-nokey-insist-fail/west.console.txt
@@ -16,7 +16,7 @@ west #
  ipsec connectionstatus westnet-eastnet-ipv4-psk-ppk
 "westnet-eastnet-ipv4-psk-ppk": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ppk":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ppk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ppk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ppk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ppk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ppk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ppk-static-06-insist-insist-nokey-fail/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-06-insist-insist-nokey-fail/east.console.txt
@@ -11,7 +11,7 @@ east #
  ipsec connectionstatus westnet-eastnet-ipv4-psk-ppk
 "westnet-eastnet-ipv4-psk-ppk": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ppk":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ppk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ppk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ppk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ppk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ppk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ppk-static-06-insist-insist-nokey-fail/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-06-insist-insist-nokey-fail/west.console.txt
@@ -16,7 +16,7 @@ west #
  ipsec connectionstatus westnet-eastnet-ipv4-psk-ppk
 "westnet-eastnet-ipv4-psk-ppk": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ppk":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ppk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ppk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ppk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ppk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ppk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ppk-static-07-large-id/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-07-large-id/east.console.txt
@@ -11,7 +11,7 @@ east #
  ipsec connectionstatus westnet-eastnet-ipv4-psk-ppk
 "westnet-eastnet-ipv4-psk-ppk": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ppk":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ppk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ppk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ppk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ppk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ppk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ppk-static-07-large-id/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-07-large-id/west.console.txt
@@ -27,7 +27,7 @@ west #
  ipsec connectionstatus westnet-eastnet-ipv4-psk-ppk
 "westnet-eastnet-ipv4-psk-ppk": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ppk":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ppk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ppk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ppk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ppk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ppk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ppk-static-08-no_ppk-responder/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-08-no_ppk-responder/east.console.txt
@@ -11,7 +11,7 @@ east #
  ipsec connectionstatus westnet-eastnet-ipv4-psk-ppk
 "westnet-eastnet-ipv4-psk-ppk": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ppk":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ppk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ppk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ppk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ppk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ppk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ppk-static-08-no_ppk-responder/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-08-no_ppk-responder/west.console.txt
@@ -27,7 +27,7 @@ west #
  ipsec connectionstatus westnet-eastnet-ipv4-psk-ppk
 "westnet-eastnet-ipv4-psk-ppk": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ppk":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ppk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ppk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ppk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ppk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ppk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ppk-static-09-no_ppk-initiator/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-09-no_ppk-initiator/east.console.txt
@@ -11,7 +11,7 @@ east #
  ipsec connectionstatus westnet-eastnet-ipv4-psk-ppk
 "westnet-eastnet-ipv4-psk-ppk": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ppk":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ppk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ppk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ppk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ppk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ppk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ppk-static-09-no_ppk-initiator/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-09-no_ppk-initiator/west.console.txt
@@ -27,7 +27,7 @@ west #
  ipsec connectionstatus westnet-eastnet-ipv4-psk-ppk
 "westnet-eastnet-ipv4-psk-ppk": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ppk":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ppk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ppk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ppk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ppk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ppk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ppk-static-10-yes-no/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-10-yes-no/east.console.txt
@@ -11,7 +11,7 @@ east #
  ipsec connectionstatus westnet-eastnet-ipv4-psk-ppk
 "westnet-eastnet-ipv4-psk-ppk": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ppk":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ppk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ppk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ppk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ppk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ppk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ppk-static-10-yes-no/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-10-yes-no/west.console.txt
@@ -27,7 +27,7 @@ west #
  ipsec connectionstatus westnet-eastnet-ipv4-psk-ppk
 "westnet-eastnet-ipv4-psk-ppk": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ppk":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ppk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ppk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ppk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ppk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ppk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ppk-static-11-multiple-ppk-ids/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-11-multiple-ppk-ids/east.console.txt
@@ -11,7 +11,7 @@ east #
  ipsec connectionstatus westnet-eastnet-ipv4-psk-ppk
 "westnet-eastnet-ipv4-psk-ppk": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ppk":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-ipv4-psk-ppk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ppk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ppk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ppk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ppk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-ppk-static-11-multiple-ppk-ids/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-11-multiple-ppk-ids/west.console.txt
@@ -27,7 +27,7 @@ west #
  ipsec connectionstatus westnet-eastnet-ipv4-psk-ppk
 "westnet-eastnet-ipv4-psk-ppk": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ppk":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ppk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ppk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ppk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ppk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ppk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-redirect-06-roadwarriors-reverse/east.console.txt
+++ b/testing/pluto/ikev2-redirect-06-roadwarriors-reverse/east.console.txt
@@ -37,7 +37,7 @@ Connection list:
 "east-any": 0.0.0.0/0===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...%any[%fromcert]; unrouted; my_ip=unset; their_ip=unset;
 "east-any":   host: oriented; local: 192.1.2.23; remote: %any;
 "east-any":   mycert=east;
-"east-any":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"east-any":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "east-any":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "east-any":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "east-any":   modecfg info: us:server, them:client, modecfg policy:pull, dns:1.2.3.4, 5.6.7.8, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-redirect-06-roadwarriors-reverse/north.console.txt
+++ b/testing/pluto/ikev2-redirect-06-roadwarriors-reverse/north.console.txt
@@ -68,7 +68,7 @@ Connection list:
 "north-east": 192.0.2.101/32===192.1.3.33[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org]---192.1.3.254...192.1.2.45<192.1.2.23>[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===0.0.0.0/0; routed-tunnel; my_ip=192.0.2.101; their_ip=unset;
 "north-east":   host: oriented; local: 192.1.3.33; remote: 192.1.2.45<192.1.2.23>; established IKE SA: #3;
 "north-east":   mycert=north;
-"north-east":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"north-east":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "north-east":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "north-east":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "north-east":   modecfg info: us:client, them:server, modecfg policy:pull, dns:1.2.3.4, 5.6.7.8, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-redirect-06-roadwarriors-reverse/road.console.txt
+++ b/testing/pluto/ikev2-redirect-06-roadwarriors-reverse/road.console.txt
@@ -68,7 +68,7 @@ Connection list:
 "road-east": 192.0.2.102/32===192.1.3.209[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org]---192.1.3.254...192.1.2.45<192.1.2.23>[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===0.0.0.0/0; routed-tunnel; my_ip=192.0.2.102; their_ip=unset;
 "road-east":   host: oriented; local: 192.1.3.209; remote: 192.1.2.45<192.1.2.23>; established IKE SA: #3;
 "road-east":   mycert=road;
-"road-east":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-east":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-east":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-east":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "road-east":   modecfg info: us:client, them:server, modecfg policy:pull, dns:1.2.3.4, 5.6.7.8, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-redirect-06-roadwarriors-reverse/west.console.txt
+++ b/testing/pluto/ikev2-redirect-06-roadwarriors-reverse/west.console.txt
@@ -26,7 +26,7 @@ Connection list:
 "east-any": 0.0.0.0/0===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...%any[%fromcert]; unrouted; my_ip=unset; their_ip=unset;
 "east-any":   host: oriented; local: 192.1.2.45; remote: %any;
 "east-any":   mycert=east;
-"east-any":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"east-any":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "east-any":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "east-any":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "east-any":   modecfg info: us:server, them:client, modecfg policy:pull, dns:1.2.3.4, 5.6.7.8, domains:unset, cat:unset;
@@ -50,7 +50,7 @@ Connection list:
 "east-any"[1]: 0.0.0.0/0===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.3.33[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org]===192.0.2.101/32; routed-tunnel; my_ip=unset; their_ip=192.0.2.101;
 "east-any"[1]:   host: oriented; local: 192.1.2.45; remote: 192.1.3.33; established IKE SA: #1;
 "east-any"[1]:   mycert=east;
-"east-any"[1]:   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"east-any"[1]:   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "east-any"[1]:   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "east-any"[1]:   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "east-any"[1]:   modecfg info: us:server, them:client, modecfg policy:pull, dns:1.2.3.4, 5.6.7.8, domains:unset, cat:unset;
@@ -75,7 +75,7 @@ Connection list:
 "east-any"[2]: 0.0.0.0/0===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.3.209[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org]===192.0.2.102/32; routed-tunnel; my_ip=unset; their_ip=192.0.2.102;
 "east-any"[2]:   host: oriented; local: 192.1.2.45; remote: 192.1.3.209; established IKE SA: #3;
 "east-any"[2]:   mycert=east;
-"east-any"[2]:   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"east-any"[2]:   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "east-any"[2]:   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "east-any"[2]:   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "east-any"[2]:   modecfg info: us:server, them:client, modecfg policy:pull, dns:1.2.3.4, 5.6.7.8, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-redirect-06-roadwarriors/east.console.txt
+++ b/testing/pluto/ikev2-redirect-06-roadwarriors/east.console.txt
@@ -51,7 +51,7 @@ Connection list:
 "east-any": 0.0.0.0/0===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...%any[%fromcert]==={192.0.2.101-192.0.2.200}; unrouted; my_ip=unset; their_ip=unset;
 "east-any":   host: oriented; local: 192.1.2.23; remote: %any;
 "east-any":   mycert=east;
-"east-any":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"east-any":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "east-any":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "east-any":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "east-any":   modecfg info: us:server, them:client, modecfg policy:pull, dns:1.2.3.4, 5.6.7.8, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-redirect-06-roadwarriors/north.console.txt
+++ b/testing/pluto/ikev2-redirect-06-roadwarriors/north.console.txt
@@ -77,7 +77,7 @@ Connection list:
 "north-east": 192.0.2.102/32===192.1.3.33[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org]---192.1.3.254...192.1.2.45<192.1.2.23>[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===0.0.0.0/0; routed-tunnel; my_ip=192.0.2.102; their_ip=unset;
 "north-east":   host: oriented; local: 192.1.3.33; nexthop: 192.1.3.254; remote: 192.1.2.45<192.1.2.23>; established IKE SA: #3;
 "north-east":   mycert=north;
-"north-east":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"north-east":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "north-east":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "north-east":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "north-east":   modecfg info: us:client, them:server, modecfg policy:pull, dns:1.2.3.4, 5.6.7.8, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-redirect-06-roadwarriors/road.console.txt
+++ b/testing/pluto/ikev2-redirect-06-roadwarriors/road.console.txt
@@ -77,7 +77,7 @@ Connection list:
 "road-east": 192.0.2.101/32===192.1.3.209[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org]---192.1.3.254...192.1.2.45<192.1.2.23>[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===0.0.0.0/0; routed-tunnel; my_ip=192.0.2.101; their_ip=unset;
 "road-east":   host: oriented; local: 192.1.3.209; nexthop: 192.1.3.254; remote: 192.1.2.45<192.1.2.23>; established IKE SA: #3;
 "road-east":   mycert=road;
-"road-east":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-east":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-east":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-east":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "road-east":   modecfg info: us:client, them:server, modecfg policy:pull, dns:1.2.3.4, 5.6.7.8, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-redirect-06-roadwarriors/west.console.txt
+++ b/testing/pluto/ikev2-redirect-06-roadwarriors/west.console.txt
@@ -36,7 +36,7 @@ Connection list:
 "east-any": 0.0.0.0/0===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...%any[%fromcert]==={192.0.2.101-192.0.2.200}; unrouted; my_ip=unset; their_ip=unset;
 "east-any":   host: oriented; local: 192.1.2.45; remote: %any;
 "east-any":   mycert=east;
-"east-any":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"east-any":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "east-any":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "east-any":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "east-any":   modecfg info: us:server, them:client, modecfg policy:pull, dns:1.2.3.4, 5.6.7.8, domains:unset, cat:unset;
@@ -60,7 +60,7 @@ Connection list:
 "east-any"[1]: 0.0.0.0/0===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.3.209[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org]==={192.0.2.101/32}; routed-tunnel; my_ip=unset; their_ip=192.0.2.101;
 "east-any"[1]:   host: oriented; local: 192.1.2.45; remote: 192.1.3.209; established IKE SA: #1;
 "east-any"[1]:   mycert=east;
-"east-any"[1]:   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"east-any"[1]:   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "east-any"[1]:   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "east-any"[1]:   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "east-any"[1]:   modecfg info: us:server, them:client, modecfg policy:pull, dns:1.2.3.4, 5.6.7.8, domains:unset, cat:unset;
@@ -86,7 +86,7 @@ Connection list:
 "east-any"[2]: 0.0.0.0/0===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.3.33[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org]==={192.0.2.102/32}; routed-tunnel; my_ip=unset; their_ip=192.0.2.102;
 "east-any"[2]:   host: oriented; local: 192.1.2.45; remote: 192.1.3.33; established IKE SA: #3;
 "east-any"[2]:   mycert=east;
-"east-any"[2]:   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"east-any"[2]:   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "east-any"[2]:   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "east-any"[2]:   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "east-any"[2]:   modecfg info: us:server, them:client, modecfg policy:pull, dns:1.2.3.4, 5.6.7.8, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-systemrole-01-host-to-host/east.console.txt
+++ b/testing/pluto/ikev2-systemrole-01-host-to-host/east.console.txt
@@ -133,7 +133,7 @@ Connection list:
  
 "192.1.2.23-to-192.1.2.45": 192.1.2.23...192.1.2.45; routed-ondemand; my_ip=unset; their_ip=unset;
 "192.1.2.23-to-192.1.2.45":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"192.1.2.23-to-192.1.2.45":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"192.1.2.23-to-192.1.2.45":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "192.1.2.23-to-192.1.2.45":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "192.1.2.23-to-192.1.2.45":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "192.1.2.23-to-192.1.2.45":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-systemrole-01-host-to-host/west.console.txt
+++ b/testing/pluto/ikev2-systemrole-01-host-to-host/west.console.txt
@@ -133,7 +133,7 @@ Connection list:
  
 "192.1.2.45-to-192.1.2.23": 192.1.2.45...192.1.2.23; routed-ondemand; my_ip=unset; their_ip=unset;
 "192.1.2.45-to-192.1.2.23":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"192.1.2.45-to-192.1.2.23":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"192.1.2.45-to-192.1.2.23":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "192.1.2.45-to-192.1.2.23":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "192.1.2.45-to-192.1.2.23":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "192.1.2.45-to-192.1.2.23":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-systemrole-02-net-to-net/east.console.txt
+++ b/testing/pluto/ikev2-systemrole-02-net-to-net/east.console.txt
@@ -133,7 +133,7 @@ Connection list:
  
 "192.1.2.23-to-192.1.2.45": 192.1.2.23...192.1.2.45; routed-ondemand; my_ip=unset; their_ip=unset;
 "192.1.2.23-to-192.1.2.45":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"192.1.2.23-to-192.1.2.45":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"192.1.2.23-to-192.1.2.45":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "192.1.2.23-to-192.1.2.45":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "192.1.2.23-to-192.1.2.45":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "192.1.2.23-to-192.1.2.45":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-systemrole-02-net-to-net/west.console.txt
+++ b/testing/pluto/ikev2-systemrole-02-net-to-net/west.console.txt
@@ -133,7 +133,7 @@ Connection list:
  
 "192.1.2.45-to-192.1.2.23": 192.1.2.45...192.1.2.23; routed-ondemand; my_ip=unset; their_ip=unset;
 "192.1.2.45-to-192.1.2.23":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"192.1.2.45-to-192.1.2.23":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"192.1.2.45-to-192.1.2.23":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "192.1.2.45-to-192.1.2.23":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "192.1.2.45-to-192.1.2.23":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "192.1.2.45-to-192.1.2.23":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-systemrole-03-certs/west.console.txt
+++ b/testing/pluto/ikev2-systemrole-03-certs/west.console.txt
@@ -43,7 +43,7 @@ west #
 "192.1.2.45-to-192.1.2.23": 192.1.2.45...192.1.2.23[%fromcert]; routed-ondemand; my_ip=unset; their_ip=unset;
 "192.1.2.45-to-192.1.2.23":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "192.1.2.45-to-192.1.2.23":   mycert=west;
-"192.1.2.45-to-192.1.2.23":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"192.1.2.45-to-192.1.2.23":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "192.1.2.45-to-192.1.2.23":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "192.1.2.45-to-192.1.2.23":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "192.1.2.45-to-192.1.2.23":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-systemrole-04-mesh/east.console.txt
+++ b/testing/pluto/ikev2-systemrole-04-mesh/east.console.txt
@@ -179,7 +179,7 @@ Connection list:
 "private": 192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]---192.1.2.254...%opportunisticgroup[%fromcert]; unrouted; my_ip=unset; their_ip=unset;
 "private":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.254; remote: %opportunisticgroup;
 "private":   mycert=east;
-"private":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"private":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "private":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "private":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "private":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -203,7 +203,7 @@ Connection list:
 "private#10.1.0.0/24": 192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]---192.1.2.254...%opportunistic[%fromcert]===10.1.0.0/24; routed-ondemand; my_ip=unset; their_ip=unset;
 "private#10.1.0.0/24":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.254; remote: %opportunistic;
 "private#10.1.0.0/24":   mycert=east;
-"private#10.1.0.0/24":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"private#10.1.0.0/24":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "private#10.1.0.0/24":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "private#10.1.0.0/24":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "private#10.1.0.0/24":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -227,7 +227,7 @@ Connection list:
 "private-or-clear": 192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]---192.1.2.254...%opportunisticgroup[%fromcert]; unrouted; my_ip=unset; their_ip=unset;
 "private-or-clear":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.254; remote: %opportunisticgroup;
 "private-or-clear":   mycert=east;
-"private-or-clear":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"private-or-clear":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "private-or-clear":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "private-or-clear":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "private-or-clear":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -251,7 +251,7 @@ Connection list:
 "private-or-clear#192.1.2.0/24": 192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]---192.1.2.254...%opportunistic[%fromcert]===192.1.2.0/24; routed-ondemand; my_ip=unset; their_ip=unset;
 "private-or-clear#192.1.2.0/24":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.254; remote: %opportunistic;
 "private-or-clear#192.1.2.0/24":   mycert=east;
-"private-or-clear#192.1.2.0/24":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"private-or-clear#192.1.2.0/24":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "private-or-clear#192.1.2.0/24":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "private-or-clear#192.1.2.0/24":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "private-or-clear#192.1.2.0/24":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-systemrole-04-mesh/west.console.txt
+++ b/testing/pluto/ikev2-systemrole-04-mesh/west.console.txt
@@ -179,7 +179,7 @@ Connection list:
 "private": 192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]---192.1.2.254...%opportunisticgroup[%fromcert]; unrouted; my_ip=unset; their_ip=unset;
 "private":   host: oriented; local: 192.1.2.45; nexthop: 192.1.2.254; remote: %opportunisticgroup;
 "private":   mycert=west;
-"private":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"private":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "private":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "private":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "private":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -203,7 +203,7 @@ Connection list:
 "private#10.1.0.0/24": 192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]---192.1.2.254...%opportunistic[%fromcert]===10.1.0.0/24; routed-ondemand; my_ip=unset; their_ip=unset;
 "private#10.1.0.0/24":   host: oriented; local: 192.1.2.45; nexthop: 192.1.2.254; remote: %opportunistic;
 "private#10.1.0.0/24":   mycert=west;
-"private#10.1.0.0/24":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"private#10.1.0.0/24":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "private#10.1.0.0/24":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "private#10.1.0.0/24":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "private#10.1.0.0/24":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -227,7 +227,7 @@ Connection list:
 "private-or-clear": 192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]---192.1.2.254...%opportunisticgroup[%fromcert]; unrouted; my_ip=unset; their_ip=unset;
 "private-or-clear":   host: oriented; local: 192.1.2.45; nexthop: 192.1.2.254; remote: %opportunisticgroup;
 "private-or-clear":   mycert=west;
-"private-or-clear":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"private-or-clear":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "private-or-clear":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "private-or-clear":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "private-or-clear":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -251,7 +251,7 @@ Connection list:
 "private-or-clear#192.1.2.0/24": 192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]---192.1.2.254...%opportunistic[%fromcert]===192.1.2.0/24; routed-ondemand; my_ip=unset; their_ip=unset;
 "private-or-clear#192.1.2.0/24":   host: oriented; local: 192.1.2.45; nexthop: 192.1.2.254; remote: %opportunistic;
 "private-or-clear#192.1.2.0/24":   mycert=west;
-"private-or-clear#192.1.2.0/24":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"private-or-clear#192.1.2.0/24":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "private-or-clear#192.1.2.0/24":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "private-or-clear#192.1.2.0/24":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "private-or-clear#192.1.2.0/24":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-tcp-10-rekey-child/west.console.txt
+++ b/testing/pluto/ikev2-tcp-10-rekey-child/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec connectionstatus west
 "west": 192.0.1.0/24===192.1.2.45:4500[@west]...192.1.2.23:4500[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "west":   host: oriented; local: 192.1.2.45:4500; remote: 192.1.2.23:4500;
-"west":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"west":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "west":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "west":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "west":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-tcp-10-rekey-ike/west.console.txt
+++ b/testing/pluto/ikev2-tcp-10-rekey-ike/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec connectionstatus west
 "west": 192.0.1.0/24===192.1.2.45:4500[@west]...192.1.2.23:4500[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "west":   host: oriented; local: 192.1.2.45:4500; remote: 192.1.2.23:4500;
-"west":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"west":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "west":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "west":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "west":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-tfc-01/west.console.txt
+++ b/testing/pluto/ikev2-tfc-01/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec auto --status | grep tfc
 "tfc": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "tfc":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"tfc":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"tfc":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "tfc":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "tfc":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "tfc":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-tfc-02/west.console.txt
+++ b/testing/pluto/ikev2-tfc-02/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec auto --status | grep tfc
 "tfc": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "tfc":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"tfc":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"tfc":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "tfc":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "tfc":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "tfc":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-tfc-03/west.console.txt
+++ b/testing/pluto/ikev2-tfc-03/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec auto --status | grep tfc
 "tfc": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "tfc":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"tfc":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"tfc":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "tfc":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "tfc":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "tfc":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-x509-24-fakewest/east.console.txt
+++ b/testing/pluto/ikev2-x509-24-fakewest/east.console.txt
@@ -34,7 +34,7 @@ east #
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "westnet-eastnet-ikev2":   mycert=east; peercert=west;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-x509-24-fakewest/west.console.txt
+++ b/testing/pluto/ikev2-x509-24-fakewest/west.console.txt
@@ -48,7 +48,7 @@ west #
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "westnet-eastnet-ikev2":   mycert=west; peercert=east;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-x509-38-failureshunt/east.console.txt
+++ b/testing/pluto/ikev2-x509-38-failureshunt/east.console.txt
@@ -102,7 +102,7 @@ Connection list:
  
 "failureshunt": 192.1.2.23...192.1.2.45; unrouted; my_ip=unset; their_ip=unset;
 "failureshunt":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"failureshunt":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"failureshunt":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "failureshunt":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "failureshunt":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "failureshunt":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -124,7 +124,7 @@ Connection list:
 "failureshunt":   conn serial: $1;
 "westnet-eastnet": 192.1.2.23...192.1.2.45; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-xfrmi-11-default-manual-route/east.console.txt
+++ b/testing/pluto/ikev2-xfrmi-11-default-manual-route/east.console.txt
@@ -107,7 +107,7 @@ Connection list:
  
 "westnet-eastnet": 0.0.0.0/0===192.1.2.23[@east]...192.1.2.45[@west]===0.0.0.0/0; routed-tunnel; my_ip=unset; their_ip=unset;
 "westnet-eastnet":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45; established IKE SA: #1;
-"westnet-eastnet":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ikev2-xfrmi-11-default-manual-route/west.console.txt
+++ b/testing/pluto/ikev2-xfrmi-11-default-manual-route/west.console.txt
@@ -156,7 +156,7 @@ Connection list:
  
 "west": 0.0.0.0/0===192.1.2.45[@west]...192.1.2.23[@east]===0.0.0.0/0; routed-tunnel; my_ip=unset; their_ip=unset;
 "west":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23; established IKE SA: #1;
-"west":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"west":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "west":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "west":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "west":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/interop-ikev2-strongswan-15-child-sa-responder/west.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-15-child-sa-responder/west.console.txt
@@ -67,7 +67,7 @@ west #
  ipsec status | grep westnet-eastnet-ikev2
 "westnet-eastnet-ikev2a": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; routed-tunnel; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2a":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23; established IKE SA: #1;
-"westnet-eastnet-ikev2a":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2a":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2a":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2a":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2a":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -93,7 +93,7 @@ west #
 "westnet-eastnet-ikev2a":   ESP algorithm newest: AES_CBC_128-HMAC_SHA2_512_256; pfsgroup=<N/A>
 "westnet-eastnet-ikev2b": 192.0.100.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.200.0/24; routed-tunnel; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2b":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ikev2b":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2b":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2b":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2b":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2b":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -118,7 +118,7 @@ west #
 "westnet-eastnet-ikev2b":   ESP algorithm newest: AES_CBC_128-HMAC_SHA2_512_256; pfsgroup=<N/A>
 "westnet-eastnet-ikev2c": 192.0.101.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.201.0/24; routed-tunnel; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2c":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-ikev2c":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2c":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2c":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2c":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2c":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/interop-ikev2-strongswan-22-cp-responder-psk/road.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-22-cp-responder-psk/road.console.txt
@@ -101,7 +101,7 @@ Connection list:
  
 "westnet-eastnet-ipv4-psk-ikev2": 0.0.0.0/0===192.1.3.209[@road]---192.1.3.254...192.1.2.23[@east]===0.0.0.0/0; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.3.209; nexthop: 192.1.3.254; remote: 192.1.2.23;
-"westnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:client, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/interop-ikev2-strongswan-23-initiator-cp/east.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-23-initiator-cp/east.console.txt
@@ -101,7 +101,7 @@ Connection list:
  
 "roadnet-eastnet-ipv4-psk-ikev2": 0.0.0.0/0===192.1.2.23[@east]...192.1.3.209[@road]==={192.0.2.1-192.0.2.200}; unrouted; my_ip=unset; their_ip=unset;
 "roadnet-eastnet-ipv4-psk-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.3.209;
-"roadnet-eastnet-ipv4-psk-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"roadnet-eastnet-ipv4-psk-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "roadnet-eastnet-ipv4-psk-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "roadnet-eastnet-ipv4-psk-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "roadnet-eastnet-ipv4-psk-ikev2":   modecfg info: us:server, them:client, modecfg policy:push, dns:1.2.3.4, 8.8.8.8, domains:unset, cat:unset;

--- a/testing/pluto/interop-ikev2-strongswan-29-rekey/east.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-29-rekey/east.console.txt
@@ -15,7 +15,7 @@ east #
  if [ -f /var/run/pluto/pluto.pid ]; then ipsec status | grep westnet-eastnet-ikev2 ; fi
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; routed-tunnel; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45; established IKE SA: #4;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/interop-ikev2-strongswan-29-responder-rekey/east.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-29-responder-rekey/east.console.txt
@@ -12,7 +12,7 @@ east #
  if [ -f /var/run/pluto/pluto.pid ]; then ipsec status | grep westnet-eastnet-ikev2 ; fi
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; routed-tunnel; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45; established IKE SA: #4;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/interop-ikev2-strongswan-35-initiator-rekey/west.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-35-initiator-rekey/west.console.txt
@@ -70,7 +70,7 @@ west #
  ipsec status | grep westnet-eastnet
 "westnet-eastnet": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; routed-tunnel; my_ip=unset; their_ip=unset;
 "westnet-eastnet":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23; established IKE SA: #1;
-"westnet-eastnet":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ipv6-4in6-01-ikev1/west.console.txt
+++ b/testing/pluto/ipv6-4in6-01-ikev1/west.console.txt
@@ -26,7 +26,7 @@ west #
  ipsec status | grep westnet-eastnet-4in6
 "westnet-eastnet-4in6": 192.0.1.0/24===2001:db8:1:2::45[@west]...2001:db8:1:2::23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-4in6":   host: oriented; local: 2001:db8:1:2::45; remote: 2001:db8:1:2::23;
-"westnet-eastnet-4in6":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-4in6":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-4in6":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-4in6":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-4in6":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ipv6-4in6-02-ikev2/west.console.txt
+++ b/testing/pluto/ipv6-4in6-02-ikev2/west.console.txt
@@ -26,7 +26,7 @@ west #
  ipsec status | grep westnet-eastnet-4in6
 "westnet-eastnet-4in6": 192.0.1.0/24===2001:db8:1:2::45[@west]...2001:db8:1:2::23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-4in6":   host: oriented; local: 2001:db8:1:2::45; remote: 2001:db8:1:2::23;
-"westnet-eastnet-4in6":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-4in6":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-4in6":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-4in6":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-4in6":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ipv6-6in4-01-ikev1/west.console.txt
+++ b/testing/pluto/ipv6-6in4-01-ikev1/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec status | grep westnet-eastnet-6in4
 "westnet-eastnet-6in4": 2001:db8:0:1::/64===192.1.2.45[@west]...192.1.2.23[@east]===2001:db8:0:2::/64; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-6in4":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-6in4":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-6in4":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-6in4":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-6in4":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-6in4":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ipv6-6in4-02-ikev2-ipsec-device/west.console.txt
+++ b/testing/pluto/ipv6-6in4-02-ikev2-ipsec-device/west.console.txt
@@ -34,7 +34,7 @@ west #
  ipsec status | grep westnet-eastnet-6in4
 "westnet-eastnet-6in4": 2001:db8:0:1::/64===192.1.2.45[@west]...192.1.2.23[@east]===2001:db8:0:2::/64; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-6in4":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-6in4":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-6in4":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-6in4":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-6in4":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-6in4":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ipv6-6in4-02-ikev2/west.console.txt
+++ b/testing/pluto/ipv6-6in4-02-ikev2/west.console.txt
@@ -28,7 +28,7 @@ west #
  ipsec status | grep westnet-eastnet-6in4
 "westnet-eastnet-6in4": 2001:db8:0:1::/64===192.1.2.45[@west]...192.1.2.23[@east]===2001:db8:0:2::/64; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-6in4":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-6in4":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-6in4":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-6in4":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-6in4":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-6in4":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ipv6-transport-mode-02-xfrm-xfrm/east.console.txt
+++ b/testing/pluto/ipv6-transport-mode-02-xfrm-xfrm/east.console.txt
@@ -105,7 +105,7 @@ Connection list:
  
 "v6-transport": 2001:db8:1:2::23[@east]...2001:db8:1:2::45[@west]; unrouted; my_ip=unset; their_ip=unset;
 "v6-transport":   host: oriented; local: 2001:db8:1:2::23; remote: 2001:db8:1:2::45;
-"v6-transport":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"v6-transport":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "v6-transport":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "v6-transport":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "v6-transport":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ipv6-transport-mode-02-xfrm-xfrm/west.console.txt
+++ b/testing/pluto/ipv6-transport-mode-02-xfrm-xfrm/west.console.txt
@@ -121,7 +121,7 @@ Connection list:
  
 "v6-transport": 2001:db8:1:2::45[@west]...2001:db8:1:2::23[@east]; unrouted; my_ip=unset; their_ip=unset;
 "v6-transport":   host: oriented; local: 2001:db8:1:2::45; remote: 2001:db8:1:2::23;
-"v6-transport":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"v6-transport":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "v6-transport":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "v6-transport":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "v6-transport":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ipv6-tunnel-mode-02-xfrm-xfrm/east.console.txt
+++ b/testing/pluto/ipv6-tunnel-mode-02-xfrm-xfrm/east.console.txt
@@ -105,7 +105,7 @@ Connection list:
  
 "v6-tunnel": 2001:db8:1:2::23[@east]...2001:db8:1:2::45[@west]; unrouted; my_ip=unset; their_ip=unset;
 "v6-tunnel":   host: oriented; local: 2001:db8:1:2::23; remote: 2001:db8:1:2::45;
-"v6-tunnel":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"v6-tunnel":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "v6-tunnel":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "v6-tunnel":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "v6-tunnel":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ipv6-tunnel-mode-02-xfrm-xfrm/west.console.txt
+++ b/testing/pluto/ipv6-tunnel-mode-02-xfrm-xfrm/west.console.txt
@@ -121,7 +121,7 @@ Connection list:
  
 "v6-tunnel": 2001:db8:1:2::45[@west]...2001:db8:1:2::23[@east]; unrouted; my_ip=unset; their_ip=unset;
 "v6-tunnel":   host: oriented; local: 2001:db8:1:2::45; remote: 2001:db8:1:2::23;
-"v6-tunnel":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"v6-tunnel":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "v6-tunnel":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "v6-tunnel":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "v6-tunnel":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ipv6-tunnel-mode-03-rw/east.console.txt
+++ b/testing/pluto/ipv6-tunnel-mode-03-rw/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep v6-tunnel-east-road
 "v6-tunnel-east-road": 2001:db8:1:2::23[@east]---2001:db8:1:2::45...2001:db8:1:3::209[@road]; unrouted; my_ip=unset; their_ip=unset;
 "v6-tunnel-east-road":   host: oriented; local: 2001:db8:1:2::23; nexthop: 2001:db8:1:2::45; remote: 2001:db8:1:3::209;
-"v6-tunnel-east-road":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"v6-tunnel-east-road":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "v6-tunnel-east-road":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "v6-tunnel-east-road":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "v6-tunnel-east-road":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ipv6-tunnel-mode-03-rw/road.console.txt
+++ b/testing/pluto/ipv6-tunnel-mode-03-rw/road.console.txt
@@ -28,7 +28,7 @@ road #
  ipsec auto --status | grep v6-tunnel-east-road
 "v6-tunnel-east-road": 2001:db8:1:3::209[@road]---2001:db8:1:3::254...2001:db8:1:2::23[@east]; unrouted; my_ip=unset; their_ip=unset;
 "v6-tunnel-east-road":   host: oriented; local: 2001:db8:1:3::209; nexthop: 2001:db8:1:3::254; remote: 2001:db8:1:2::23;
-"v6-tunnel-east-road":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"v6-tunnel-east-road":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "v6-tunnel-east-road":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "v6-tunnel-east-road":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "v6-tunnel-east-road":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ipv6-tunnel-mode-04-rw/east.console.txt
+++ b/testing/pluto/ipv6-tunnel-mode-04-rw/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep v6-tunnel-east-road
 "v6-tunnel-east-road": 2001:db8:1:2::23[@east]---2001:db8:1:2::45...2001:db8:1:3::209[@road]; unrouted; my_ip=unset; their_ip=unset;
 "v6-tunnel-east-road":   host: oriented; local: 2001:db8:1:2::23; nexthop: 2001:db8:1:2::45; remote: 2001:db8:1:3::209;
-"v6-tunnel-east-road":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"v6-tunnel-east-road":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "v6-tunnel-east-road":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "v6-tunnel-east-road":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "v6-tunnel-east-road":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/ipv6-tunnel-mode-04-rw/road.console.txt
+++ b/testing/pluto/ipv6-tunnel-mode-04-rw/road.console.txt
@@ -28,7 +28,7 @@ road #
  ipsec auto --status | grep v6-tunnel-east-road
 "v6-tunnel-east-road": 2001:db8:1:3::209[@road]---2001:db8:1:3::254...2001:db8:1:2::23[@east]; unrouted; my_ip=unset; their_ip=unset;
 "v6-tunnel-east-road":   host: oriented; local: 2001:db8:1:3::209; nexthop: 2001:db8:1:3::254; remote: 2001:db8:1:2::23;
-"v6-tunnel-east-road":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"v6-tunnel-east-road":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "v6-tunnel-east-road":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "v6-tunnel-east-road":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "v6-tunnel-east-road":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/multinet-01/east.console.txt
+++ b/testing/pluto/multinet-01/east.console.txt
@@ -15,7 +15,7 @@ east #
  ipsec status | grep westnet-eastnet
 "westnet-eastnet-subnets/1x1": 192.0.2.16/28===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/28; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-subnets/1x1":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-subnets/1x1":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-subnets/1x1":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-subnets/1x1":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-subnets/1x1":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-subnets/1x1":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -37,7 +37,7 @@ east #
 "westnet-eastnet-subnets/1x1":   aliases: westnet-eastnet-subnets
 "westnet-eastnet-subnets/1x2": 192.0.2.64/30===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/28; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-subnets/1x2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-subnets/1x2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-subnets/1x2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-subnets/1x2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-subnets/1x2":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-subnets/1x2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -59,7 +59,7 @@ east #
 "westnet-eastnet-subnets/1x2":   aliases: westnet-eastnet-subnets
 "westnet-eastnet-subnets/2x1": 192.0.2.16/28===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.128/28; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-subnets/2x1":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-subnets/2x1":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-subnets/2x1":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-subnets/2x1":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-subnets/2x1":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-subnets/2x1":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -81,7 +81,7 @@ east #
 "westnet-eastnet-subnets/2x1":   aliases: westnet-eastnet-subnets
 "westnet-eastnet-subnets/2x2": 192.0.2.64/30===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.128/28; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-subnets/2x2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-subnets/2x2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-subnets/2x2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-subnets/2x2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-subnets/2x2":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-subnets/2x2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/multinet-01/west.console.txt
+++ b/testing/pluto/multinet-01/west.console.txt
@@ -31,7 +31,7 @@ west #
  ipsec status | grep westnet-eastnet
 "westnet-eastnet-subnets/1x1": 192.0.1.0/28===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.16/28; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-subnets/1x1":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-subnets/1x1":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-subnets/1x1":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-subnets/1x1":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-subnets/1x1":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-subnets/1x1":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -53,7 +53,7 @@ west #
 "westnet-eastnet-subnets/1x1":   aliases: westnet-eastnet-subnets
 "westnet-eastnet-subnets/1x2": 192.0.1.0/28===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.64/30; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-subnets/1x2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-subnets/1x2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-subnets/1x2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-subnets/1x2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-subnets/1x2":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-subnets/1x2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -75,7 +75,7 @@ west #
 "westnet-eastnet-subnets/1x2":   aliases: westnet-eastnet-subnets
 "westnet-eastnet-subnets/2x1": 192.0.1.128/28===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.16/28; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-subnets/2x1":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-subnets/2x1":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-subnets/2x1":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-subnets/2x1":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-subnets/2x1":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-subnets/2x1":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -97,7 +97,7 @@ west #
 "westnet-eastnet-subnets/2x1":   aliases: westnet-eastnet-subnets
 "westnet-eastnet-subnets/2x2": 192.0.1.128/28===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.64/30; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-subnets/2x2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-subnets/2x2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-subnets/2x2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-subnets/2x2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-subnets/2x2":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-subnets/2x2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -193,7 +193,7 @@ west #
  ipsec status | grep westnet
 "westnet-eastnet-subnets/1x1": 192.0.1.0/28===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.16/28; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-subnets/1x1":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-subnets/1x1":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-subnets/1x1":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-subnets/1x1":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-subnets/1x1":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-subnets/1x1":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -215,7 +215,7 @@ west #
 "westnet-eastnet-subnets/1x1":   aliases: westnet-eastnet-subnets
 "westnet-eastnet-subnets/1x2": 192.0.1.0/28===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.64/30; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-subnets/1x2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-subnets/1x2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-subnets/1x2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-subnets/1x2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-subnets/1x2":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-subnets/1x2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -237,7 +237,7 @@ west #
 "westnet-eastnet-subnets/1x2":   aliases: westnet-eastnet-subnets
 "westnet-eastnet-subnets/2x1": 192.0.1.128/28===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.16/28; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-subnets/2x1":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-subnets/2x1":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-subnets/2x1":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-subnets/2x1":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-subnets/2x1":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-subnets/2x1":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -259,7 +259,7 @@ west #
 "westnet-eastnet-subnets/2x1":   aliases: westnet-eastnet-subnets
 "westnet-eastnet-subnets/2x2": 192.0.1.128/28===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.64/30; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-subnets/2x2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-subnets/2x2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-subnets/2x2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-subnets/2x2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-subnets/2x2":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-subnets/2x2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nat-pluto-04/road.console.txt
+++ b/testing/pluto/nat-pluto-04/road.console.txt
@@ -12,7 +12,7 @@ road #
  ipsec auto --status | grep road-eastnet-nat
 "road-eastnet-nat": 192.0.2.219/32===192.1.3.209[@road]---192.1.3.254...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=192.0.2.219; their_ip=unset;
 "road-eastnet-nat":   host: oriented; local: 192.1.3.209; nexthop: 192.1.3.254; remote: 192.1.2.23;
-"road-eastnet-nat":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-eastnet-nat":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-eastnet-nat":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-eastnet-nat":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "road-eastnet-nat":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/newoe-25-cat-1/road.console.txt
+++ b/testing/pluto/newoe-25-cat-1/road.console.txt
@@ -112,7 +112,7 @@ Connection list:
  
 "block": 192.1.3.209---192.1.3.254...%group; unrouted; eroute owner: #0
 "block":     oriented; my_ip=unset; their_ip=unset;
-"block":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"block":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "block":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "block":   our auth:never, their auth:never, our autheap:none, their autheap:none;
 "block":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -134,7 +134,7 @@ Connection list:
 "block":   conn serial: $5;
 "clear": 192.1.3.209---192.1.3.254...%group; unrouted; eroute owner: #0
 "clear":     oriented; my_ip=unset; their_ip=unset;
-"clear":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"clear":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "clear":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "clear":   our auth:never, their auth:never, our autheap:none, their autheap:none;
 "clear":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -155,7 +155,7 @@ Connection list:
 "clear":   routing: unrouted;
 "clear":   conn serial: $1;
 "clear#192.1.2.253/32": 192.1.3.209---192.1.3.254...%any===192.1.2.253/32; routed-ondemand; my_ip=unset; their_ip=unset;
-"clear#192.1.2.253/32":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"clear#192.1.2.253/32":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "clear#192.1.2.253/32":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "clear#192.1.2.253/32":   our auth:never, their auth:never, our autheap:none, their autheap:none;
 "clear#192.1.2.253/32":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -176,7 +176,7 @@ Connection list:
 "clear#192.1.2.253/32":   conn serial: $8, instantiated from: $1;
 "clear#192.1.3.253/32": 192.1.3.209---192.1.3.254...%any===192.1.3.253/32; prospective erouted; eroute owner: #0
 "clear#192.1.3.253/32":     oriented; my_ip=unset; their_ip=unset;
-"clear#192.1.3.253/32":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"clear#192.1.3.253/32":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "clear#192.1.3.253/32":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "clear#192.1.3.253/32":   our auth:never, their auth:never, our autheap:none, their autheap:none;
 "clear#192.1.3.253/32":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -197,7 +197,7 @@ Connection list:
 "clear#192.1.3.253/32":   conn serial: $7, instantiated from: $1;
 "clear#192.1.3.254/32": 192.1.3.209---192.1.3.254...%any===192.1.3.254/32; prospective erouted; eroute owner: #0
 "clear#192.1.3.254/32":     oriented; my_ip=unset; their_ip=unset;
-"clear#192.1.3.254/32":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"clear#192.1.3.254/32":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "clear#192.1.3.254/32":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "clear#192.1.3.254/32":   our auth:never, their auth:never, our autheap:none, their autheap:none;
 "clear#192.1.3.254/32":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -218,7 +218,7 @@ Connection list:
 "clear#192.1.3.254/32":   conn serial: $6, instantiated from: $1;
 "clear-or-private": 192.1.3.209[ID_NULL]---192.1.3.254...%opportunisticgroup[ID_NULL]; unrouted; eroute owner: #0
 "clear-or-private":     oriented; my_ip=unset; their_ip=unset;
-"clear-or-private":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"clear-or-private":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "clear-or-private":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "clear-or-private":   our auth:null, their auth:null, our autheap:none, their autheap:none;
 "clear-or-private":   modecfg info: us:client, them:server, modecfg policy:push, dns:unset, domains:unset, cat:set;
@@ -239,7 +239,7 @@ Connection list:
 "clear-or-private":   conn serial: $2;
 "private": 192.1.3.209[ID_NULL]---192.1.3.254...%opportunisticgroup[ID_NULL]; unrouted; eroute owner: #0
 "private":     oriented; my_ip=unset; their_ip=unset;
-"private":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"private":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "private":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "private":   our auth:null, their auth:null, our autheap:none, their autheap:none;
 "private":   modecfg info: us:client, them:server, modecfg policy:push, dns:unset, domains:unset, cat:set;
@@ -260,7 +260,7 @@ Connection list:
 "private":   conn serial: $4;
 "private-or-clear": 192.1.3.209[ID_NULL]---192.1.3.254...%opportunisticgroup[ID_NULL]; unrouted; eroute owner: #0
 "private-or-clear":     oriented; my_ip=unset; their_ip=unset;
-"private-or-clear":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"private-or-clear":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "private-or-clear":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "private-or-clear":   our auth:null, their auth:null, our autheap:none, their autheap:none;
 "private-or-clear":   modecfg info: us:client, them:server, modecfg policy:push, dns:unset, domains:unset, cat:set;
@@ -281,7 +281,7 @@ Connection list:
 "private-or-clear":   conn serial: $3;
 "private-or-clear#192.1.2.0/24": 192.1.3.209[ID_NULL]---192.1.3.254...%opportunistic[ID_NULL]===192.1.2.0/24; prospective erouted; eroute owner: #0
 "private-or-clear#192.1.2.0/24":     oriented; my_ip=unset; their_ip=unset;
-"private-or-clear#192.1.2.0/24":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"private-or-clear#192.1.2.0/24":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "private-or-clear#192.1.2.0/24":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "private-or-clear#192.1.2.0/24":   our auth:null, their auth:null, our autheap:none, their autheap:none;
 "private-or-clear#192.1.2.0/24":   modecfg info: us:client, them:server, modecfg policy:push, dns:unset, domains:unset, cat:set;

--- a/testing/pluto/newoe-25-cat-2/road.console.txt
+++ b/testing/pluto/newoe-25-cat-2/road.console.txt
@@ -107,7 +107,7 @@ Connection list:
  
 "block": 192.1.3.209---192.1.3.254...%group; unrouted; eroute owner: #0
 "block":     oriented; my_ip=unset; their_ip=unset;
-"block":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"block":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "block":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "block":   our auth:never, their auth:never, our autheap:none, their autheap:none;
 "block":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -129,7 +129,7 @@ Connection list:
 "block":   conn serial: $5;
 "clear": 192.1.3.209---192.1.3.254...%group; unrouted; eroute owner: #0
 "clear":     oriented; my_ip=unset; their_ip=unset;
-"clear":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"clear":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "clear":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "clear":   our auth:never, their auth:never, our autheap:none, their autheap:none;
 "clear":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -150,7 +150,7 @@ Connection list:
 "clear":   routing: unrouted;
 "clear":   conn serial: $1;
 "clear#192.1.2.253/32": 192.1.3.209---192.1.3.254...%any===192.1.2.253/32; routed-ondemand; my_ip=unset; their_ip=unset;
-"clear#192.1.2.253/32":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"clear#192.1.2.253/32":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "clear#192.1.2.253/32":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "clear#192.1.2.253/32":   our auth:never, their auth:never, our autheap:none, their autheap:none;
 "clear#192.1.2.253/32":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -171,7 +171,7 @@ Connection list:
 "clear#192.1.2.253/32":   conn serial: $8, instantiated from: $1;
 "clear#192.1.3.253/32": 192.1.3.209---192.1.3.254...%any===192.1.3.253/32; prospective erouted; eroute owner: #0
 "clear#192.1.3.253/32":     oriented; my_ip=unset; their_ip=unset;
-"clear#192.1.3.253/32":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"clear#192.1.3.253/32":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "clear#192.1.3.253/32":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "clear#192.1.3.253/32":   our auth:never, their auth:never, our autheap:none, their autheap:none;
 "clear#192.1.3.253/32":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -192,7 +192,7 @@ Connection list:
 "clear#192.1.3.253/32":   conn serial: $7, instantiated from: $1;
 "clear#192.1.3.254/32": 192.1.3.209---192.1.3.254...%any===192.1.3.254/32; prospective erouted; eroute owner: #0
 "clear#192.1.3.254/32":     oriented; my_ip=unset; their_ip=unset;
-"clear#192.1.3.254/32":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"clear#192.1.3.254/32":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "clear#192.1.3.254/32":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "clear#192.1.3.254/32":   our auth:never, their auth:never, our autheap:none, their autheap:none;
 "clear#192.1.3.254/32":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -213,7 +213,7 @@ Connection list:
 "clear#192.1.3.254/32":   conn serial: $6, instantiated from: $1;
 "clear-or-private": 192.1.3.209[ID_NULL]---192.1.3.254...%opportunisticgroup[ID_NULL]; unrouted; eroute owner: #0
 "clear-or-private":     oriented; my_ip=unset; their_ip=unset;
-"clear-or-private":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"clear-or-private":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "clear-or-private":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "clear-or-private":   our auth:null, their auth:null, our autheap:none, their autheap:none;
 "clear-or-private":   modecfg info: us:client, them:server, modecfg policy:push, dns:unset, domains:unset, cat:set;
@@ -234,7 +234,7 @@ Connection list:
 "clear-or-private":   conn serial: $2;
 "private": 192.1.3.209[ID_NULL]---192.1.3.254...%opportunisticgroup[ID_NULL]; unrouted; eroute owner: #0
 "private":     oriented; my_ip=unset; their_ip=unset;
-"private":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"private":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "private":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "private":   our auth:null, their auth:null, our autheap:none, their autheap:none;
 "private":   modecfg info: us:client, them:server, modecfg policy:push, dns:unset, domains:unset, cat:set;
@@ -255,7 +255,7 @@ Connection list:
 "private":   conn serial: $4;
 "private-or-clear": 192.1.3.209[ID_NULL]---192.1.3.254...%opportunisticgroup[ID_NULL]; unrouted; eroute owner: #0
 "private-or-clear":     oriented; my_ip=unset; their_ip=unset;
-"private-or-clear":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"private-or-clear":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "private-or-clear":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "private-or-clear":   our auth:null, their auth:null, our autheap:none, their autheap:none;
 "private-or-clear":   modecfg info: us:client, them:server, modecfg policy:push, dns:unset, domains:unset, cat:set;
@@ -276,7 +276,7 @@ Connection list:
 "private-or-clear":   conn serial: $3;
 "private-or-clear#192.1.2.0/24": 192.1.3.209[ID_NULL]---192.1.3.254...%opportunistic[ID_NULL]===192.1.2.0/24; prospective erouted; eroute owner: #0
 "private-or-clear#192.1.2.0/24":     oriented; my_ip=unset; their_ip=unset;
-"private-or-clear#192.1.2.0/24":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"private-or-clear#192.1.2.0/24":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "private-or-clear#192.1.2.0/24":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "private-or-clear#192.1.2.0/24":   our auth:null, their auth:null, our autheap:none, their autheap:none;
 "private-or-clear#192.1.2.0/24":   modecfg info: us:client, them:server, modecfg policy:push, dns:unset, domains:unset, cat:set;

--- a/testing/pluto/newoe-25-cat-5/road.console.txt
+++ b/testing/pluto/newoe-25-cat-5/road.console.txt
@@ -107,7 +107,7 @@ Connection list:
  
 "block": 192.1.3.209---192.1.3.254...%group; unrouted; eroute owner: #0
 "block":     oriented; my_ip=unset; their_ip=unset;
-"block":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"block":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "block":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "block":   our auth:never, their auth:never, our autheap:none, their autheap:none;
 "block":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -129,7 +129,7 @@ Connection list:
 "block":   conn serial: $5;
 "clear": 192.1.3.209---192.1.3.254...%group; unrouted; eroute owner: #0
 "clear":     oriented; my_ip=unset; their_ip=unset;
-"clear":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"clear":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "clear":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "clear":   our auth:never, their auth:never, our autheap:none, their autheap:none;
 "clear":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -150,7 +150,7 @@ Connection list:
 "clear":   routing: unrouted;
 "clear":   conn serial: $1;
 "clear#192.1.2.253/32": 192.1.3.209---192.1.3.254...%any===192.1.2.253/32; routed-ondemand; my_ip=unset; their_ip=unset;
-"clear#192.1.2.253/32":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"clear#192.1.2.253/32":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "clear#192.1.2.253/32":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "clear#192.1.2.253/32":   our auth:never, their auth:never, our autheap:none, their autheap:none;
 "clear#192.1.2.253/32":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -171,7 +171,7 @@ Connection list:
 "clear#192.1.2.253/32":   conn serial: $8, instantiated from: $1;
 "clear#192.1.3.253/32": 192.1.3.209---192.1.3.254...%any===192.1.3.253/32; prospective erouted; eroute owner: #0
 "clear#192.1.3.253/32":     oriented; my_ip=unset; their_ip=unset;
-"clear#192.1.3.253/32":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"clear#192.1.3.253/32":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "clear#192.1.3.253/32":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "clear#192.1.3.253/32":   our auth:never, their auth:never, our autheap:none, their autheap:none;
 "clear#192.1.3.253/32":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -192,7 +192,7 @@ Connection list:
 "clear#192.1.3.253/32":   conn serial: $7, instantiated from: $1;
 "clear#192.1.3.254/32": 192.1.3.209---192.1.3.254...%any===192.1.3.254/32; prospective erouted; eroute owner: #0
 "clear#192.1.3.254/32":     oriented; my_ip=unset; their_ip=unset;
-"clear#192.1.3.254/32":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"clear#192.1.3.254/32":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "clear#192.1.3.254/32":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "clear#192.1.3.254/32":   our auth:never, their auth:never, our autheap:none, their autheap:none;
 "clear#192.1.3.254/32":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -213,7 +213,7 @@ Connection list:
 "clear#192.1.3.254/32":   conn serial: $6, instantiated from: $1;
 "clear-or-private": 192.1.3.209[ID_NULL]---192.1.3.254...%opportunisticgroup[ID_NULL]; unrouted; eroute owner: #0
 "clear-or-private":     oriented; my_ip=unset; their_ip=unset;
-"clear-or-private":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"clear-or-private":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "clear-or-private":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "clear-or-private":   our auth:null, their auth:null, our autheap:none, their autheap:none;
 "clear-or-private":   modecfg info: us:client, them:server, modecfg policy:push, dns:unset, domains:unset, cat:set;
@@ -234,7 +234,7 @@ Connection list:
 "clear-or-private":   conn serial: $2;
 "private": 192.1.3.209[ID_NULL]---192.1.3.254...%opportunisticgroup[ID_NULL]; unrouted; eroute owner: #0
 "private":     oriented; my_ip=unset; their_ip=unset;
-"private":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"private":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "private":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "private":   our auth:null, their auth:null, our autheap:none, their autheap:none;
 "private":   modecfg info: us:client, them:server, modecfg policy:push, dns:unset, domains:unset, cat:set;
@@ -255,7 +255,7 @@ Connection list:
 "private":   conn serial: $4;
 "private-or-clear": 192.1.3.209[ID_NULL]---192.1.3.254...%opportunisticgroup[ID_NULL]; unrouted; eroute owner: #0
 "private-or-clear":     oriented; my_ip=unset; their_ip=unset;
-"private-or-clear":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"private-or-clear":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "private-or-clear":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "private-or-clear":   our auth:null, their auth:null, our autheap:none, their autheap:none;
 "private-or-clear":   modecfg info: us:client, them:server, modecfg policy:push, dns:unset, domains:unset, cat:set;
@@ -276,7 +276,7 @@ Connection list:
 "private-or-clear":   conn serial: $3;
 "private-or-clear#192.1.2.0/24": 192.1.3.209[ID_NULL]---192.1.3.254...%opportunistic[ID_NULL]===192.1.2.0/24; prospective erouted; eroute owner: #0
 "private-or-clear#192.1.2.0/24":     oriented; my_ip=unset; their_ip=unset;
-"private-or-clear#192.1.2.0/24":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"private-or-clear#192.1.2.0/24":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "private-or-clear#192.1.2.0/24":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "private-or-clear#192.1.2.0/24":   our auth:null, their auth:null, our autheap:none, their autheap:none;
 "private-or-clear#192.1.2.0/24":   modecfg info: us:client, them:server, modecfg policy:push, dns:unset, domains:unset, cat:set;

--- a/testing/pluto/nss-cert-01-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-01-ikev1/east.console.txt
@@ -13,7 +13,7 @@ east #
 "nss-cert": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert":   mycert=east; peercert=west;
-"nss-cert":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-01-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-01-ikev1/west.console.txt
@@ -13,7 +13,7 @@ west #
 "nss-cert": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert":   mycert=west; peercert=east;
-"nss-cert":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-01-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-01-ikev2/east.console.txt
@@ -13,7 +13,7 @@ east #
 "nss-cert": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert":   mycert=east; peercert=west;
-"nss-cert":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-01-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-01-ikev2/west.console.txt
@@ -13,7 +13,7 @@ west #
 "nss-cert": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert":   mycert=west; peercert=east;
-"nss-cert":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-02-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-02-ikev1/east.console.txt
@@ -21,7 +21,7 @@ east #
 "nss-cert": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert":   mycert=east;
-"nss-cert":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-02-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-02-ikev1/west.console.txt
@@ -21,7 +21,7 @@ west #
 "nss-cert": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert":   mycert=west;
-"nss-cert":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-02-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-02-ikev2/east.console.txt
@@ -21,7 +21,7 @@ east #
 "nss-cert": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert":   mycert=east;
-"nss-cert":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-02-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-02-ikev2/west.console.txt
@@ -21,7 +21,7 @@ west #
 "nss-cert": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert":   mycert=west;
-"nss-cert":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-03-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-03-ikev1/east.console.txt
@@ -21,7 +21,7 @@ east #
 "nss-cert": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=*, E=*]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert":   mycert=east;
-"nss-cert":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-03-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-03-ikev1/west.console.txt
@@ -21,7 +21,7 @@ west #
 "nss-cert": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert":   mycert=west;
-"nss-cert":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-03-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-03-ikev2/east.console.txt
@@ -21,7 +21,7 @@ east #
 "nss-cert": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=*, E=*]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert":   mycert=east;
-"nss-cert":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-03-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-03-ikev2/west.console.txt
@@ -21,7 +21,7 @@ west #
 "nss-cert": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert":   mycert=west;
-"nss-cert":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-04-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-04-ikev1/east.console.txt
@@ -29,7 +29,7 @@ east #
 "nss-cert": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert":   mycert=east;
-"nss-cert":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-04-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-04-ikev1/west.console.txt
@@ -41,7 +41,7 @@ west #
 "nss-cert": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=otherwest.other.libreswan.org, E=user-otherwest@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert":   mycert=otherwest;
-"nss-cert":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-04-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-04-ikev2/east.console.txt
@@ -29,7 +29,7 @@ east #
 "nss-cert": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert":   mycert=east;
-"nss-cert":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-04-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-04-ikev2/west.console.txt
@@ -41,7 +41,7 @@ west #
 "nss-cert": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=otherwest.other.libreswan.org, E=user-otherwest@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert":   mycert=otherwest;
-"nss-cert":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-05-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-05-ikev1/east.console.txt
@@ -35,7 +35,7 @@ east #
 "nss-cert": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert":   mycert=east;
-"nss-cert":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-05-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-05-ikev1/west.console.txt
@@ -41,7 +41,7 @@ west #
 "nss-cert": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=otherwest.other.libreswan.org, E=user-otherwest@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert":   mycert=otherwest;
-"nss-cert":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-05-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-05-ikev2/east.console.txt
@@ -35,7 +35,7 @@ east #
 "nss-cert": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert":   mycert=east;
-"nss-cert":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-05-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-05-ikev2/west.console.txt
@@ -41,7 +41,7 @@ west #
 "nss-cert": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=otherwest.other.libreswan.org, E=user-otherwest@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert":   mycert=otherwest;
-"nss-cert":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-06-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-06-ikev1/east.console.txt
@@ -38,7 +38,7 @@ east #
 "nss-cert-correct": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]---192.1.2.45...%any[@west.testing.libreswan.org]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=unset;
 "nss-cert-correct":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.45; remote: %any;
 "nss-cert-correct":   mycert=east;
-"nss-cert-correct":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-correct":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-correct":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-correct":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-correct":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -61,7 +61,7 @@ east #
 "nss-cert-wrong": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]---192.1.2.45...%any[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=signedbyother.testing.libreswan.org, E=user-signedbyother@testing.libreswan.org]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=unset;
 "nss-cert-wrong":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.45; remote: %any;
 "nss-cert-wrong":   mycert=east;
-"nss-cert-wrong":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-wrong":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-wrong":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-wrong":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-wrong":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-06-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-06-ikev1/west.console.txt
@@ -29,7 +29,7 @@ west #
 "nss-cert": 192.0.1.254/32===192.1.2.45[@west.testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert":   mycert=west;
-"nss-cert":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-06-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-06-ikev2/east.console.txt
@@ -38,7 +38,7 @@ east #
 "nss-cert-correct": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]---192.1.2.45...%any[@west.testing.libreswan.org]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=unset;
 "nss-cert-correct":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.45; remote: %any;
 "nss-cert-correct":   mycert=east;
-"nss-cert-correct":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-correct":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-correct":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-correct":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert-correct":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -62,7 +62,7 @@ east #
 "nss-cert-wrong": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]---192.1.2.45...%any[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=signedbyother.testing.libreswan.org, E=user-signedbyother@testing.libreswan.org]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=unset;
 "nss-cert-wrong":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.45; remote: %any;
 "nss-cert-wrong":   mycert=east;
-"nss-cert-wrong":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-wrong":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-wrong":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-wrong":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert-wrong":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-06-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-06-ikev2/west.console.txt
@@ -29,7 +29,7 @@ west #
 "nss-cert": 192.0.1.254/32===192.1.2.45[@west.testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert":   mycert=west;
-"nss-cert":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-chain-01-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-chain-01-ikev1/east.console.txt
@@ -23,7 +23,7 @@ east #
 "nss-cert-chain": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east_chain_endcert.testing.libreswan.org, E=east_chain_endcert@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert-chain":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert-chain":   mycert=east_chain_endcert;
-"nss-cert-chain":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-chain":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-chain":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-chain":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-chain":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-chain-01-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-chain-01-ikev1/west.console.txt
@@ -23,7 +23,7 @@ west #
 "nss-cert-chain": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west_chain_endcert.testing.libreswan.org, E=west_chain_endcert@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert-chain":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert-chain":   mycert=west_chain_endcert;
-"nss-cert-chain":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-chain":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-chain":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-chain":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-chain":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-chain-01-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-chain-01-ikev2/east.console.txt
@@ -23,7 +23,7 @@ east #
 "nss-cert-chain": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east_chain_endcert.testing.libreswan.org, E=east_chain_endcert@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert-chain":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert-chain":   mycert=east_chain_endcert;
-"nss-cert-chain":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-chain":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-chain":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-chain":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert-chain":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-chain-01-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-chain-01-ikev2/west.console.txt
@@ -23,7 +23,7 @@ west #
 "nss-cert-chain": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west_chain_endcert.testing.libreswan.org, E=west_chain_endcert@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert-chain":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert-chain":   mycert=west_chain_endcert;
-"nss-cert-chain":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-chain":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-chain":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-chain":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert-chain":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-chain-02-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-chain-02-ikev1/east.console.txt
@@ -24,7 +24,7 @@ east #
 "nss-cert-chain": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east_chain_endcert.testing.libreswan.org, E=east_chain_endcert@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert-chain":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert-chain":   mycert=east_chain_endcert;
-"nss-cert-chain":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-chain":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-chain":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-chain":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-chain":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-chain-02-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-chain-02-ikev1/west.console.txt
@@ -24,7 +24,7 @@ west #
 "nss-cert-chain": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west_chain_endcert.testing.libreswan.org, E=west_chain_endcert@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert-chain":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert-chain":   mycert=west_chain_endcert;
-"nss-cert-chain":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-chain":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-chain":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-chain":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-chain":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-chain-02-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-chain-02-ikev2/east.console.txt
@@ -24,7 +24,7 @@ east #
 "nss-cert-chain": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east_chain_endcert.testing.libreswan.org, E=east_chain_endcert@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert-chain":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert-chain":   mycert=east_chain_endcert;
-"nss-cert-chain":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-chain":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-chain":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-chain":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert-chain":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-chain-02-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-chain-02-ikev2/west.console.txt
@@ -24,7 +24,7 @@ west #
 "nss-cert-chain": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west_chain_endcert.testing.libreswan.org, E=west_chain_endcert@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert-chain":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert-chain":   mycert=west_chain_endcert;
-"nss-cert-chain":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-chain":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-chain":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-chain":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert-chain":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-chain-03-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-chain-03-ikev1/east.console.txt
@@ -38,7 +38,7 @@ east #
 "nss-cert-chain": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east_chain_endcert.testing.libreswan.org, E=east_chain_endcert@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert-chain":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert-chain":   mycert=east_chain_endcert;
-"nss-cert-chain":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-chain":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-chain":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-chain":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-chain":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-chain-03-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-chain-03-ikev1/west.console.txt
@@ -38,7 +38,7 @@ west #
 "nss-cert-chain": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west_chain_endcert.testing.libreswan.org, E=west_chain_endcert@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert-chain":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert-chain":   mycert=west_chain_endcert;
-"nss-cert-chain":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-chain":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-chain":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-chain":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-chain":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-chain-03-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-chain-03-ikev2/east.console.txt
@@ -38,7 +38,7 @@ east #
 "nss-cert-chain": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east_chain_endcert.testing.libreswan.org, E=east_chain_endcert@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert-chain":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert-chain":   mycert=east_chain_endcert;
-"nss-cert-chain":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-chain":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-chain":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-chain":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert-chain":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-chain-03-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-chain-03-ikev2/west.console.txt
@@ -38,7 +38,7 @@ west #
 "nss-cert-chain": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west_chain_endcert.testing.libreswan.org, E=west_chain_endcert@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert-chain":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert-chain":   mycert=west_chain_endcert;
-"nss-cert-chain":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-chain":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-chain":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-chain":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert-chain":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-chain-04-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-chain-04-ikev1/east.console.txt
@@ -38,7 +38,7 @@ east #
 "road-A": 192.0.2.254/32===192.1.2.23[@east.testing.libreswan.org]---192.1.2.45...%any[@someone.testing.libreswan.org]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=unset;
 "road-A":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.45; remote: %any;
 "road-A":   mycert=east;
-"road-A":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-A":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-A":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-A":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "road-A":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -61,7 +61,7 @@ east #
 "road-chain-B": 192.0.2.254/32===192.1.2.23[@east.testing.libreswan.org]---192.1.2.45...%any[@west_chain_endcert.testing.libreswan.org]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=unset;
 "road-chain-B":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.45; remote: %any;
 "road-chain-B":   mycert=east;
-"road-chain-B":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-chain-B":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-chain-B":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-chain-B":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "road-chain-B":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-chain-04-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-chain-04-ikev1/west.console.txt
@@ -33,7 +33,7 @@ west #
 "road-chain-B": 192.0.1.254/32===192.1.2.45[@west_chain_endcert.testing.libreswan.org]...192.1.2.23[@east.testing.libreswan.org]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=unset;
 "road-chain-B":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "road-chain-B":   mycert=west_chain_endcert;
-"road-chain-B":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-chain-B":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-chain-B":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-chain-B":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "road-chain-B":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-chain-04-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-chain-04-ikev2/east.console.txt
@@ -38,7 +38,7 @@ east #
 "road-A": 192.0.2.254/32===192.1.2.23[@east.testing.libreswan.org]---192.1.2.45...%any[@someone.testing.libreswan.org]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=unset;
 "road-A":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.45; remote: %any;
 "road-A":   mycert=east;
-"road-A":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-A":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-A":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-A":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "road-A":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;
@@ -62,7 +62,7 @@ east #
 "road-chain-B": 192.0.2.254/32===192.1.2.23[@east.testing.libreswan.org]---192.1.2.45...%any[@west_chain_endcert.testing.libreswan.org]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=unset;
 "road-chain-B":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.45; remote: %any;
 "road-chain-B":   mycert=east;
-"road-chain-B":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-chain-B":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-chain-B":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-chain-B":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "road-chain-B":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-chain-04-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-chain-04-ikev2/west.console.txt
@@ -33,7 +33,7 @@ west #
 "road-chain-B": 192.0.1.254/32===192.1.2.45[@west_chain_endcert.testing.libreswan.org]...192.1.2.23[@east.testing.libreswan.org]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=unset;
 "road-chain-B":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "road-chain-B":   mycert=west_chain_endcert;
-"road-chain-B":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-chain-B":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-chain-B":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-chain-B":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "road-chain-B":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-nosecret/east.console.txt
+++ b/testing/pluto/nss-cert-nosecret/east.console.txt
@@ -28,7 +28,7 @@ east #
 "nss-cert": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert":   mycert=east;
-"nss-cert":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-nosecret/west.console.txt
+++ b/testing/pluto/nss-cert-nosecret/west.console.txt
@@ -70,7 +70,7 @@ west #
 "nss-cert": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert":   mycert=west;
-"nss-cert":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-01-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-01-ikev1/east.console.txt
@@ -27,7 +27,7 @@ east #
 "nss-cert-ocsp": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert-ocsp":   mycert=east;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-01-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-01-ikev1/west.console.txt
@@ -21,7 +21,7 @@ west #
 "nss-cert-ocsp": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert-ocsp":   mycert=west;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-01-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-01-ikev2/east.console.txt
@@ -27,7 +27,7 @@ east #
 "nss-cert-ocsp": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert-ocsp":   mycert=east;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-01-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-01-ikev2/west.console.txt
@@ -21,7 +21,7 @@ west #
 "nss-cert-ocsp": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert-ocsp":   mycert=west;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-02-revoked-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-02-revoked-ikev1/east.console.txt
@@ -36,7 +36,7 @@ east #
 "nss-cert-ocsp": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert-ocsp":   mycert=east;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-02-revoked-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-02-revoked-ikev1/west.console.txt
@@ -38,7 +38,7 @@ west #
 "nss-cert-ocsp": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=revoked.testing.libreswan.org, E=user-revoked@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert-ocsp":   mycert=revoked;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-02-revoked-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-02-revoked-ikev2/east.console.txt
@@ -36,7 +36,7 @@ east #
 "nss-cert-ocsp": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert-ocsp":   mycert=east;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-02-revoked-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-02-revoked-ikev2/west.console.txt
@@ -40,7 +40,7 @@ west #
 "nss-cert-ocsp": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=revoked.testing.libreswan.org, E=user-revoked@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert-ocsp":   mycert=revoked;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-03-bogus-uri-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-03-bogus-uri-ikev1/east.console.txt
@@ -29,7 +29,7 @@ east #
 "nss-cert-ocsp": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert-ocsp":   mycert=east;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-03-bogus-uri-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-03-bogus-uri-ikev1/west.console.txt
@@ -21,7 +21,7 @@ west #
 "nss-cert-ocsp": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert-ocsp":   mycert=west;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-03-bogus-uri-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-03-bogus-uri-ikev2/east.console.txt
@@ -27,7 +27,7 @@ east #
 "nss-cert-ocsp": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert-ocsp":   mycert=east;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-03-bogus-uri-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-03-bogus-uri-ikev2/west.console.txt
@@ -21,7 +21,7 @@ west #
 "nss-cert-ocsp": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert-ocsp":   mycert=west;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-03-bogus-uri-strict-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-03-bogus-uri-strict-ikev1/east.console.txt
@@ -29,7 +29,7 @@ east #
 "nss-cert-ocsp": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert-ocsp":   mycert=east;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-03-bogus-uri-strict-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-03-bogus-uri-strict-ikev1/west.console.txt
@@ -21,7 +21,7 @@ west #
 "nss-cert-ocsp": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert-ocsp":   mycert=west;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-04-revoked-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-04-revoked-ikev1/east.console.txt
@@ -36,7 +36,7 @@ east #
 "nss-cert-ocsp": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert-ocsp":   mycert=east;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-04-revoked-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-04-revoked-ikev1/west.console.txt
@@ -36,7 +36,7 @@ west #
 "nss-cert-ocsp": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=revoked.testing.libreswan.org, E=user-revoked@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert-ocsp":   mycert=revoked;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-05-no-trust-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-05-no-trust-ikev1/east.console.txt
@@ -29,7 +29,7 @@ east #
 "nss-cert-ocsp": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert-ocsp":   mycert=east;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-05-no-trust-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-05-no-trust-ikev1/west.console.txt
@@ -21,7 +21,7 @@ west #
 "nss-cert-ocsp": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert-ocsp":   mycert=west;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-05-no-trust-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-05-no-trust-ikev2/east.console.txt
@@ -27,7 +27,7 @@ east #
 "nss-cert-ocsp": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert-ocsp":   mycert=east;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-05-no-trust-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-05-no-trust-ikev2/west.console.txt
@@ -21,7 +21,7 @@ west #
 "nss-cert-ocsp": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert-ocsp":   mycert=west;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-05-no-trust-strict-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-05-no-trust-strict-ikev1/east.console.txt
@@ -29,7 +29,7 @@ east #
 "nss-cert-ocsp": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert-ocsp":   mycert=east;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-05-no-trust-strict-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-05-no-trust-strict-ikev1/west.console.txt
@@ -21,7 +21,7 @@ west #
 "nss-cert-ocsp": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert-ocsp":   mycert=west;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-06-no-trust-revoked-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-06-no-trust-revoked-ikev1/east.console.txt
@@ -36,7 +36,7 @@ east #
 "nss-cert-ocsp": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert-ocsp":   mycert=east;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-06-no-trust-revoked-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-06-no-trust-revoked-ikev1/west.console.txt
@@ -36,7 +36,7 @@ west #
 "nss-cert-ocsp": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=revoked.testing.libreswan.org, E=user-revoked@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert-ocsp":   mycert=revoked;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-07-nic-no-ocsp-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-07-nic-no-ocsp-ikev1/west.console.txt
@@ -38,7 +38,7 @@ west #
 "nss-cert-ocsp": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=revoked.testing.libreswan.org, E=user-revoked@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert-ocsp":   mycert=revoked;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-07-nic-no-ocsp-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-07-nic-no-ocsp-ikev2/west.console.txt
@@ -38,7 +38,7 @@ west #
 "nss-cert-ocsp": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=revoked.testing.libreswan.org, E=user-revoked@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert-ocsp":   mycert=revoked;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-08-post-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-08-post-ikev1/east.console.txt
@@ -36,7 +36,7 @@ east #
 "nss-cert-ocsp": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert-ocsp":   mycert=east;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-08-post-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-08-post-ikev1/west.console.txt
@@ -38,7 +38,7 @@ west #
 "nss-cert-ocsp": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=revoked.testing.libreswan.org, E=user-revoked@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert-ocsp":   mycert=revoked;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-09-chain-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-09-chain-ikev1/east.console.txt
@@ -29,7 +29,7 @@ east #
 "nss-cert-ocsp": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east_chain_endcert.testing.libreswan.org, E=east_chain_endcert@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "nss-cert-ocsp":   mycert=east_chain_endcert;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/nss-cert-ocsp-09-chain-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-09-chain-ikev1/west.console.txt
@@ -29,7 +29,7 @@ west #
 "nss-cert-ocsp": 192.0.1.254/32===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west_chain_endcert.testing.libreswan.org, E=west_chain_endcert@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.254/32; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "nss-cert-ocsp":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "nss-cert-ocsp":   mycert=west_chain_endcert;
-"nss-cert-ocsp":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"nss-cert-ocsp":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "nss-cert-ocsp":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "nss-cert-ocsp":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "nss-cert-ocsp":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/psk-pluto-02/road.console.txt
+++ b/testing/pluto/psk-pluto-02/road.console.txt
@@ -14,7 +14,7 @@ road #
  ipsec auto --status | grep road-eastnet-psk
 "road-eastnet-psk": 192.1.3.209[@roadrandom]---192.1.3.254...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "road-eastnet-psk":   host: oriented; local: 192.1.3.209; nexthop: 192.1.3.254; remote: 192.1.2.23;
-"road-eastnet-psk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"road-eastnet-psk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "road-eastnet-psk":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "road-eastnet-psk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "road-eastnet-psk":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/replay-window-ikev1/east.console.txt
+++ b/testing/pluto/replay-window-ikev1/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-null
 "westnet-eastnet-null": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-null":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-null":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-null":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-null":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-null":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-null":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/replay-window-ikev2-pfkeyv2-freebsd/east.console.txt
+++ b/testing/pluto/replay-window-ikev2-pfkeyv2-freebsd/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-null
 "westnet-eastnet-null": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-null":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-null":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-null":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-null":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-null":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-null":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/replay-window-ikev2/east.console.txt
+++ b/testing/pluto/replay-window-ikev2/east.console.txt
@@ -12,7 +12,7 @@ east #
  ipsec auto --status | grep westnet-eastnet-null
 "westnet-eastnet-null": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-null":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-null":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-null":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-null":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-null":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "westnet-eastnet-null":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/whack-rereadcerts-01/east.console.txt
+++ b/testing/pluto/whack-rereadcerts-01/east.console.txt
@@ -16,7 +16,7 @@ east #
 "westnet-eastnet-ikev2": 192.0.2.0/24===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "westnet-eastnet-ikev2":   mycert=east; peercert=west;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/whack-rereadcerts-01/west.console.txt
+++ b/testing/pluto/whack-rereadcerts-01/west.console.txt
@@ -29,7 +29,7 @@ west #
 "westnet-eastnet-ikev2": 192.0.1.0/24===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "westnet-eastnet-ikev2":   mycert=west; peercert=east;
-"westnet-eastnet-ikev2":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-ikev2":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-ikev2":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-ikev2":   our auth:rsasig(RSASIG+RSASIG_v1_5), their auth:RSASIG+ECDSA+RSASIG_v1_5, our autheap:none, their autheap:none;
 "westnet-eastnet-ikev2":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/x509-pluto-01/east.console.txt
+++ b/testing/pluto/x509-pluto-01/east.console.txt
@@ -24,7 +24,7 @@ east #
 "westnet-eastnet-x509-nosend": 192.0.2.0/24===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]===192.0.1.0/24; unrouted; my_ip=192.0.2.254; their_ip=192.0.1.254;
 "westnet-eastnet-x509-nosend":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "westnet-eastnet-x509-nosend":   mycert=east; peercert=west;
-"westnet-eastnet-x509-nosend":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-x509-nosend":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-x509-nosend":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-x509-nosend":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-x509-nosend":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/x509-pluto-01/west.console.txt
+++ b/testing/pluto/x509-pluto-01/west.console.txt
@@ -40,7 +40,7 @@ west #
 "westnet-eastnet-x509-nosend": 192.0.1.0/24===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===192.0.2.0/24; unrouted; my_ip=192.0.1.254; their_ip=192.0.2.254;
 "westnet-eastnet-x509-nosend":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "westnet-eastnet-x509-nosend":   mycert=west; peercert=east;
-"westnet-eastnet-x509-nosend":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-x509-nosend":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-x509-nosend":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-x509-nosend":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-x509-nosend":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/x509-pluto-02/east.console.txt
+++ b/testing/pluto/x509-pluto-02/east.console.txt
@@ -21,7 +21,7 @@ east #
 "north-east-x509-pluto-02": 192.0.2.0/24===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]---192.1.2.254...192.1.3.33[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=*, E=*]===192.0.3.0/24; unrouted; my_ip=unset; their_ip=unset;
 "north-east-x509-pluto-02":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.254; remote: 192.1.3.33;
 "north-east-x509-pluto-02":   mycert=east;
-"north-east-x509-pluto-02":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"north-east-x509-pluto-02":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "north-east-x509-pluto-02":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "north-east-x509-pluto-02":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "north-east-x509-pluto-02":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/x509-pluto-02/north.console.txt
+++ b/testing/pluto/x509-pluto-02/north.console.txt
@@ -24,7 +24,7 @@ north #
 "north-east-x509-pluto-02": 192.0.3.0/24===192.1.3.33[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org]---192.1.3.254...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "north-east-x509-pluto-02":   host: oriented; local: 192.1.3.33; nexthop: 192.1.3.254; remote: 192.1.2.23;
 "north-east-x509-pluto-02":   mycert=north;
-"north-east-x509-pluto-02":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"north-east-x509-pluto-02":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "north-east-x509-pluto-02":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "north-east-x509-pluto-02":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "north-east-x509-pluto-02":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/x509-pluto-03/east.console.txt
+++ b/testing/pluto/x509-pluto-03/east.console.txt
@@ -21,7 +21,7 @@ east #
 "westnet-eastnet-x509-cr": 192.0.2.0/24===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-x509-cr":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "westnet-eastnet-x509-cr":   mycert=east;
-"westnet-eastnet-x509-cr":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-x509-cr":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-x509-cr":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-x509-cr":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-x509-cr":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/x509-pluto-03/west.console.txt
+++ b/testing/pluto/x509-pluto-03/west.console.txt
@@ -37,7 +37,7 @@ west #
 "westnet-eastnet-x509-cr": 192.0.1.0/24===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]...192.1.2.23[%fromcert]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-x509-cr":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
 "westnet-eastnet-x509-cr":   mycert=west;
-"westnet-eastnet-x509-cr":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-x509-cr":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-x509-cr":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-x509-cr":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-x509-cr":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/x509-pluto-04/east.console.txt
+++ b/testing/pluto/x509-pluto-04/east.console.txt
@@ -31,7 +31,7 @@ east #
 "westnet-eastnet-x509-cr": 192.0.2.0/24===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[%fromcert]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-x509-cr":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "westnet-eastnet-x509-cr":   mycert=east;
-"westnet-eastnet-x509-cr":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-x509-cr":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-x509-cr":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-x509-cr":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-x509-cr":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/x509-pluto-05/east.console.txt
+++ b/testing/pluto/x509-pluto-05/east.console.txt
@@ -24,7 +24,7 @@ east #
 "westnet-eastnet-x509": 192.0.2.0/24===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-x509":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
 "westnet-eastnet-x509":   mycert=east; peercert=west;
-"westnet-eastnet-x509":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-x509":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-x509":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-x509":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-x509":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/xauth-pluto-05-xfrm/road.console.txt
+++ b/testing/pluto/xauth-pluto-05-xfrm/road.console.txt
@@ -22,7 +22,7 @@ road #
  ipsec whack --status | grep modecfg-road-eastnet-psk
 "modecfg-road-eastnet-psk": 192.1.3.194[@roadrandom]---192.1.3.254...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "modecfg-road-eastnet-psk":   host: oriented; local: 192.1.3.194; nexthop: 192.1.3.254; remote: 192.1.2.23;
-"modecfg-road-eastnet-psk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"modecfg-road-eastnet-psk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "modecfg-road-eastnet-psk":   xauth us:client, xauth them:server, my_username=[any]; their_username=[any]
 "modecfg-road-eastnet-psk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "modecfg-road-eastnet-psk":   modecfg info: us:client, them:server, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/xauth-pluto-05/road.console.txt
+++ b/testing/pluto/xauth-pluto-05/road.console.txt
@@ -22,7 +22,7 @@ road #
  ipsec whack --status | grep modecfg-road-eastnet-psk
 "modecfg-road-eastnet-psk": 192.1.3.194[@roadrandom]---192.1.3.254...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "modecfg-road-eastnet-psk":   host: oriented; local: 192.1.3.194; nexthop: 192.1.3.254; remote: 192.1.2.23;
-"modecfg-road-eastnet-psk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"modecfg-road-eastnet-psk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "modecfg-road-eastnet-psk":   xauth us:client, xauth them:server, my_username=[any]; their_username=[any]
 "modecfg-road-eastnet-psk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "modecfg-road-eastnet-psk":   modecfg info: us:client, them:server, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/xauth-pluto-06/road.console.txt
+++ b/testing/pluto/xauth-pluto-06/road.console.txt
@@ -18,7 +18,7 @@ road #
  ipsec whack --status | grep modecfg-road-eastnet-psk
 "modecfg-road-eastnet-psk": 192.1.3.209[@roadrandom]---192.1.3.254...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "modecfg-road-eastnet-psk":   host: oriented; local: 192.1.3.209; nexthop: 192.1.3.254; remote: 192.1.2.23;
-"modecfg-road-eastnet-psk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"modecfg-road-eastnet-psk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "modecfg-road-eastnet-psk":   xauth us:client, xauth them:server, my_username=[any]; their_username=[any]
 "modecfg-road-eastnet-psk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "modecfg-road-eastnet-psk":   modecfg info: us:client, them:server, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/xauth-pluto-09/road.console.txt
+++ b/testing/pluto/xauth-pluto-09/road.console.txt
@@ -18,7 +18,7 @@ road #
  ipsec whack --status | grep modecfg-road-eastnet-psk
 "modecfg-road-eastnet-psk": 192.1.3.209[@roadrandom]---192.1.3.254...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "modecfg-road-eastnet-psk":   host: oriented; local: 192.1.3.209; nexthop: 192.1.3.254; remote: 192.1.2.23;
-"modecfg-road-eastnet-psk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"modecfg-road-eastnet-psk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "modecfg-road-eastnet-psk":   xauth us:client, xauth them:server, my_username=[any]; their_username=[any]
 "modecfg-road-eastnet-psk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "modecfg-road-eastnet-psk":   modecfg info: us:client, them:server, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/xauth-pluto-19/road.console.txt
+++ b/testing/pluto/xauth-pluto-19/road.console.txt
@@ -22,7 +22,7 @@ road #
  ipsec whack --status | grep modecfg-road-eastnet-psk
 "modecfg-road-eastnet-psk": 192.1.3.194[@roadrandom]---192.1.3.254...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "modecfg-road-eastnet-psk":   host: oriented; local: 192.1.3.194; nexthop: 192.1.3.254; remote: 192.1.2.23;
-"modecfg-road-eastnet-psk":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"modecfg-road-eastnet-psk":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "modecfg-road-eastnet-psk":   xauth us:client, xauth them:server, my_username=[any]; their_username=[any]
 "modecfg-road-eastnet-psk":   our auth:secret, their auth:secret, our autheap:none, their autheap:none;
 "modecfg-road-eastnet-psk":   modecfg info: us:client, them:server, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/xfrm-algo-aes_gcm-01/east.console.txt
+++ b/testing/pluto/xfrm-algo-aes_gcm-01/east.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-eastnet-gcm": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-gcm":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-gcm":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-gcm":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-gcm":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-gcm":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-gcm":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/xfrm-algo-aes_gcm-01/west.console.txt
+++ b/testing/pluto/xfrm-algo-aes_gcm-01/west.console.txt
@@ -115,7 +115,7 @@ Connection list:
  
 "westnet-eastnet-gcm": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-gcm":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-gcm":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-gcm":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-gcm":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-gcm":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-gcm":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/xfrm-algo-aes_gcm-02/east.console.txt
+++ b/testing/pluto/xfrm-algo-aes_gcm-02/east.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-eastnet-gcm": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-gcm":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-gcm":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-gcm":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-gcm":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-gcm":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-gcm":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/xfrm-algo-aes_gcm-02/west.console.txt
+++ b/testing/pluto/xfrm-algo-aes_gcm-02/west.console.txt
@@ -115,7 +115,7 @@ Connection list:
  
 "westnet-eastnet-gcm": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-gcm":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-gcm":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-gcm":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-gcm":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-gcm":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-gcm":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/xfrm-algo-aes_gcm-03/east.console.txt
+++ b/testing/pluto/xfrm-algo-aes_gcm-03/east.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-eastnet-gcm": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-gcm":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-gcm":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-gcm":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-gcm":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-gcm":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-gcm":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/xfrm-algo-aes_gcm-03/west.console.txt
+++ b/testing/pluto/xfrm-algo-aes_gcm-03/west.console.txt
@@ -115,7 +115,7 @@ Connection list:
  
 "westnet-eastnet-gcm": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-gcm":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-gcm":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-gcm":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-gcm":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-gcm":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-gcm":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/xfrm-algo-null-01/east.console.txt
+++ b/testing/pluto/xfrm-algo-null-01/east.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-eastnet-null": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-null":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-null":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-null":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-null":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-null":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-null":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/xfrm-algo-null-01/west.console.txt
+++ b/testing/pluto/xfrm-algo-null-01/west.console.txt
@@ -115,7 +115,7 @@ Connection list:
  
 "westnet-eastnet-null": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-null":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-null":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-null":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-null":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-null":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-null":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/xfrm-algo-null-02/east.console.txt
+++ b/testing/pluto/xfrm-algo-null-02/east.console.txt
@@ -99,7 +99,7 @@ Connection list:
  
 "westnet-eastnet-esp-null-alg": 192.0.2.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-esp-null-alg":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
-"westnet-eastnet-esp-null-alg":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-esp-null-alg":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-esp-null-alg":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-esp-null-alg":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-esp-null-alg":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;

--- a/testing/pluto/xfrm-algo-null-02/west.console.txt
+++ b/testing/pluto/xfrm-algo-null-02/west.console.txt
@@ -115,7 +115,7 @@ Connection list:
  
 "westnet-eastnet-esp-null-alg": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-esp-null-alg":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
-"westnet-eastnet-esp-null-alg":   my_updown=ipsec _updown; my_updown-config=noasync,noexec;
+"westnet-eastnet-esp-null-alg":   my_updown=PATH/libexec/ipsec/_updown.xfrm; my_updown-config=noasync,noexec;
 "westnet-eastnet-esp-null-alg":   xauth us:none, xauth them:none, my_username=[any]; their_username=[any]
 "westnet-eastnet-esp-null-alg":   our auth:rsasig, their auth:rsasig, our autheap:none, their autheap:none;
 "westnet-eastnet-esp-null-alg":   modecfg info: us:none, them:none, modecfg policy:push, dns:unset, domains:unset, cat:unset;


### PR DESCRIPTION
Instead `updown=ipsec _updown`, leading to the exec chain:

- /bin/sh -c
- ipsec
- _updown
- _updown.OS

set `updown=PATH-TO/_updown.OS` reducing things to:

- /bin/sh -c
- _updown.OS

(/bin/sh -c can be eliminated with updown-config=exec)

The result is a bit confusing.  The documentation still refers to:
```
leftupdown=ipsec _updown --route yes
```

an updown-config option might be better initially?