### PR TITLE
feat(pluto): connection lookup  via reqid hashtable

### DIFF
--- a/programs/pluto/acquire.c
+++ b/programs/pluto/acquire.c
@@ -106,9 +106,31 @@ void initiate_ondemand(const struct kernel_acquire *b)
 		return;
 	}
 
-	struct connection *c = find_connection_for_packet(b->packet,
-							  b->sec_label,
-							  b->logger);
+	struct connection *c = NULL;
+
+	/*
+	 * Fast path: the kernel echoed our planted reqid in the
+	 * ACQUIRE tmpl
+	 */
+	if (b->policy_id != 0 && b->sec_label.len == 0) {
+		c = connection_by_reqid((reqid_t) b->policy_id);
+		if (c != NULL && !oriented(c)) {
+			/* defensive: treat as miss */
+			c = NULL;
+		}
+		if (c != NULL) {
+			ldbg(b->logger,
+			     "reqid lookup matched connection %s (policy_id "PRI_REQID")",
+			     c->name, pri_reqid((reqid_t) b->policy_id));
+		}
+	}
+
+	if (c == NULL) {
+		c = find_connection_for_packet(b->packet,
+					       b->sec_label,
+					       b->logger);
+	}
+
 	if (c == NULL) {
 		/*
 		 * No connection explicitly handles the clients and
@@ -150,6 +172,15 @@ void initiate_ondemand(const struct kernel_acquire *b)
 	whack_attach(cp, b->logger);
 	LLOG_JAMBUF(RC_LOG, cp->logger, buf) {
 		jam_kernel_acquire(buf, b);
+	}
+
+
+	if (b->by_acquire) {
+		if (cp->negotiating_child_sa != SOS_NOBODY) {
+			ldbg(cp->logger,
+			     "ACQUIRE for connection with in-progress child SA "PRI_SO": rekey already underway, ACQUIRE will be ignored",
+			     pri_so(cp->negotiating_child_sa));
+		}
 	}
 
 	const struct child_policy policy = child_sa_policy(cp);

--- a/programs/pluto/connection_db.c
+++ b/programs/pluto/connection_db.c
@@ -133,6 +133,36 @@ HASH_TABLE(connection, host_pair, , STATE_TABLE_SIZE);
 REHASH_DB_ENTRY(connection, host_pair, );
 
 /*
+ * A table hashed by child.reqid.
+ */
+
+static hash_t hash_connection_reqid(const reqid_t *reqid)
+{
+	return hash_thing(*reqid, zero_hash);
+}
+
+HASH_TABLE(connection, reqid, .child.reqid, STATE_TABLE_SIZE);
+
+REHASH_DB_ENTRY(connection, reqid, .child.reqid);
+
+struct connection *connection_by_reqid(reqid_t reqid)
+{
+	if (reqid == 0) {
+		/* sentinel: not yet assigned */
+		return NULL;
+	}
+	struct connection *c;
+	hash_t hash = hash_connection_reqid(&reqid);
+	struct list_head *bucket = hash_table_bucket(&connection_reqid_hash_table, hash);
+	FOR_EACH_LIST_ENTRY_NEW2OLD(c, bucket) {
+		if (c->child.reqid == reqid) {
+			return c;
+		}
+	}
+	return NULL;
+}
+
+/*
  * Maintain the contents of the hash tables.
  */
 
@@ -140,7 +170,8 @@ HASH_DB(connection,
 	&connection_clonedfrom_hash_table,
 	&connection_serialno_hash_table,
 	&connection_that_id_hash_table,
-	&connection_host_pair_hash_table);
+	&connection_host_pair_hash_table,
+	&connection_reqid_hash_table);
 
 /*
  * See also {new2old,old2new}_state()

--- a/programs/pluto/connections.h
+++ b/programs/pluto/connections.h
@@ -79,6 +79,7 @@ struct kernel_acquire;
  */
 
 struct connection *connection_by_serialno(co_serial_t serialno);
+struct connection *connection_by_reqid(reqid_t reqid);
 
 /*
  * IKE SA configuration.
@@ -929,6 +930,7 @@ struct connection {
 		struct list_entry that_id;
 		struct list_entry clonedfrom;
 		struct list_entry host_pair;
+		struct list_entry reqid;
 	} connection_db_entries;
 
 	struct pending *pending;
@@ -1163,6 +1165,7 @@ bool next_spd(struct spd_filter *srf);
 void replace_connection_that_id(struct connection *c, const struct id *new_id);
 void connection_db_rehash_that_id(struct connection *c);
 void connection_db_rehash_host_pair(struct connection *c);
+void connection_db_rehash_reqid(struct connection *c);
 
 void spd_db_rehash_remote_client(struct spd *sr);
 

--- a/programs/pluto/instantiate.c
+++ b/programs/pluto/instantiate.c
@@ -708,6 +708,13 @@ static struct connection *oppo_instantiate(struct connection *t,
 	PEXPECT(d->logger, oriented(d));
 	build_connection_spds_from_proposals(d);
 
+	/*
+	 * Force a unique reqid on every oppo clone, even when the
+	 * template config pinned sa_reqid.
+	 */
+	d->child.reqid = gen_reqid();
+	connection_db_rehash_reqid(d);
+
 	vdbg_connection(d, verbose, where, "%s: from %s",
 			func, t->name);
 	return d;


### PR DESCRIPTION
Add a hashtable keyed on reqid so that `initiate_ondemand()` can find the connection instead of scanning all connections with `find_connection_for_packet()` 

This PR is in continuation with #2811.
