### PR TITLE
ikev2: extend struct authby to contain rsasig_sha2 and ecdsa_sha2 fields

### DIFF
--- a/include/authby.h
+++ b/include/authby.h
@@ -31,19 +31,75 @@ struct authby {
 	bool ecdsa;
 	bool eddsa;
 	bool rsasig_v1_5;
+
+	bool rsasig_sha2_256;
+	bool rsasig_sha2_384;
+	bool rsasig_sha2_512;
+	bool ecdsa_sha2_256;
+	bool ecdsa_sha2_384;
+	bool ecdsa_sha2_512;	
 };
 
-#define AUTHBY_ALL (struct authby) { true, true, true, true, true, true, true }
-#define AUTHBY_DIGITAL_SIGNATURE (struct authby)	\
-	{						\
+#define AUTHBY_ALL (struct authby)	\
+	{								\
+		.psk = true,				\
+		.null = true,				\
+		.never = true,				\
 		.rsasig = true,				\
 		.ecdsa = true,				\
 		.eddsa = true,				\
+		.rsasig_v1_5 = true,		\
+		.rsasig_sha2_256 = true,	\
+		.rsasig_sha2_384 = true,	\
+		.rsasig_sha2_512 = true,	\
+		.ecdsa_sha2_256= true,		\
+		.ecdsa_sha2_384= true,		\
+		.ecdsa_sha2_512= true,		\
+ 	}
+
+#define AUTHBY_DIGITAL_SIGNATURE (struct authby)	\
+	{									\
+		.rsasig = true,					\
+		.ecdsa = true,					\
+		.eddsa = true,					\
 		.rsasig_v1_5 = true,			\
+		.rsasig_sha2_256 = true,		\
+		.rsasig_sha2_384 = true,		\
+		.rsasig_sha2_512 = true,		\
+		.ecdsa_sha2_256 = true,			\
+		.ecdsa_sha2_384 = true,			\
+		.ecdsa_sha2_512 = true,			\
 	}
 
 #define AUTHBY_IKEv1_DEFAULTS (struct authby) { .rsasig = true, }
-#define AUTHBY_IKEv2_DEFAULTS (struct authby) { .rsasig = true, .rsasig_v1_5 = true, .ecdsa = true, }
+#define AUTHBY_IKEv2_DEFAULTS (struct authby)	\
+	{									\
+		.rsasig = true,					\
+		.rsasig_v1_5 = true,			\
+		.ecdsa = true,					\
+		.rsasig_sha2_256 = true,		\
+		.rsasig_sha2_384 = true,		\
+		.rsasig_sha2_512 = true,		\
+		.ecdsa_sha2_256 = true,			\
+		.ecdsa_sha2_384 = true,			\
+		.ecdsa_sha2_512 = true,			\
+	}
+
+#define AUTHBY_ALL_RSASIG_SHA2 (struct authby)	\
+	{									\
+		.rsasig = true,					\
+		.rsasig_sha2_256 = true,		\
+		.rsasig_sha2_384 = true,		\
+		.rsasig_sha2_512 = true,		\
+	}
+
+#define AUTHBY_ALL_ECDSA_SHA2 (struct authby)	\
+	{									\
+		.ecdsa = true,					\
+		.ecdsa_sha2_256 = true,			\
+		.ecdsa_sha2_384 = true,			\
+		.ecdsa_sha2_512 = true,			\
+	}
 
 struct authby authby_xor(struct authby lhs, struct authby rhs);
 struct authby authby_and(struct authby lhs, struct authby rhs);
@@ -61,7 +117,9 @@ enum auth auth_from_authby(struct authby authby);
 struct authby authby_from_auth(enum auth auth);
 
 typedef struct {
-	char buf[sizeof("RSA+NULL+NEVER+RSASIG+ECDSA+RSASIG_v1_5") + 1/*canary*/];
+	char buf[sizeof("PSK+RSASIG+ECDSA+EDDSA+AUTH_NEVER+AUTH_NULL+"
+		"RSASIG_v1_5+RSASIG_SHA2_256+RSASIG_SHA2_384+RSASIG_SHA2_512+"
+		"ECDSA_SHA2_256+ECDSA_SHA2_384+ECDSA_SHA2_512") + 1/*canary*/];
 } authby_buf;
 
 const char *str_authby(struct authby authby, authby_buf *buf);

--- a/lib/libswan/authby.c
+++ b/lib/libswan/authby.c
@@ -27,7 +27,13 @@
 	 (LHS).rsasig OP			\
 	 (LHS).rsasig_v1_5 OP			\
 	 (LHS).eddsa OP				\
-	 (LHS).ecdsa)
+	 (LHS).ecdsa OP				\
+	 (LHS).rsasig_sha2_256 OP	\
+	 (LHS).rsasig_sha2_384 OP	\
+	 (LHS).rsasig_sha2_512 OP	\
+	 (LHS).ecdsa_sha2_256 OP	\
+	 (LHS).ecdsa_sha2_384 OP	\
+	 (LHS).ecdsa_sha2_512)
 
 #define OP(LHS, OP, RHS)						\
 	({								\
@@ -39,6 +45,12 @@
 			.eddsa = (LHS).eddsa OP (RHS).eddsa,		\
 			.ecdsa = (LHS).ecdsa OP (RHS).ecdsa,		\
 			.rsasig_v1_5 = (LHS).rsasig_v1_5 OP (RHS).rsasig_v1_5, \
+			.rsasig_sha2_256 = (LHS).rsasig_sha2_256 OP (RHS).rsasig_sha2_256, \
+			.rsasig_sha2_384 = (LHS).rsasig_sha2_384 OP (RHS).rsasig_sha2_384, \
+			.rsasig_sha2_512 = (LHS).rsasig_sha2_512 OP (RHS).rsasig_sha2_512, \
+			.ecdsa_sha2_256 = (LHS).ecdsa_sha2_256 OP (RHS).ecdsa_sha2_256, \
+			.ecdsa_sha2_384 = (LHS).ecdsa_sha2_384 OP (RHS).ecdsa_sha2_384, \
+			.ecdsa_sha2_512 = (LHS).ecdsa_sha2_512 OP (RHS).ecdsa_sha2_512, \
 		};							\
 		tmp_;							\
 	})
@@ -111,9 +123,20 @@ struct authby authby_from_auth(enum auth auth)
 	case AUTH_NEVER: return (struct authby) { .never = true, };
 	case AUTH_NULL: return (struct authby) { .null = true, };
 	case AUTH_PSK: return (struct authby) { .psk = true, };
-	case AUTH_ECDSA: return (struct authby) { .ecdsa = true, };
+	case AUTH_ECDSA: return (struct authby) { 
+		.ecdsa = true, 
+		.ecdsa_sha2_256 = true, 
+		.ecdsa_sha2_384 = true, 
+		.ecdsa_sha2_512 = true, 
+	};
 	case AUTH_EDDSA: return (struct authby) { .eddsa = true, };
-	case AUTH_RSASIG: return (struct authby) { .rsasig = true, .rsasig_v1_5 = true };
+	case AUTH_RSASIG: return (struct authby) { 
+		.rsasig = true, 
+		.rsasig_v1_5 = true, 
+		.rsasig_sha2_256 = true, 
+		.rsasig_sha2_384 = true, 
+		.rsasig_sha2_512 = true, 
+	};
 	case AUTH_EAPONLY: return (struct authby) {0};
 	}
 	bad_case(auth);
@@ -133,7 +156,17 @@ size_t jam_authby(struct jambuf *buf, struct authby authby)
 	const char *sep = "";
 	JAM_AUTHBY(psk, PSK);
 	JAM_AUTHBY(rsasig, RSASIG);
+	if (!authby_le(AUTHBY_ALL_RSASIG_SHA2, authby)) {
+		JAM_AUTHBY(rsasig_sha2_256, RSASIG_SHA2_256);
+		JAM_AUTHBY(rsasig_sha2_384, RSASIG_SHA2_384);
+		JAM_AUTHBY(rsasig_sha2_512, RSASIG_SHA2_512);
+	}
 	JAM_AUTHBY(ecdsa, ECDSA);
+	if (!authby_le(AUTHBY_ALL_ECDSA_SHA2, authby)) {
+		JAM_AUTHBY(ecdsa_sha2_256, ECDSA_SHA2_256);
+		JAM_AUTHBY(ecdsa_sha2_384, ECDSA_SHA2_384);
+		JAM_AUTHBY(ecdsa_sha2_512, ECDSA_SHA2_512);
+	}
 	JAM_AUTHBY(eddsa, EDDSA);
 	JAM_AUTHBY(never, AUTH_NEVER);
 	JAM_AUTHBY(null, AUTH_NULL);

--- a/programs/pluto/extract.c
+++ b/programs/pluto/extract.c
@@ -1283,11 +1283,11 @@ static diag_t extract_authby(struct authby *authby, lset_t *sighash_policy,
 
 			/* Supported for IKEv1 and IKEv2 */
 			if (hunk_streq(val, "secret")) {
-				authby->psk = true;;
+				authby->psk = true;
 			} else if (hunk_streq(val, "rsasig") ||
 				   hunk_streq(val, "rsa")) {
-				authby->rsasig = true;
 				authby->rsasig_v1_5 = true;
+				*authby = authby_or(*authby, AUTHBY_ALL_RSASIG_SHA2);
 				(*sighash_policy) |= POL_SIGHASH_SHA2_256;
 				(*sighash_policy) |= POL_SIGHASH_SHA2_384;
 				(*sighash_policy) |= POL_SIGHASH_SHA2_512;
@@ -1302,36 +1302,42 @@ static diag_t extract_authby(struct authby *authby, lset_t *sighash_policy,
 			} else if (hunk_streq(val, "rsa-sha1")) {
 				authby->rsasig_v1_5 = true;
 			} else if (hunk_streq(val, "rsa-sha2")) {
-				authby->rsasig = true;
+				*authby = authby_or(*authby, AUTHBY_ALL_RSASIG_SHA2);
 				(*sighash_policy) |= POL_SIGHASH_SHA2_256;
 				(*sighash_policy) |= POL_SIGHASH_SHA2_384;
 				(*sighash_policy) |= POL_SIGHASH_SHA2_512;
 			} else if (hunk_streq(val, "rsa-sha2_256")) {
 				authby->rsasig = true;
+				authby->rsasig_sha2_256 = true;
 				(*sighash_policy) |= POL_SIGHASH_SHA2_256;
 			} else if (hunk_streq(val, "rsa-sha2_384")) {
 				authby->rsasig = true;
+				authby->rsasig_sha2_384 = true;
 				(*sighash_policy) |= POL_SIGHASH_SHA2_384;
 			} else if (hunk_streq(val, "rsa-sha2_512")) {
 				authby->rsasig = true;
+				authby->rsasig_sha2_512 = true;
 				(*sighash_policy) |= POL_SIGHASH_SHA2_512;
 			} else if (hunk_streq(val, "eddsa")) {
 				authby->eddsa = true;
 				(*sighash_policy) |= POL_SIGHASH_IDENTITY;
 			} else if (hunk_streq(val, "ecdsa") ||
 				   hunk_streq(val, "ecdsa-sha2")) {
-				authby->ecdsa = true;
+				*authby = authby_or(*authby, AUTHBY_ALL_ECDSA_SHA2);
 				(*sighash_policy) |= POL_SIGHASH_SHA2_256;
 				(*sighash_policy) |= POL_SIGHASH_SHA2_384;
 				(*sighash_policy) |= POL_SIGHASH_SHA2_512;
 			} else if (hunk_streq(val, "ecdsa-sha2_256")) {
 				authby->ecdsa = true;
+				authby->ecdsa_sha2_256 = true;
 				(*sighash_policy) |= POL_SIGHASH_SHA2_256;
 			} else if (hunk_streq(val, "ecdsa-sha2_384")) {
 				authby->ecdsa = true;
+				authby->ecdsa_sha2_384 = true;
 				(*sighash_policy) |= POL_SIGHASH_SHA2_384;
 			} else if (hunk_streq(val, "ecdsa-sha2_512")) {
 				authby->ecdsa = true;
+				authby->ecdsa_sha2_512 = true;
 				(*sighash_policy) |= POL_SIGHASH_SHA2_512;
 			} else if (hunk_streq(val, "ecdsa-sha1")) {
 				return diag("authby=ecdsa cannot use sha1, only sha2");
@@ -1843,6 +1849,9 @@ static diag_t extract_host_end(enum end end,
 		 */
 		authby = authby_from_auth(auth);
 		authby.rsasig_v1_5 = false; /* not supported */
+		authby.rsasig_sha2_256 = false; /* not supported */
+		authby.rsasig_sha2_384 = false; /* not supported */
+		authby.rsasig_sha2_512 = false; /* not supported */
 		/*
 		 * Now compare the rebuilt AUTH with the original
 		 * WHACK_AUTH, looking for auth bits that disappeared.
@@ -1850,7 +1859,14 @@ static diag_t extract_host_end(enum end end,
 		struct authby exclude = authby_not(authby);
 		struct authby supplied = whack_authby;
 		supplied.rsasig_v1_5 = false;
+		supplied.rsasig_sha2_256 = false;
+		supplied.rsasig_sha2_384 = false;
+		supplied.rsasig_sha2_512 = false;
 		supplied.ecdsa = false;
+		supplied.ecdsa_sha2_256 = false;
+		supplied.ecdsa_sha2_384 = false;
+		supplied.ecdsa_sha2_512 = false;
+		supplied.eddsa = false;
 		struct authby unexpected = authby_and(supplied, exclude);
 		if (authby_is_set(unexpected)) {
 			authby_buf wb, ub;

--- a/programs/pluto/whack_connectionstatus.c
+++ b/programs/pluto/whack_connectionstatus.c
@@ -605,6 +605,9 @@ static void show_connection_status(struct show *s, const struct connection *c)
 			struct authby expect = authby_from_auth(end->auth);
 			struct authby mask = (oriented(c) && end == c->local->host.config ? expect : AUTHBY_ALL);
 			expect.rsasig_v1_5 = false;
+			expect.rsasig_sha2_256 = false;
+			expect.rsasig_sha2_384 = false;
+			expect.rsasig_sha2_512 = false;
 			struct authby authby = authby_and(end->authby, mask);
 			if (authby_eq(authby, expect)) {
 				jam_enum_human(buf, &auth_names, end->auth);

--- a/testing/pluto/addconn-22-authby-hash-algo/west.console.txt
+++ b/testing/pluto/addconn-22-authby-hash-algo/west.console.txt
@@ -66,11 +66,11 @@ west #
 "ecdsa,rsa":   v2-auth-hash-policy: SHA2_256+SHA2_384+SHA2_512;
 "ecdsa-sha2":   policy: IKEv2+ECDSA+ENCRYPT+TUNNEL+PFS+IKE_FRAG_ALLOW+ESN_NO+ESN_YES;
 "ecdsa-sha2":   v2-auth-hash-policy: SHA2_256+SHA2_384+SHA2_512;
-"ecdsa-sha2_256":   policy: IKEv2+ECDSA+ENCRYPT+TUNNEL+PFS+IKE_FRAG_ALLOW+ESN_NO+ESN_YES;
+"ecdsa-sha2_256":   policy: IKEv2+ECDSA+ECDSA_SHA2_256+ENCRYPT+TUNNEL+PFS+IKE_FRAG_ALLOW+ESN_NO+ESN_YES;
 "ecdsa-sha2_256":   v2-auth-hash-policy: SHA2_256;
-"ecdsa-sha2_384":   policy: IKEv2+ECDSA+ENCRYPT+TUNNEL+PFS+IKE_FRAG_ALLOW+ESN_NO+ESN_YES;
+"ecdsa-sha2_384":   policy: IKEv2+ECDSA+ECDSA_SHA2_384+ENCRYPT+TUNNEL+PFS+IKE_FRAG_ALLOW+ESN_NO+ESN_YES;
 "ecdsa-sha2_384":   v2-auth-hash-policy: SHA2_384;
-"ecdsa-sha2_512":   policy: IKEv2+ECDSA+ENCRYPT+TUNNEL+PFS+IKE_FRAG_ALLOW+ESN_NO+ESN_YES;
+"ecdsa-sha2_512":   policy: IKEv2+ECDSA+ECDSA_SHA2_512+ENCRYPT+TUNNEL+PFS+IKE_FRAG_ALLOW+ESN_NO+ESN_YES;
 "ecdsa-sha2_512":   v2-auth-hash-policy: SHA2_512;
 "eddsa":   policy: IKEv2+EDDSA+ENCRYPT+TUNNEL+PFS+IKE_FRAG_ALLOW+ESN_NO+ESN_YES;
 "eddsa":   v2-auth-hash-policy: IDENTITY;
@@ -80,11 +80,11 @@ west #
 "rsa-sha1":   v2-auth-hash-policy: none;
 "rsa-sha2":   policy: IKEv2+RSASIG+ENCRYPT+TUNNEL+PFS+IKE_FRAG_ALLOW+ESN_NO+ESN_YES;
 "rsa-sha2":   v2-auth-hash-policy: SHA2_256+SHA2_384+SHA2_512;
-"rsa-sha2_256":   policy: IKEv2+RSASIG+ENCRYPT+TUNNEL+PFS+IKE_FRAG_ALLOW+ESN_NO+ESN_YES;
+"rsa-sha2_256":   policy: IKEv2+RSASIG+RSASIG_SHA2_256+ENCRYPT+TUNNEL+PFS+IKE_FRAG_ALLOW+ESN_NO+ESN_YES;
 "rsa-sha2_256":   v2-auth-hash-policy: SHA2_256;
-"rsa-sha2_384":   policy: IKEv2+RSASIG+ENCRYPT+TUNNEL+PFS+IKE_FRAG_ALLOW+ESN_NO+ESN_YES;
+"rsa-sha2_384":   policy: IKEv2+RSASIG+RSASIG_SHA2_384+ENCRYPT+TUNNEL+PFS+IKE_FRAG_ALLOW+ESN_NO+ESN_YES;
 "rsa-sha2_384":   v2-auth-hash-policy: SHA2_384;
-"rsa-sha2_512":   policy: IKEv2+RSASIG+ENCRYPT+TUNNEL+PFS+IKE_FRAG_ALLOW+ESN_NO+ESN_YES;
+"rsa-sha2_512":   policy: IKEv2+RSASIG+RSASIG_SHA2_512+ENCRYPT+TUNNEL+PFS+IKE_FRAG_ALLOW+ESN_NO+ESN_YES;
 "rsa-sha2_512":   v2-auth-hash-policy: SHA2_512;
 west #
  # these should fail to load


### PR DESCRIPTION
Extend authby struct to include SHA-2 hashes for both ecdsa and rsasig.

Add AUTHBY_ALL_RSASIG_SHA2 and AUTHBY_ALL_ECDSA_SHA2 macros, used in jam_authby() and extract_authby().

Update authby_buf size to hold the new maximum length.

Update addconn-22-authby-hash-algo output.

close #2840 