### PR TITLE
documentation: rpm build requires openldap-devel

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,14 @@ For Debian / Ubuntu / Mint
       libldns-dev xmlto libcurl4-openssl-dev \
       systemd-dev
 
-For Fedora/CentOS-Stream/RHEL/AlmaLinux/RockyLinux etc.
+
+For Fedora/CentOS-Stream/RHEL/AlmaLinux/RockyLinux etc.:
+
+    If you have source repositories enabled:
+
+    dnf builddep libreswan
+
+    Otherwise:
 
     dnf install audit-libs-devel bison curl-devel flex \
       gcc ldns-devel libcap-ng-devel libevent-devel \

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -26,7 +26,6 @@ override_dh_auto_build:
 		PREFIX=/usr \
 		LIBEXECDIR=/usr/libexec/ipsec \
 		MANDIR=/usr/share/man \
-		USE_LDAP=true \
 		INITSYSTEM=systemd \
 		$(ENABLE_LIBCAP_NG) \
 		$(ENABLE_SELINUX)
@@ -39,7 +38,6 @@ override_dh_auto_install-arch:
 		PREFIX=/usr \
 		LIBEXECDIR=/usr/libexec/ipsec \
 		MANDIR=/usr/share/man \
-		USE_LDAP=true \
 		INITSYSTEM=systemd \
 		$(ENABLE_LIBCAP_NG) \
 		$(ENABLE_SELINUX) \

--- a/packaging/devuan/rules
+++ b/packaging/devuan/rules
@@ -26,7 +26,6 @@ override_dh_auto_build:
 		PREFIX=/usr \
 		LIBEXECDIR=/usr/libexec/ipsec \
 		NSSDIR=/var/lib/ipsec/nss \
-		USE_LDAP=true \
 		$(ENABLE_LIBCAP_NG) \
 		$(ENABLE_SELINUX)
 
@@ -38,7 +37,6 @@ override_dh_auto_install-arch:
 		PREFIX=/usr \
 		LIBEXECDIR=/usr/libexec/ipsec \
 		NSSDIR=/var/lib/ipsec/nss \
-		USE_LDAP=true \
 		$(ENABLE_LIBCAP_NG) \
 		$(ENABLE_SELINUX) \
 		DESTDIR=$(CURDIR)/debian/libreswan

--- a/packaging/fedora/libreswan.spec
+++ b/packaging/fedora/libreswan.spec
@@ -18,7 +18,6 @@
     USE_AUTHPAM=true \\\
     USE_DNSSEC=true \\\
     USE_LABELED_IPSEC=true \\\
-    USE_LDAP=true \\\
     USE_LIBCAP_NG=true \\\
     USE_LIBCURL=true \\\
     USE_LINUX_AUDIT=true \\\


### PR DESCRIPTION
Latest versions of Debian (13), Devuan (6) and Fedora (44) are shipped with curl supporting ldap/ldaps protocols and hence we no longer need to package them direct ldap support. This is not the case for RHEL since its ubi9 and ubi10 minimal versions come with libcurl-minimal lacking ldap protocol support.

_Original description was: RHEL and Fedora specfiles contain `USE_LDAP=true` and build requires `openldap-devel`._
