### PR TITLE
RFC 9611 - per-CPU Child SA

### DIFF
--- a/programs/pluto/ikev2_child.c
+++ b/programs/pluto/ikev2_child.c
@@ -71,6 +71,7 @@
 #include "ikev2_ke.h"
 #include "ikev2_auth.h"
 #include "terminate.h"
+#include "ikev2_create_child_sa.h"
 
 static bool emit_v2_child_response_payloads(struct ike_sa *ike,
 					    const struct child_sa *child,
@@ -292,6 +293,16 @@ bool emit_v2_child_request_payloads(const struct ike_sa *ike,
 	if (cc->config->child.send.esp_tfc_padding_not_supported &&
 	    !emit_v2N(v2N_ESP_TFC_PADDING_NOT_SUPPORTED, pbs)) {
 		return false;
+	}
+
+	/* SA_RESOURCE_INFO for Additional Child SAs (RFC 9611) */
+	if (!ike_auth_exchange &&
+	    larval_child->sa.st_v2_resource_info.cpu_id != CPU_ID_NONE) {
+		ldbg(logger, "sending SA_RESOURCE_INFO for Additional Child SA (cpu=%u)",
+		     larval_child->sa.st_v2_resource_info.cpu_id);
+		if (!emit_v2N(v2N_SA_RESOURCE_INFO, pbs)) {
+			return false;
+		}
 	}
 
 	return true;
@@ -1085,6 +1096,24 @@ static v2_notification_t process_v2_IKE_AUTH_request_child_sa_payloads(struct ik
 		return n;
 	}
 
+	/* Check if initiator supports per-CPU Child SAs (RFC 9611) */
+	if (md->pd[PD_v2N_SA_RESOURCE_INFO] != NULL) {
+		child->sa.st_v2_resource_info.state = RESOURCE_INFO_RECV;
+		ldbg(child->sa.logger, "initiator supports per-CPU Child SAs");
+
+		/* Send SA_RESOURCE_INFO back if wanted for the connection */
+		struct connection *c = child->sa.st_connection;
+		if (c->config->child.clones.nr > 0) {
+			llog(RC_LOG, child->sa.logger, "sending SA_RESOURCE_INFO (clones=%u)",
+			     c->config->child.clones.nr);
+			if (!emit_v2N(v2N_SA_RESOURCE_INFO, sk_pbs)) {
+				return v2N_INVALID_SYNTAX;
+			}
+			child->sa.st_v2_resource_info.state = RESOURCE_INFO_DONE;
+			llog_sa(RC_LOG, child, "per-CPU SA negotiation complete");
+		}
+	}
+
 	return v2N_NOTHING_WRONG;
 }
 
@@ -1194,6 +1223,36 @@ v2_notification_t process_v2_IKE_AUTH_response_child_payloads(struct ike_sa *ike
 	 */
 	set_larval_v2_transition(child, &state_v2_ESTABLISHED_CHILD_SA, HERE);
 
+	/* Check if responder supports per-CPU Child SAs (RFC 9611) */
+	if (response_md->pd[PD_v2N_SA_RESOURCE_INFO] != NULL) {
+		passert(child->sa.st_v2_resource_info.state == RESOURCE_INFO_SENT);
+		child->sa.st_v2_resource_info.state = RESOURCE_INFO_DONE;
+		llog_sa(RC_LOG, child, "per-CPU child SA negotiation complete");
+
+		/* Note: this Child SA is the Initial SA */
+
+		/* Create Additional Child SAs */
+		unsigned int num_additional_sas = child->sa.st_connection->config->child.clones.nr;
+		unsigned int num_to_create = (num_additional_sas < MAX_ADDITIONAL_SAS) ? num_additional_sas : MAX_ADDITIONAL_SAS;
+
+		if (num_to_create < num_additional_sas) {
+			llog_sa(RC_LOG, child,
+				"Additional Child SAs count reduced from %u to %u (limit)",
+				num_additional_sas, MAX_ADDITIONAL_SAS);
+		}
+
+		for (unsigned int i = 0; i < num_to_create; i++) {
+			llog_sa(RC_LOG, child, "creating Additional Child SA %u", i);
+			submit_v2_CREATE_CHILD_SA_additional_child(ike, child, i);
+		}
+
+	} else {
+		if (child->sa.st_v2_resource_info.state == RESOURCE_INFO_SENT) {
+			llog_sa(RC_LOG, child, "peer does not support per-CPU child SA");
+
+		}
+	}
+
 	/*
 	 * Was there an error notification for the Child SA in the
 	 * response?  The RFC says this list isn't definitive.
@@ -1243,6 +1302,17 @@ v2_notification_t process_v2_IKE_AUTH_response_child_payloads(struct ike_sa *ike
 			/* handled */
 			return n;
 		}
+	}
+
+	/*
+	 * Check TS_MAX_QUEUE from responder (RFC 9611)
+	 *
+	 * This means the responder reached its limit for number of Additional
+	 * Child SA - no more Additional SAs.
+	 */
+	if (response_md->pd[PD_v2N_TS_MAX_QUEUE] != NULL) {
+		llog_sa(RC_LOG, child,
+			"responder reached maximum Additional Child SAs");
 	}
 
 	/*

--- a/programs/pluto/ikev2_child.c
+++ b/programs/pluto/ikev2_child.c
@@ -830,6 +830,28 @@ void v2_child_sa_established(struct ike_sa *ike, struct child_sa *child)
 	     pri_so(child->sa.st_serialno),
 	     child->sa.st_connection->name);
 	unpend(ike, child->sa.st_connection);
+
+	/* If this is a rekeyed Initial SA... (RFC 9611) */
+	if (child->sa.st_v2_rekey_pred != SOS_NOBODY) {
+		struct child_sa *predecessor = child_sa_by_serialno(child->sa.st_v2_rekey_pred);
+		if (predecessor != NULL &&
+		    predecessor->sa.st_v2_resource_info.cpu_id == CPU_ID_NONE &&
+		    predecessor->sa.st_v2_resource_info.state == RESOURCE_INFO_DONE &&
+		    child->sa.st_connection->config->child.clones.nr > 0) {
+			llog_sa(RC_LOG, child, "Initial Child SA rekeyed - recreating %u Additional Child SAs",
+				child->sa.st_connection->config->child.clones.nr);
+
+			/* RESOURCE_INFO negotiation already happened (CPU_ID_NONE set already) */
+			child->sa.st_v2_resource_info.state = RESOURCE_INFO_DONE;
+
+			/* Recreate Additional SAs for new Initial SA */
+			unsigned int num_additional_sas = child->sa.st_connection->config->child.clones.nr;
+			for (unsigned int i = 0; i < num_additional_sas; i++) {
+				llog_sa(RC_LOG, child, "creating Additional Child SA %u for rekeyed Initial SA", i);
+				submit_v2_CREATE_CHILD_SA_additional_child(ike, child, i);
+			}
+		}
+	}
 }
 
 v2_notification_t process_v2_child_response_payloads(struct ike_sa *ike, struct child_sa *child,

--- a/programs/pluto/ikev2_child.c
+++ b/programs/pluto/ikev2_child.c
@@ -833,6 +833,28 @@ void v2_child_sa_established(struct ike_sa *ike, struct child_sa *child)
 	     pri_so(child->sa.st_serialno),
 	     child->sa.st_connection->name);
 	unpend(ike, child->sa.st_connection);
+
+	/* If this is a rekeyed Initial SA... (RFC 9611) */
+	if (child->sa.st_v2_rekey_pred != SOS_NOBODY) {
+		struct child_sa *predecessor = child_sa_by_serialno(child->sa.st_v2_rekey_pred);
+		if (predecessor != NULL &&
+		    predecessor->sa.st_v2_resource_info.cpu_id == CPU_ID_NONE &&
+		    predecessor->sa.st_v2_resource_info.state == RESOURCE_INFO_DONE &&
+		    child->sa.st_connection->config->child.clones.nr > 0) {
+			llog_sa(RC_LOG, child, "Initial Child SA rekeyed - recreating %u Additional Child SAs",
+				child->sa.st_connection->config->child.clones.nr);
+
+			/* RESOURCE_INFO negotiation already happened (CPU_ID_NONE set already) */
+			child->sa.st_v2_resource_info.state = RESOURCE_INFO_DONE;
+
+			/* Recreate Additional SAs for new Initial SA */
+			unsigned int num_additional_sas = child->sa.st_connection->config->child.clones.nr;
+			for (unsigned int i = 0; i < num_additional_sas; i++) {
+				llog_sa(RC_LOG, child, "creating Additional Child SA %u for rekeyed Initial SA", i);
+				submit_v2_CREATE_CHILD_SA_additional_child(ike, child, i);
+			}
+		}
+	}
 }
 
 v2_notification_t process_v2_child_response_payloads(struct ike_sa *ike, struct child_sa *child,

--- a/programs/pluto/ikev2_child.c
+++ b/programs/pluto/ikev2_child.c
@@ -584,6 +584,12 @@ bool emit_v2_child_response_payloads(struct ike_sa *ike,
 		return false;
 	}
 
+	/* Echo SA_RESOURCE_INFO for Additional Child SAs (RFC 9611) */
+	if (larval_child->sa.st_v2_resource_info.cpu_id != CPU_ID_NONE &&
+	    !emit_v2N(v2N_SA_RESOURCE_INFO, outpbs)) {
+		return false;
+	}
+
 	return true;
 }
 

--- a/programs/pluto/ikev2_child.c
+++ b/programs/pluto/ikev2_child.c
@@ -815,7 +815,13 @@ void v2_child_sa_established(struct ike_sa *ike, struct child_sa *child)
 
 	llog_v2_child_sa_established(ike, child);
 
-	schedule_v2_replace_event(&child->sa);
+	/*
+	 * Only Initial Child SA (RFC 9611) is scheduled for rekey, Additional Child SA
+	 * are tied to their Initial.
+	 */
+	if (child->sa.st_v2_resource_info.cpu_id == CPU_ID_NONE) {
+		schedule_v2_replace_event(&child->sa);
+	}
 
 	/*
 	 * start liveness checks if set, making sure we only schedule
@@ -834,8 +840,13 @@ void v2_child_sa_established(struct ike_sa *ike, struct child_sa *child)
 	     child->sa.st_connection->name);
 	unpend(ike, child->sa.st_connection);
 
-	/* If this is a rekeyed Initial SA... (RFC 9611) */
-	if (child->sa.st_v2_rekey_pred != SOS_NOBODY) {
+	/*
+	 * If this is a rekeyed Initial SA, recreate Additional SAs (RFC 9611).
+	 *
+	 * Note: Only the rekey initiator does this (the responder handles the requests).
+	 */
+	if (child->sa.st_sa_role == SA_INITIATOR &&
+	    child->sa.st_v2_rekey_pred != SOS_NOBODY) {
 		struct child_sa *predecessor = child_sa_by_serialno(child->sa.st_v2_rekey_pred);
 		if (predecessor != NULL &&
 		    predecessor->sa.st_v2_resource_info.cpu_id == CPU_ID_NONE &&

--- a/programs/pluto/ikev2_child.c
+++ b/programs/pluto/ikev2_child.c
@@ -71,6 +71,7 @@
 #include "ikev2_ke.h"
 #include "ikev2_auth.h"
 #include "terminate.h"
+#include "ikev2_create_child_sa.h"
 
 static bool emit_v2_child_response_payloads(struct ike_sa *ike,
 					    const struct child_sa *child,
@@ -292,6 +293,16 @@ bool emit_v2_child_request_payloads(const struct ike_sa *ike,
 	if (cc->config->child.send.esp_tfc_padding_not_supported &&
 	    !emit_v2N(v2N_ESP_TFC_PADDING_NOT_SUPPORTED, pbs)) {
 		return false;
+	}
+
+	/* SA_RESOURCE_INFO for Additional Child SAs (RFC 9611) */
+	if (!ike_auth_exchange &&
+	    larval_child->sa.st_v2_resource_info.cpu_id != CPU_ID_NONE) {
+		ldbg(logger, "sending SA_RESOURCE_INFO for Additional Child SA (cpu=%u)",
+		     larval_child->sa.st_v2_resource_info.cpu_id);
+		if (!emit_v2N(v2N_SA_RESOURCE_INFO, pbs)) {
+			return false;
+		}
 	}
 
 	return true;
@@ -1091,6 +1102,24 @@ static v2_notification_t process_v2_IKE_AUTH_request_child_sa_payloads(struct ik
 		return n;
 	}
 
+	/* Check if initiator supports per-CPU Child SAs (RFC 9611) */
+	if (md->pd[PD_v2N_SA_RESOURCE_INFO] != NULL) {
+		child->sa.st_v2_resource_info.state = RESOURCE_INFO_RECV;
+		ldbg(child->sa.logger, "initiator supports per-CPU Child SAs");
+
+		/* Send SA_RESOURCE_INFO back if wanted for the connection */
+		struct connection *c = child->sa.st_connection;
+		if (c->config->child.clones.nr > 0) {
+			llog(RC_LOG, child->sa.logger, "sending SA_RESOURCE_INFO (clones=%u)",
+			     c->config->child.clones.nr);
+			if (!emit_v2N(v2N_SA_RESOURCE_INFO, sk_pbs)) {
+				return v2N_INVALID_SYNTAX;
+			}
+			child->sa.st_v2_resource_info.state = RESOURCE_INFO_DONE;
+			llog_sa(RC_LOG, child, "per-CPU SA negotiation complete");
+		}
+	}
+
 	return v2N_NOTHING_WRONG;
 }
 
@@ -1200,6 +1229,36 @@ v2_notification_t process_v2_IKE_AUTH_response_child_payloads(struct ike_sa *ike
 	 */
 	set_larval_v2_transition(child, &state_v2_ESTABLISHED_CHILD_SA, HERE);
 
+	/* Check if responder supports per-CPU Child SAs (RFC 9611) */
+	if (response_md->pd[PD_v2N_SA_RESOURCE_INFO] != NULL) {
+		passert(child->sa.st_v2_resource_info.state == RESOURCE_INFO_SENT);
+		child->sa.st_v2_resource_info.state = RESOURCE_INFO_DONE;
+		llog_sa(RC_LOG, child, "per-CPU child SA negotiation complete");
+
+		/* Note: this Child SA is the Initial SA */
+
+		/* Create Additional Child SAs */
+		unsigned int num_additional_sas = child->sa.st_connection->config->child.clones.nr;
+		unsigned int num_to_create = (num_additional_sas < MAX_ADDITIONAL_SAS) ? num_additional_sas : MAX_ADDITIONAL_SAS;
+
+		if (num_to_create < num_additional_sas) {
+			llog_sa(RC_LOG, child,
+				"Additional Child SAs count reduced from %u to %u (limit)",
+				num_additional_sas, MAX_ADDITIONAL_SAS);
+		}
+
+		for (unsigned int i = 0; i < num_to_create; i++) {
+			llog_sa(RC_LOG, child, "creating Additional Child SA %u", i);
+			submit_v2_CREATE_CHILD_SA_additional_child(ike, child, i);
+		}
+
+	} else {
+		if (child->sa.st_v2_resource_info.state == RESOURCE_INFO_SENT) {
+			llog_sa(RC_LOG, child, "peer does not support per-CPU child SA");
+
+		}
+	}
+
 	/*
 	 * Assume reaching here with an error notification means that
 	 * the Child SA failed (error notifications intended for the
@@ -1238,6 +1297,17 @@ v2_notification_t process_v2_IKE_AUTH_response_child_payloads(struct ike_sa *ike
 		ike->sa.st_v2_msgid_windows.initiator.wip_sa = child = NULL;
 		/* handled */
 		return error;
+	}
+
+	/*
+	 * Check TS_MAX_QUEUE from responder (RFC 9611)
+	 *
+	 * This means the responder reached its limit for number of Additional
+	 * Child SA - no more Additional SAs.
+	 */
+	if (response_md->pd[PD_v2N_TS_MAX_QUEUE] != NULL) {
+		llog_sa(RC_LOG, child,
+			"responder reached maximum Additional Child SAs");
 	}
 
 	/*

--- a/programs/pluto/ikev2_create_child_sa.c
+++ b/programs/pluto/ikev2_create_child_sa.c
@@ -532,6 +532,55 @@ struct child_sa *submit_v2_CREATE_CHILD_SA_rekey_child(struct ike_sa *ike,
 	return larval_child;
 }
 
+/*
+ * Create Additional Child SA (RFC 9611)
+ *
+ * Creates an Additional Child SA with identical Traffic Selectors as
+ * the Initial SA but bound to a specific CPU via cpu_id. Both TS and
+ * proposals are re-used. Lifetime is synchornized with the Initial SA.
+ */
+struct child_sa *submit_v2_CREATE_CHILD_SA_additional_child(struct ike_sa *ike,
+							      struct child_sa *initial_sa,
+							      uint32_t cpu_id)
+{
+	ldbg(ike->sa.logger, "initiating Additional Child SA (cpu=%u)", cpu_id);
+
+	struct child_sa *larval_child = new_v2_child_sa(initial_sa->sa.st_connection, ike, CHILD_SA,
+							 SA_INITIATOR,
+							 STATE_V2_REKEY_CHILD_I0);
+	whack_attach(&larval_child->sa, initial_sa->sa.logger);
+	struct verbose verbose = VERBOSE(DEBUG_STREAM, larval_child->sa.logger, NULL);
+
+	free_chunk_content(&larval_child->sa.st_ni);
+	free_chunk_content(&larval_child->sa.st_nr);
+
+	/* Mark as Additional SA (ie. cpu_id != CPU_ID_NONE) */
+	larval_child->sa.st_v2_resource_info.cpu_id = cpu_id;
+	larval_child->sa.st_v2_resource_info.state = RESOURCE_INFO_DONE;
+
+	/* Use same policy and proposals as Initial SA */
+	larval_child->sa.st_policy = capture_child_rekey_policy(&initial_sa->sa);
+	larval_child->sa.st_v2_create_child_sa_proposals =
+		get_v2_CREATE_CHILD_SA_new_child_proposals(ike, larval_child, verbose);
+	larval_child->sa.st_pfs_kem =
+		ikev2_proposals_first_kem(larval_child->sa.st_v2_create_child_sa_proposals, verbose);
+
+	/* Synchronize lifetime with Initial SA */
+	larval_child->sa.st_replace_margin = initial_sa->sa.st_replace_margin;
+
+	ldbg(larval_child->sa.logger,
+	     "submitting crypto for Additional Child SA (cpu=%u) using IKE SA "PRI_SO,
+	     cpu_id, pri_so(ike->sa.st_serialno));
+
+	submit_ke_and_nonce(&larval_child->sa, &larval_child->sa, NULL,
+			    larval_child->sa.st_pfs_kem,
+			    queue_v2_CREATE_CHILD_SA_new_child_request,
+			    false, HERE);
+
+	return larval_child;
+}
+
+
 void llog_success_initiate_v2_CREATE_CHILD_SA_child_request(struct ike_sa *ike,
 							    const struct msg_digest *md)
 {
@@ -823,6 +872,78 @@ stf_status initiate_v2_CREATE_CHILD_SA_rekey_child_request(struct ike_sa *ike,
 	return STF_OK; /* IKE */
 }
 
+/*
+ * Get number of Additional Child SAs for this connection (RFC 9611)
+ *
+ * Note: Any SA with cpu_id != CPU_ID_NONE is Additional
+ */
+static uint32_t count_additional_sas(struct connection *c)
+{
+	uint32_t count = 0;
+	struct state_filter sf = {
+		.connection_serialno = c->serialno,
+		.search = {
+			.order = NEW2OLD,
+			.where = HERE,
+		},
+	};
+
+	while (next_state(&sf)) {
+		struct child_sa *child = IS_CHILD_SA(sf.st) ? pexpect_child_sa(sf.st) : NULL;
+		if (child != NULL &&
+		    child->sa.st_v2_resource_info.cpu_id != CPU_ID_NONE) {
+			count++;
+		}
+	}
+
+	return count;
+}
+
+/*
+ * Find first unused CPU (RFC 9611)
+ *
+ * Notes:
+ *
+ *  - once all CPUs are used, round-robin follows
+ *  - no load-balancing between connections
+ *
+ */
+static uint32_t assign_least_loaded_cpu(struct connection *c, uint32_t sa_index)
+{
+	uint32_t clones_nr = c->config->child.clones.nr;
+	uint32_t actual_cpus = nr_processors_online();
+	uint32_t num_cpus = (clones_nr < actual_cpus) ? clones_nr : actual_cpus;
+	bool used[MAX_ADDITIONAL_SAS] = {false};
+
+	/* Mark which CPU IDs are in use for this connection */
+	struct state_filter sf = {
+		.connection_serialno = c->serialno,
+		.search = {
+			.order = NEW2OLD,
+			.where = HERE,
+		},
+	};
+
+	while (next_state(&sf)) {
+		struct child_sa *child = IS_CHILD_SA(sf.st) ? pexpect_child_sa(sf.st) : NULL;
+		if (child != NULL &&
+		    child->sa.st_v2_resource_info.cpu_id != CPU_ID_NONE &&
+		    child->sa.st_v2_resource_info.cpu_id < num_cpus) {
+			used[child->sa.st_v2_resource_info.cpu_id] = true;
+		}
+	}
+
+	uint32_t cpu_id;
+	for (cpu_id = 0; cpu_id < num_cpus; cpu_id++) {
+		if (!used[cpu_id]) {
+			return cpu_id;
+		}
+	}
+
+	/* All CPUs are used - use round-robin (normal when multiple SAs per CPU) */
+	return sa_index % num_cpus;
+}
+
 stf_status process_v2_CREATE_CHILD_SA_rekey_child_request(struct ike_sa *ike,
 							  struct child_sa *unused_child,
 							  struct msg_digest *md)
@@ -854,12 +975,39 @@ stf_status process_v2_CREATE_CHILD_SA_rekey_child_request(struct ike_sa *ike,
 		get_v2_CREATE_CHILD_SA_rekey_child_proposals(ike, predecessor, verbose);
 
 	if (!verify_rekey_child_request_ts(larval_child, md)) {
-		record_v2N_response(ike->sa.logger, ike, md,
-				    v2N_TS_UNACCEPTABLE, empty_shunk/*no data*/,
-				    ENCRYPTED_PAYLOAD);
-		delete_child_sa(&larval_child);
-		ike->sa.st_v2_msgid_windows.responder.wip_sa = NULL;
-		return STF_OK; /*IKE*/
+
+		/* Check if this is an Additional SA request (RFC 9611) */
+		if (md->pd[PD_v2N_SA_RESOURCE_INFO] != NULL &&
+		    ike->sa.st_v2_resource_info.state == RESOURCE_INFO_DONE) {
+			ldbg(ike->sa.logger, "duplicate TS allowed for Additional Child SA");
+			larval_child->sa.st_v2_resource_info.state = RESOURCE_INFO_DONE;
+
+			/* Limit Additional Child SAs, reject more with TS_MAX_QUEUE */
+			uint32_t count = count_additional_sas(larval_child->sa.st_connection);
+			if (count >= MAX_ADDITIONAL_SAS) {
+				llog_sa(RC_LOG, larval_child,
+					"refusing Additional Child SA %u (Dlimit=%u)",
+					count + 1, MAX_ADDITIONAL_SAS);
+				record_v2N_response(ike->sa.logger, ike, md,
+						   v2N_TS_MAX_QUEUE, empty_shunk,
+						   ENCRYPTED_PAYLOAD);
+				delete_child_sa(&larval_child);
+				ike->sa.st_v2_msgid_windows.responder.wip_sa = NULL;
+				return STF_OK;
+			}
+
+			larval_child->sa.st_v2_resource_info.cpu_id = assign_least_loaded_cpu(larval_child->sa.st_connection, count);
+
+			ldbg(larval_child->sa.logger,
+			     "assigned Additional Child SA %u to CPU %u",
+			     count, larval_child->sa.st_v2_resource_info.cpu_id);
+		} else {
+			record_v2N_response(ike->sa.logger, ike, md,
+				v2N_TS_UNACCEPTABLE, empty_shunk/*no data*/, ENCRYPTED_PAYLOAD);
+			delete_child_sa(&larval_child);
+			ike->sa.st_v2_msgid_windows.responder.wip_sa = NULL;
+			return STF_OK; /*IKE*/
+		}
 	}
 
 	return process_v2_CREATE_CHILD_SA_request(ike, larval_child, md);

--- a/programs/pluto/ikev2_create_child_sa.c
+++ b/programs/pluto/ikev2_create_child_sa.c
@@ -588,6 +588,7 @@ struct child_sa *submit_v2_CREATE_CHILD_SA_additional_child(struct ike_sa *ike,
 	/* Mark as Additional SA (ie. cpu_id != CPU_ID_NONE) */
 	larval_child->sa.st_v2_resource_info.cpu_id = cpu_id;
 	larval_child->sa.st_v2_resource_info.state = RESOURCE_INFO_DONE;
+	larval_child->sa.st_v2_resource_info.initial_sa = initial_sa->sa.st_serialno;
 
 	/* Use same policy and proposals as Initial SA */
 	larval_child->sa.st_policy = capture_child_rekey_policy(&initial_sa->sa);
@@ -1028,6 +1029,7 @@ stf_status process_v2_CREATE_CHILD_SA_rekey_child_request(struct ike_sa *ike,
 			}
 
 			larval_child->sa.st_v2_resource_info.cpu_id = assign_least_loaded_cpu(larval_child->sa.st_connection, count);
+			larval_child->sa.st_v2_resource_info.initial_sa = larval_child->sa.st_connection->established_child_sa;
 
 			ldbg(larval_child->sa.logger,
 			     "assigned Additional Child SA %u to CPU %u",
@@ -1305,13 +1307,46 @@ stf_status process_v2_CREATE_CHILD_SA_new_child_request(struct ike_sa *ike,
 	}
 
 	if (!process_v2TS_request_payloads(ike, larval_child, md)) {
-		/* already logged */
-		record_v2N_response(larval_child->sa.logger, ike, md,
-				    v2N_TS_UNACCEPTABLE, empty_shunk/*no-data*/,
-				    ENCRYPTED_PAYLOAD);
-		delete_child_sa(&larval_child);
-		ike->sa.st_v2_msgid_windows.responder.wip_sa = NULL;
-		return STF_OK; /*IKE*/
+		/* Check if this is an Additional SA request (RFC 9611) */
+		if (md->pd[PD_v2N_SA_RESOURCE_INFO] != NULL &&
+		    larval_child->sa.st_connection->config->child.clones.nr > 0) {
+			ldbg(ike->sa.logger, "duplicate TS allowed for Additional Child SA");
+		} else {
+			/* already logged */
+			record_v2N_response(larval_child->sa.logger, ike, md,
+					    v2N_TS_UNACCEPTABLE, empty_shunk/*no-data*/,
+					    ENCRYPTED_PAYLOAD);
+			delete_child_sa(&larval_child);
+			ike->sa.st_v2_msgid_windows.responder.wip_sa = NULL;
+			return STF_OK; /*IKE*/
+		}
+	}
+
+	/* Handle SA_RESOURCE_INFO for Additional Child SAs (RFC 9611) */
+	if (md->pd[PD_v2N_SA_RESOURCE_INFO] != NULL &&
+	    larval_child->sa.st_connection->config->child.clones.nr > 0) {
+		larval_child->sa.st_v2_resource_info.state = RESOURCE_INFO_DONE;
+
+		uint32_t count = count_additional_sas(larval_child->sa.st_connection);
+		if (count >= MAX_ADDITIONAL_SAS) {
+			llog_sa(RC_LOG, larval_child,
+				"refusing Additional Child SA %u (limit=%u)",
+				count + 1, MAX_ADDITIONAL_SAS);
+			record_v2N_response(ike->sa.logger, ike, md,
+					   v2N_TS_MAX_QUEUE, empty_shunk,
+					   ENCRYPTED_PAYLOAD);
+			delete_child_sa(&larval_child);
+			ike->sa.st_v2_msgid_windows.responder.wip_sa = NULL;
+			return STF_OK;
+		}
+
+		larval_child->sa.st_v2_resource_info.cpu_id = assign_least_loaded_cpu(larval_child->sa.st_connection, count);
+		larval_child->sa.st_v2_resource_info.initial_sa = larval_child->sa.st_connection->established_child_sa;
+
+		ldbg(larval_child->sa.logger,
+		     "assigned Additional Child SA %u to CPU %u (initial_sa="PRI_SO")",
+		     count, larval_child->sa.st_v2_resource_info.cpu_id,
+		     pri_so(larval_child->sa.st_v2_resource_info.initial_sa));
 	}
 
 	return process_v2_CREATE_CHILD_SA_request(ike, larval_child, md);

--- a/programs/pluto/ikev2_create_child_sa.c
+++ b/programs/pluto/ikev2_create_child_sa.c
@@ -563,6 +563,55 @@ struct child_sa *submit_v2_CREATE_CHILD_SA_rekey_child(struct ike_sa *ike,
 	return larval_child;
 }
 
+/*
+ * Create Additional Child SA (RFC 9611)
+ *
+ * Creates an Additional Child SA with identical Traffic Selectors as
+ * the Initial SA but bound to a specific CPU via cpu_id. Both TS and
+ * proposals are re-used. Lifetime is synchornized with the Initial SA.
+ */
+struct child_sa *submit_v2_CREATE_CHILD_SA_additional_child(struct ike_sa *ike,
+							      struct child_sa *initial_sa,
+							      uint32_t cpu_id)
+{
+	ldbg(ike->sa.logger, "initiating Additional Child SA (cpu=%u)", cpu_id);
+
+	struct child_sa *larval_child = new_v2_child_sa(initial_sa->sa.st_connection, ike, CHILD_SA,
+							 SA_INITIATOR,
+							 STATE_V2_REKEY_CHILD_I0);
+	whack_attach(&larval_child->sa, initial_sa->sa.logger);
+	struct verbose verbose = VERBOSE(DEBUG_STREAM, larval_child->sa.logger, NULL);
+
+	free_chunk_content(&larval_child->sa.st_ni);
+	free_chunk_content(&larval_child->sa.st_nr);
+
+	/* Mark as Additional SA (ie. cpu_id != CPU_ID_NONE) */
+	larval_child->sa.st_v2_resource_info.cpu_id = cpu_id;
+	larval_child->sa.st_v2_resource_info.state = RESOURCE_INFO_DONE;
+
+	/* Use same policy and proposals as Initial SA */
+	larval_child->sa.st_policy = capture_child_rekey_policy(&initial_sa->sa);
+	larval_child->sa.st_v2_create_child_sa_proposals =
+		get_v2_CREATE_CHILD_SA_new_child_proposals(ike, larval_child, verbose);
+	larval_child->sa.st_pfs_kem =
+		ikev2_proposals_first_kem(larval_child->sa.st_v2_create_child_sa_proposals, verbose);
+
+	/* Synchronize lifetime with Initial SA */
+	larval_child->sa.st_replace_margin = initial_sa->sa.st_replace_margin;
+
+	ldbg(larval_child->sa.logger,
+	     "submitting crypto for Additional Child SA (cpu=%u) using IKE SA "PRI_SO,
+	     cpu_id, pri_so(ike->sa.st_serialno));
+
+	submit_ke_and_nonce(&larval_child->sa, &larval_child->sa, NULL,
+			    larval_child->sa.st_pfs_kem,
+			    queue_v2_CREATE_CHILD_SA_new_child_request,
+			    false, HERE);
+
+	return larval_child;
+}
+
+
 void llog_success_initiate_v2_CREATE_CHILD_SA_child_request(struct ike_sa *ike,
 							    const struct msg_digest *md)
 {
@@ -854,6 +903,78 @@ stf_status initiate_v2_CREATE_CHILD_SA_rekey_child_request(struct ike_sa *ike,
 	return STF_OK; /* IKE */
 }
 
+/*
+ * Get number of Additional Child SAs for this connection (RFC 9611)
+ *
+ * Note: Any SA with cpu_id != CPU_ID_NONE is Additional
+ */
+static uint32_t count_additional_sas(struct connection *c)
+{
+	uint32_t count = 0;
+	struct state_filter sf = {
+		.connection_serialno = c->serialno,
+		.search = {
+			.order = NEW2OLD,
+			.where = HERE,
+		},
+	};
+
+	while (next_state(&sf)) {
+		struct child_sa *child = IS_CHILD_SA(sf.st) ? pexpect_child_sa(sf.st) : NULL;
+		if (child != NULL &&
+		    child->sa.st_v2_resource_info.cpu_id != CPU_ID_NONE) {
+			count++;
+		}
+	}
+
+	return count;
+}
+
+/*
+ * Find first unused CPU (RFC 9611)
+ *
+ * Notes:
+ *
+ *  - once all CPUs are used, round-robin follows
+ *  - no load-balancing between connections
+ *
+ */
+static uint32_t assign_least_loaded_cpu(struct connection *c, uint32_t sa_index)
+{
+	uint32_t clones_nr = c->config->child.clones.nr;
+	uint32_t actual_cpus = nr_processors_online();
+	uint32_t num_cpus = (clones_nr < actual_cpus) ? clones_nr : actual_cpus;
+	bool used[MAX_ADDITIONAL_SAS] = {false};
+
+	/* Mark which CPU IDs are in use for this connection */
+	struct state_filter sf = {
+		.connection_serialno = c->serialno,
+		.search = {
+			.order = NEW2OLD,
+			.where = HERE,
+		},
+	};
+
+	while (next_state(&sf)) {
+		struct child_sa *child = IS_CHILD_SA(sf.st) ? pexpect_child_sa(sf.st) : NULL;
+		if (child != NULL &&
+		    child->sa.st_v2_resource_info.cpu_id != CPU_ID_NONE &&
+		    child->sa.st_v2_resource_info.cpu_id < num_cpus) {
+			used[child->sa.st_v2_resource_info.cpu_id] = true;
+		}
+	}
+
+	uint32_t cpu_id;
+	for (cpu_id = 0; cpu_id < num_cpus; cpu_id++) {
+		if (!used[cpu_id]) {
+			return cpu_id;
+		}
+	}
+
+	/* All CPUs are used - use round-robin (normal when multiple SAs per CPU) */
+	return sa_index % num_cpus;
+}
+
 stf_status process_v2_CREATE_CHILD_SA_rekey_child_request(struct ike_sa *ike,
 							  struct child_sa *unused_child,
 							  struct msg_digest *md)
@@ -885,12 +1006,39 @@ stf_status process_v2_CREATE_CHILD_SA_rekey_child_request(struct ike_sa *ike,
 		get_v2_CREATE_CHILD_SA_rekey_child_proposals(ike, predecessor, verbose);
 
 	if (!verify_rekey_child_request_ts(larval_child, md)) {
-		record_v2N_response(ike->sa.logger, ike, md,
-				    v2N_TS_UNACCEPTABLE, empty_shunk/*no data*/,
-				    ENCRYPTED_PAYLOAD);
-		delete_child_sa(&larval_child);
-		ike->sa.st_v2_msgid_windows.responder.wip_sa = NULL;
-		return STF_OK; /*IKE*/
+
+		/* Check if this is an Additional SA request (RFC 9611) */
+		if (md->pd[PD_v2N_SA_RESOURCE_INFO] != NULL &&
+		    ike->sa.st_v2_resource_info.state == RESOURCE_INFO_DONE) {
+			ldbg(ike->sa.logger, "duplicate TS allowed for Additional Child SA");
+			larval_child->sa.st_v2_resource_info.state = RESOURCE_INFO_DONE;
+
+			/* Limit Additional Child SAs, reject more with TS_MAX_QUEUE */
+			uint32_t count = count_additional_sas(larval_child->sa.st_connection);
+			if (count >= MAX_ADDITIONAL_SAS) {
+				llog_sa(RC_LOG, larval_child,
+					"refusing Additional Child SA %u (Dlimit=%u)",
+					count + 1, MAX_ADDITIONAL_SAS);
+				record_v2N_response(ike->sa.logger, ike, md,
+						   v2N_TS_MAX_QUEUE, empty_shunk,
+						   ENCRYPTED_PAYLOAD);
+				delete_child_sa(&larval_child);
+				ike->sa.st_v2_msgid_windows.responder.wip_sa = NULL;
+				return STF_OK;
+			}
+
+			larval_child->sa.st_v2_resource_info.cpu_id = assign_least_loaded_cpu(larval_child->sa.st_connection, count);
+
+			ldbg(larval_child->sa.logger,
+			     "assigned Additional Child SA %u to CPU %u",
+			     count, larval_child->sa.st_v2_resource_info.cpu_id);
+		} else {
+			record_v2N_response(ike->sa.logger, ike, md,
+				v2N_TS_UNACCEPTABLE, empty_shunk/*no data*/, ENCRYPTED_PAYLOAD);
+			delete_child_sa(&larval_child);
+			ike->sa.st_v2_msgid_windows.responder.wip_sa = NULL;
+			return STF_OK; /*IKE*/
+		}
 	}
 
 	return process_v2_CREATE_CHILD_SA_request(ike, larval_child, md);

--- a/programs/pluto/ikev2_create_child_sa.h
+++ b/programs/pluto/ikev2_create_child_sa.h
@@ -34,6 +34,9 @@ struct child_sa *submit_v2_CREATE_CHILD_SA_new_child(struct ike_sa *ike,
 						     struct connection *c, /*child+whack*/
 						     const struct child_policy *policy,
 						     bool detach_whack);
+struct child_sa *submit_v2_CREATE_CHILD_SA_additional_child(struct ike_sa *ike,
+							      struct child_sa *initial_sa,
+							      uint32_t cpu_id);
 
 extern ikev2_state_transition_fn process_v2_CREATE_CHILD_SA_new_child_request;
 
@@ -49,5 +52,6 @@ extern ikev2_state_transition_fn process_v2_CREATE_CHILD_SA_failure_response;
 extern const struct v2_exchange v2_CREATE_CHILD_SA_new_child_exchange;
 extern const struct v2_exchange v2_CREATE_CHILD_SA_rekey_child_exchange;
 extern const struct v2_exchange v2_CREATE_CHILD_SA_rekey_ike_exchange;
+
 
 #endif

--- a/programs/pluto/ikev2_create_child_sa.h
+++ b/programs/pluto/ikev2_create_child_sa.h
@@ -34,6 +34,9 @@ struct child_sa *submit_v2_CREATE_CHILD_SA_new_child(struct ike_sa *ike,
 						     struct connection *c, /*child+whack*/
 						     const struct child_policy *policy,
 						     bool detach_whack);
+struct child_sa *submit_v2_CREATE_CHILD_SA_additional_child(struct ike_sa *ike,
+							      struct child_sa *initial_sa,
+							      uint32_t cpu_id);
 
 extern ikev2_state_transition_fn process_v2_CREATE_CHILD_SA_new_child_request;
 
@@ -51,5 +54,6 @@ extern ikev2_state_transition_fn process_v2_CREATE_CHILD_SA_failure_response;
 extern const struct v2_exchange v2_CREATE_CHILD_SA_new_child_exchange;
 extern const struct v2_exchange v2_CREATE_CHILD_SA_rekey_child_exchange;
 extern const struct v2_exchange v2_CREATE_CHILD_SA_rekey_ike_exchange;
+
 
 #endif

--- a/programs/pluto/ikev2_ike_auth.c
+++ b/programs/pluto/ikev2_ike_auth.c
@@ -314,6 +314,15 @@ stf_status initiate_v2_IKE_AUTH_request_signature_continue(struct ike_sa *ike,
 		}
 	}
 
+	/* Send SA_RESOURCE_INFO if per-CPU Child SAs are requested (RFC 9611) */
+	if (pc->config->child.clones.nr > 0) {
+		llog(RC_LOG, ike->sa.logger, "sending SA_RESOURCE_INFO (clones=%u)",
+		     pc->config->child.clones.nr);
+		if (!emit_v2N(v2N_SA_RESOURCE_INFO, request.pbs)) {
+			return STF_INTERNAL_ERROR;
+		}
+	}
+
 	/* Notification payload for ticket request */
 	if (ike->sa.st_connection->config->session_resumption) {
 		llog(RC_LOG, ike->sa.logger, "asking for session resume ticket");
@@ -360,6 +369,10 @@ stf_status initiate_v2_IKE_AUTH_request_signature_continue(struct ike_sa *ike,
 		release_whack(cc->logger, HERE);
 
 		ike->sa.st_v2_msgid_windows.initiator.wip_sa = child;
+
+		if (pc->config->child.clones.nr > 0) {
+			child->sa.st_v2_resource_info.state = RESOURCE_INFO_SENT;
+		}
 
 		if (cc != pc) {
 			llog(RC_LOG, child->sa.logger,

--- a/programs/pluto/ikev2_notification.c
+++ b/programs/pluto/ikev2_notification.c
@@ -152,6 +152,24 @@ void decode_v2N_payload(struct logger *logger, struct msg_digest *md,
 		LDBG_log(logger, "%s notification %s saved", type, name.buf);
 	}
 	md->pd[v2_pd] = notify;
+
+	/*
+	 * Log optional SA_RESOURCE_INFO data if peer sends it (RFC 9611)
+	 *
+	 * Notice that we don't send any.
+	 */
+	if (n == v2N_SA_RESOURCE_INFO) {
+		shunk_t data = pbs_in_left(&notify->pbs);
+
+		if (pbs_left(&notify->pbs) == sizeof(uint32_t)) {
+			uint32_t peer_data;
+			memcpy(&peer_data, data.ptr, sizeof(peer_data));
+			peer_data = ntohl(peer_data);
+			ldbg(logger, "peer SA_RESOURCE_INFO data: 0x%08x", peer_data);
+		} else if (pbs_left(&notify->pbs) > 0) {
+			ldbg(logger, "peer SA_RESOURCE_INFO data: %zu bytes", data.len);
+		}
+	}
 }
 
 void decode_v2N_payloads(struct logger *logger, struct msg_digest *md)

--- a/programs/pluto/ikev2_notification.c
+++ b/programs/pluto/ikev2_notification.c
@@ -152,6 +152,24 @@ void decode_v2N_payload(struct msg_digest *md,
 	}
 
 	md->pd[v2_pd] = notify;
+
+	/*
+	 * Log optional SA_RESOURCE_INFO data if peer sends it (RFC 9611)
+	 *
+	 * Notice that we don't send any.
+	 */
+	if (n == v2N_SA_RESOURCE_INFO) {
+		shunk_t data = pbs_in_left(&notify->pbs);
+
+		if (pbs_left(&notify->pbs) == sizeof(uint32_t)) {
+			uint32_t peer_data;
+			memcpy(&peer_data, data.ptr, sizeof(peer_data));
+			peer_data = ntohl(peer_data);
+			ldbg(logger, "peer SA_RESOURCE_INFO data: 0x%08x", peer_data);
+		} else if (pbs_left(&notify->pbs) > 0) {
+			ldbg(logger, "peer SA_RESOURCE_INFO data: %zu bytes", data.len);
+		}
+	}
 }
 
 void decode_v2N_payloads(struct msg_digest *md,

--- a/programs/pluto/kernel.c
+++ b/programs/pluto/kernel.c
@@ -1266,6 +1266,9 @@ static bool setup_half_kernel_state(struct child_sa *child, enum direction direc
 		.sa_mark_out = (c->ipsec_interface == NULL ? NULL :
 				(c->sa_marks.out.val == 0 && c->sa_marks.out.mask == 0) ? NULL :
 				&c->sa_marks.out),
+		.cpu_id = (child->sa.st_v2_resource_info.cpu_id != CPU_ID_NONE &&
+			   kernel_ops->pcpu_ipsec_sa_is_enabled(c->logger) == NULL) ?
+			  child->sa.st_v2_resource_info.cpu_id : CPU_ID_NONE,
 	};
 
 	address_buf sab, dab;

--- a/programs/pluto/kernel.h
+++ b/programs/pluto/kernel.h
@@ -306,6 +306,7 @@ struct kernel_ops {
 	bool (*iptfs_ipsec_sa)(struct child_sa *child);
 	err_t (*directional_ipsec_sa_is_enabled)(struct logger *);
 	bool (*directional_ipsec_sa)(struct child_sa *child);
+	err_t (*pcpu_ipsec_sa_is_enabled)(struct logger *);
 	bool (*poke_ipsec_policy_hole)(int fd, const struct ip_info *afi, struct logger *logger);
 	bool (*detect_nic_offload)(const char *name, const struct logger *logger);
 	bool (*poke_ipsec_offload_policy_hole)(struct nic_offload *nic_offload, struct logger *logger);

--- a/programs/pluto/kernel.h
+++ b/programs/pluto/kernel.h
@@ -201,6 +201,8 @@ struct kernel_state {
 	uint32_t tfcpad;
 
 	const struct config_iptfs *iptfs;	/* non-NULL when enabled */
+
+	uint32_t cpu_id; /* CPU ID or CPU_ID_NONE (RFC 9611) */
 };
 
 struct kernel_ops {

--- a/programs/pluto/kernel_pfkeyv2.c
+++ b/programs/pluto/kernel_pfkeyv2.c
@@ -1816,6 +1816,12 @@ static err_t pfkeyv2_migrate_ipsec_sa_is_enabled(struct logger *logger)
 	return "not supported";
 }
 
+static err_t pfkeyv2_pcpu_ipsec_sa_is_enabled(struct logger *logger)
+{
+	ldbg(logger, "%s() called; nothing to do", __func__);
+	return "not supported";
+}
+
 static const char *pfkeyv2_protostack_names[] = {
 	"pfkeyv2",
 	"pfkey",
@@ -1857,5 +1863,6 @@ const struct kernel_ops pfkeyv2_kernel_ops = {
 	.ipsec_interface = &kernel_ipsec_interface_ifconfig,
 	.directional_ipsec_sa_is_enabled = pfkeyv2_directional_ipsec_sa_is_enabled,
 	.iptfs_ipsec_sa_is_enabled = pfkeyv2_iptfs_ipsec_sa_is_enabled,
+	.pcpu_ipsec_sa_is_enabled = pfkeyv2_pcpu_ipsec_sa_is_enabled,
 	.migrate_ipsec_sa_is_enabled = pfkeyv2_migrate_ipsec_sa_is_enabled,
 };

--- a/programs/pluto/kernel_pfkeyv2.c
+++ b/programs/pluto/kernel_pfkeyv2.c
@@ -1995,6 +1995,12 @@ static err_t pfkeyv2_migrate_ipsec_sa_is_enabled(struct logger *logger)
 	return "not supported";
 }
 
+static err_t pfkeyv2_pcpu_ipsec_sa_is_enabled(struct logger *logger)
+{
+	ldbg(logger, "%s() called; nothing to do", __func__);
+	return "not supported";
+}
+
 static const char *pfkeyv2_protostack_names[] = {
 	"pfkeyv2",
 	"pfkey",
@@ -2039,5 +2045,6 @@ const struct kernel_ops pfkeyv2_kernel_ops = {
 	.ipsec_interface = &kernel_ipsec_interface_ifconfig,
 	.directional_ipsec_sa_is_enabled = pfkeyv2_directional_ipsec_sa_is_enabled,
 	.iptfs_ipsec_sa_is_enabled = pfkeyv2_iptfs_ipsec_sa_is_enabled,
+	.pcpu_ipsec_sa_is_enabled = pfkeyv2_pcpu_ipsec_sa_is_enabled,
 	.migrate_ipsec_sa_is_enabled = pfkeyv2_migrate_ipsec_sa_is_enabled,
 };

--- a/programs/pluto/kernel_xfrm.c
+++ b/programs/pluto/kernel_xfrm.c
@@ -1735,6 +1735,22 @@ static bool netlink_add_sa(const struct kernel_state *sa,
 			req.n.nlmsg_len += attr->rta_len;
 			attr = (struct rtattr *)((char *)&req + req.n.nlmsg_len);
 		}
+
+		/*
+		 * RFC 9611 - Per-CPU Child SAs
+		 *
+		 *  - Initial SA = no cpu binding (CPU_ID_NONE)
+		 *  - Additional SA = cpu binding via XFRMA_SA_PCPU
+		 */
+		if (sa->cpu_id != CPU_ID_NONE) {
+			ldbg(logger, "%s() setting XFRMA_SA_PCPU to %u for Additional Child SA", __func__, sa->cpu_id);
+			attr->rta_type = XFRMA_SA_PCPU;
+			attr->rta_len = RTA_LENGTH(sizeof(sa->cpu_id));
+			memcpy(RTA_DATA(attr), &sa->cpu_id, sizeof(sa->cpu_id));
+			req.n.nlmsg_len += attr->rta_len;
+			attr = (struct rtattr *)((char *)&req + req.n.nlmsg_len);
+		}
+
 		if (sa->nopmtudisc) {
 			ldbg(logger, "%s() disabling Path MTU Discovery", __func__);
 			req.p.flags |= XFRM_STATE_NOPMTUDISC;

--- a/programs/pluto/kernel_xfrm.c
+++ b/programs/pluto/kernel_xfrm.c
@@ -3112,6 +3112,46 @@ static bool qry_xfrm_iptfs_support(struct logger *logger) {
 	return qry_xfrm_base_support(logger, true, true);
 }
 
+static bool qry_xfrm_pcpu_support(struct logger *logger)
+{
+	uint8_t fakekey[max(AES_BLOCK_SIZE, SHA2_256_DIGEST_SIZE)];
+	get_rnd_bytes(&fakekey, sizeof(fakekey));
+
+	const struct encrypt_desc *cipher = &ike_alg_encrypt_aes_cbc;
+	shunk_t cipher_key = shunk2(fakekey, AES_BLOCK_SIZE);
+
+	const struct integ_desc *integ = &ike_alg_integ_sha2_256;
+	shunk_t integ_key = shunk2(fakekey, SHA2_256_DIGEST_SIZE);
+
+	struct kernel_state sa = {
+		.mode = KERNEL_MODE_TUNNEL,
+		.src.address = ipv4_info.address.zero,
+		.dst.address = ipv4_info.address.zero,
+		.proto = &ip_protocol_esp,
+		.direction = DIRECTION_OUTBOUND,
+		.spi = 1,
+		.state_id = DEFAULT_KERNEL_STATE_ID,
+		.reqid = 1,
+		.story = "PCPU Probe",
+		.encrypt = cipher,
+		.integ = integ,
+		.encrypt_key = cipher_key,
+		.integ_key = integ_key,
+		.cpu_id = 0,  /* Check support of XFRMA_SA_PCPU with CPU 0 */
+	};
+
+	if (netlink_add_sa(&sa, false, logger)) {
+		ldbg(logger, "kernel: XFRMA_SA_PCPU (per-CPU SAs) supported");
+		if (!xfrm_del_ipsec_spi(sa.spi, sa.proto,
+			&sa.src.address, &sa.dst.address,
+			"del percpu probe", logger)) {
+			llog(RC_LOG, logger, "kernel: per-CPU probe SA deletion failed - ignored");
+		}
+		return true;
+	}
+	ldbg(logger, "kernel: XFRMA_SA_PCPU (per-CPU SAs) not supported");
+	return false;
+}
 
 static bool qry_xfrm_migrate_support(const struct logger *logger)
 {
@@ -3264,6 +3304,26 @@ static err_t xfrm_iptfs_ipsec_sa_is_enabled(struct logger *logger)
 	}
 }
 
+static err_t xfrm_pcpu_ipsec_sa_is_enabled(struct logger *logger)
+{
+	static enum {
+		UNKNOWN, ENABLED, DISABLED,
+	} state = UNKNOWN;
+	static const char disabled_message[] = "requires kernel with XFRMA_SA_PCPU support";
+
+	switch (state) {
+	case UNKNOWN:
+		state = (qry_xfrm_pcpu_support(logger) ? ENABLED : DISABLED);
+		return state == ENABLED ? NULL : disabled_message;
+	case ENABLED:
+		return NULL;
+	case DISABLED:
+		return disabled_message;
+	default:
+		bad_case(state);
+	}
+}
+
 static bool netlink_poke_ipsec_offload_policy_hole(struct nic_offload *nic_offload, struct logger *logger)
 {
 	if (nic_offload->type != KERNEL_OFFLOAD_PACKET)
@@ -3403,6 +3463,7 @@ const struct kernel_ops xfrm_kernel_ops = {
 	.migrate_ipsec_sa_is_enabled = xfrm_migrate_ipsec_sa_is_enabled,
 	.directional_ipsec_sa_is_enabled = xfrm_directional_ipsec_sa_is_enabled,
 	.iptfs_ipsec_sa_is_enabled = xfrm_iptfs_ipsec_sa_is_enabled,
+	.pcpu_ipsec_sa_is_enabled = xfrm_pcpu_ipsec_sa_is_enabled,
 	.migrate_ipsec_sa = xfrm_migrate_ipsec_sa,
 	.sha2_truncbug_support = true,
 	.poke_ipsec_policy_hole = netlink_poke_ipsec_policy_hole,

--- a/programs/pluto/kernel_xfrm.c
+++ b/programs/pluto/kernel_xfrm.c
@@ -3116,6 +3116,46 @@ static bool qry_xfrm_iptfs_support(struct logger *logger) {
 	return qry_xfrm_base_support(logger, true, true);
 }
 
+static bool qry_xfrm_pcpu_support(struct logger *logger)
+{
+	uint8_t fakekey[max(AES_BLOCK_SIZE, SHA2_256_DIGEST_SIZE)];
+	get_rnd_bytes(&fakekey, sizeof(fakekey));
+
+	const struct encrypt_desc *cipher = &ike_alg_encrypt_aes_cbc;
+	shunk_t cipher_key = shunk2(fakekey, AES_BLOCK_SIZE);
+
+	const struct integ_desc *integ = &ike_alg_integ_sha2_256;
+	shunk_t integ_key = shunk2(fakekey, SHA2_256_DIGEST_SIZE);
+
+	struct kernel_state sa = {
+		.mode = KERNEL_MODE_TUNNEL,
+		.src.address = ipv4_info.address.zero,
+		.dst.address = ipv4_info.address.zero,
+		.proto = &ip_protocol_esp,
+		.direction = DIRECTION_OUTBOUND,
+		.spi = 1,
+		.state_id = DEFAULT_KERNEL_STATE_ID,
+		.reqid = 1,
+		.story = "PCPU Probe",
+		.encrypt = cipher,
+		.integ = integ,
+		.encrypt_key = cipher_key,
+		.integ_key = integ_key,
+		.cpu_id = 0,  /* Check support of XFRMA_SA_PCPU with CPU 0 */
+	};
+
+	if (netlink_add_sa(&sa, false, logger)) {
+		ldbg(logger, "kernel: XFRMA_SA_PCPU (per-CPU SAs) supported");
+		if (!xfrm_del_ipsec_spi(sa.spi, sa.proto,
+			&sa.src.address, &sa.dst.address,
+			"del percpu probe", logger)) {
+			llog(RC_LOG, logger, "kernel: per-CPU probe SA deletion failed - ignored");
+		}
+		return true;
+	}
+	ldbg(logger, "kernel: XFRMA_SA_PCPU (per-CPU SAs) not supported");
+	return false;
+}
 
 static bool qry_xfrm_migrate_support(const struct logger *logger)
 {
@@ -3268,6 +3308,26 @@ static err_t xfrm_iptfs_ipsec_sa_is_enabled(struct logger *logger)
 	}
 }
 
+static err_t xfrm_pcpu_ipsec_sa_is_enabled(struct logger *logger)
+{
+	static enum {
+		UNKNOWN, ENABLED, DISABLED,
+	} state = UNKNOWN;
+	static const char disabled_message[] = "requires kernel with XFRMA_SA_PCPU support";
+
+	switch (state) {
+	case UNKNOWN:
+		state = (qry_xfrm_pcpu_support(logger) ? ENABLED : DISABLED);
+		return state == ENABLED ? NULL : disabled_message;
+	case ENABLED:
+		return NULL;
+	case DISABLED:
+		return disabled_message;
+	default:
+		bad_case(state);
+	}
+}
+
 static bool netlink_poke_ipsec_offload_policy_hole(struct nic_offload *nic_offload, struct logger *logger)
 {
 	if (nic_offload->type != KERNEL_OFFLOAD_PACKET)
@@ -3407,6 +3467,7 @@ const struct kernel_ops xfrm_kernel_ops = {
 	.migrate_ipsec_sa_is_enabled = xfrm_migrate_ipsec_sa_is_enabled,
 	.directional_ipsec_sa_is_enabled = xfrm_directional_ipsec_sa_is_enabled,
 	.iptfs_ipsec_sa_is_enabled = xfrm_iptfs_ipsec_sa_is_enabled,
+	.pcpu_ipsec_sa_is_enabled = xfrm_pcpu_ipsec_sa_is_enabled,
 	.migrate_ipsec_sa = xfrm_migrate_ipsec_sa,
 	.sha2_truncbug_support = true,
 	.poke_ipsec_policy_hole = netlink_poke_ipsec_policy_hole,

--- a/programs/pluto/kernel_xfrm.c
+++ b/programs/pluto/kernel_xfrm.c
@@ -1738,6 +1738,22 @@ static bool netlink_add_sa(const struct kernel_state *sa,
 			req.n.nlmsg_len += attr->rta_len;
 			attr = (struct rtattr *)((char *)&req + req.n.nlmsg_len);
 		}
+
+		/*
+		 * RFC 9611 - Per-CPU Child SAs
+		 *
+		 *  - Initial SA = no cpu binding (CPU_ID_NONE)
+		 *  - Additional SA = cpu binding via XFRMA_SA_PCPU
+		 */
+		if (sa->cpu_id != CPU_ID_NONE) {
+			ldbg(logger, "%s() setting XFRMA_SA_PCPU to %u for Additional Child SA", __func__, sa->cpu_id);
+			attr->rta_type = XFRMA_SA_PCPU;
+			attr->rta_len = RTA_LENGTH(sizeof(sa->cpu_id));
+			memcpy(RTA_DATA(attr), &sa->cpu_id, sizeof(sa->cpu_id));
+			req.n.nlmsg_len += attr->rta_len;
+			attr = (struct rtattr *)((char *)&req + req.n.nlmsg_len);
+		}
+
 		if (sa->nopmtudisc) {
 			ldbg(logger, "%s() disabling Path MTU Discovery", __func__);
 			req.p.flags |= XFRM_STATE_NOPMTUDISC;

--- a/programs/pluto/plutomain.c
+++ b/programs/pluto/plutomain.c
@@ -1554,6 +1554,12 @@ int main(int argc, char **argv)
 	else
 		llog(RC_LOG, logger, "kernel: MIGRATE SA supported by kernel");
 
+	msg = kernel_ops->pcpu_ipsec_sa_is_enabled(logger);
+	if (msg != NULL)
+		llog(RC_LOG, logger, "kernel: per-CPU ipsec SA error: %s", msg);
+	else
+		llog(RC_LOG, logger, "kernel: per-CPU SA supported by kernel (RFC 9611)");
+
 	run_server(conffile, logger);
 }
 

--- a/programs/pluto/routing.c
+++ b/programs/pluto/routing.c
@@ -601,7 +601,11 @@ static void set_established_outbound(struct connection *c,
 	c->routing.state = routing;
 	c->routing_sa = child->sa.st_serialno;
 	c->negotiating_child_sa = child->sa.st_serialno;
-	c->established_child_sa = child->sa.st_serialno;
+
+	/* We want to keep trask of Initial Child SA (RFC 9611) only */
+	if (child->sa.st_v2_resource_info.cpu_id == CPU_ID_NONE) {
+		c->established_child_sa = child->sa.st_serialno;
+	}
 }
 
 static bool unrouted_to_routed_ondemand(struct connection *c, where_t where)

--- a/programs/pluto/routing.c
+++ b/programs/pluto/routing.c
@@ -550,8 +550,10 @@ static void set_established_inbound(struct connection *c,
 				    const struct routing_annex *e)
 {
 	struct child_sa *child = (*e->child);
-	c->routing_sa = child->sa.st_serialno;
-	c->negotiating_child_sa = child->sa.st_serialno;
+	if (child->sa.st_v2_resource_info.cpu_id == CPU_ID_NONE) {
+		c->routing_sa = child->sa.st_serialno;
+		c->negotiating_child_sa = child->sa.st_serialno;
+	}
 	c->routing.state = new_routing;
 }
 
@@ -599,11 +601,11 @@ static void set_established_outbound(struct connection *c,
 		}
 	}
 	c->routing.state = routing;
-	c->routing_sa = child->sa.st_serialno;
-	c->negotiating_child_sa = child->sa.st_serialno;
 
-	/* We want to keep trask of Initial Child SA (RFC 9611) only */
+	/* Only Initial Child SAs own the connection (RFC 9611) */
 	if (child->sa.st_v2_resource_info.cpu_id == CPU_ID_NONE) {
+		c->routing_sa = child->sa.st_serialno;
+		c->negotiating_child_sa = child->sa.st_serialno;
 		c->established_child_sa = child->sa.st_serialno;
 	}
 }

--- a/programs/pluto/state.c
+++ b/programs/pluto/state.c
@@ -1347,9 +1347,11 @@ struct child_sa *new_v2_child_sa(struct connection *c,
 	child->sa.st_v2_ike_fragmentation_enabled = ike->sa.st_v2_ike_fragmentation_enabled;
 	child->sa.st_seen_redirect_sup = ike->sa.st_seen_redirect_sup;
 	child->sa.st_sent_redirect = ike->sa.st_sent_redirect;
+	child->sa.st_v2_resource_info.cpu_id = CPU_ID_NONE;
 
 	change_state(&child->sa, fs->kind);
 	set_v2_transition(&child->sa, transition, HERE);
+
 
 	return child;
 }

--- a/programs/pluto/state.c
+++ b/programs/pluto/state.c
@@ -1354,9 +1354,11 @@ struct child_sa *new_v2_child_sa(struct connection *c,
 	child->sa.st_v2_ike_fragmentation_enabled = ike->sa.st_v2_ike_fragmentation_enabled;
 	child->sa.st_seen_redirect_sup = ike->sa.st_seen_redirect_sup;
 	child->sa.st_sent_redirect = ike->sa.st_sent_redirect;
+	child->sa.st_v2_resource_info.cpu_id = CPU_ID_NONE;
 
 	change_state(&child->sa, fs->kind);
 	set_v2_transition(&child->sa, transition, HERE);
+
 
 	return child;
 }

--- a/programs/pluto/state.h
+++ b/programs/pluto/state.h
@@ -79,6 +79,36 @@ struct child_policy {
 
 #define has_child_policy(POLICY) ((POLICY) != NULL && (POLICY)->is_set)
 
+/*
+ * Maximum number of Additional Child SAs per connection (RFC 9611)
+ *
+ * The limit prevents initiators from exhausting responder resources
+ * by creating too many Additional SAs.
+ */
+#define MAX_ADDITIONAL_SAS 64
+
+/*
+ * No CPU bound to SA (RFC 9611)
+ *
+ * Also used also for Initial Child SA.
+ */
+#define CPU_ID_NONE ((uint32_t)-1)
+
+/*
+ * State of negotiation of using Additional SAs (RFC 9611)
+ *
+ *   NONE - no negotiated
+ *   SENT - SA_RESOURCE_INFO notify message sent
+ *   RECV - SA_RESOURCE_INFO notify message received
+ *   DONE - successfully negotiated
+ */
+enum resource_info_state {
+	RESOURCE_INFO_NONE = 0,
+	RESOURCE_INFO_SENT,
+	RESOURCE_INFO_RECV,
+	RESOURCE_INFO_DONE,
+};
+
 typedef struct {
 	char buf[32];
 } child_policy_buf;
@@ -424,6 +454,11 @@ struct state {
 		uint32_t id;		/* ID of last IKE_INTERMEDIATE exchange */
 		unsigned next_exchange;
 	} st_v2_ike_intermediate;
+
+	struct {
+		uint32_t cpu_id;                    /* CPU_ID_NONE for Initial SA, or 0..N for Additional SA */
+		enum resource_info_state state;     /* RFC 9611 SA_RESOURCE_INFO negotiation state */
+	} st_v2_resource_info;
 
 	/** end of IKEv2-only things **/
 

--- a/programs/pluto/state.h
+++ b/programs/pluto/state.h
@@ -80,6 +80,36 @@ struct child_policy {
 
 #define has_child_policy(POLICY) ((POLICY) != NULL && (POLICY)->is_set)
 
+/*
+ * Maximum number of Additional Child SAs per connection (RFC 9611)
+ *
+ * The limit prevents initiators from exhausting responder resources
+ * by creating too many Additional SAs.
+ */
+#define MAX_ADDITIONAL_SAS 64
+
+/*
+ * No CPU bound to SA (RFC 9611)
+ *
+ * Also used also for Initial Child SA.
+ */
+#define CPU_ID_NONE ((uint32_t)-1)
+
+/*
+ * State of negotiation of using Additional SAs (RFC 9611)
+ *
+ *   NONE - no negotiated
+ *   SENT - SA_RESOURCE_INFO notify message sent
+ *   RECV - SA_RESOURCE_INFO notify message received
+ *   DONE - successfully negotiated
+ */
+enum resource_info_state {
+	RESOURCE_INFO_NONE = 0,
+	RESOURCE_INFO_SENT,
+	RESOURCE_INFO_RECV,
+	RESOURCE_INFO_DONE,
+};
+
 typedef struct {
 	char buf[32];
 } child_policy_buf;
@@ -441,6 +471,11 @@ struct state {
 		unsigned next_exchange;
 		struct prf_keys *keys;
 	} st_v2_ike_followup_ke;
+
+	struct {
+		uint32_t cpu_id;                    /* CPU_ID_NONE for Initial SA, or 0..N for Additional SA */
+		enum resource_info_state state;     /* RFC 9611 SA_RESOURCE_INFO negotiation state */
+	} st_v2_resource_info;
 
 	/** end of IKEv2-only things **/
 

--- a/programs/pluto/state.h
+++ b/programs/pluto/state.h
@@ -475,6 +475,7 @@ struct state {
 	struct {
 		uint32_t cpu_id;                    /* CPU_ID_NONE for Initial SA, or 0..N for Additional SA */
 		enum resource_info_state state;     /* RFC 9611 SA_RESOURCE_INFO negotiation state */
+		so_serial_t initial_sa;             /* serialno of the Initial SA this Additional SA belongs to */
 	} st_v2_resource_info;
 
 	/** end of IKEv2-only things **/

--- a/programs/pluto/timer.c
+++ b/programs/pluto/timer.c
@@ -399,7 +399,34 @@ static void dispatch_event(struct state *st, enum event_type event_type,
 			st = NULL;
 		} else if (IS_IKE_SA_ESTABLISHED(&ike->sa)) {
 			/* note: no md->st to clear */
-			submit_v2_delete_exchange(ike, pexpect_child_sa(st));
+			struct child_sa *child = pexpect_child_sa(st);
+			submit_v2_delete_exchange(ike, child);
+
+			/* If this is an Initial SA, also delete its Additional SAs (RFC 9611) */
+			if (child != NULL &&
+			    child->sa.st_v2_resource_info.cpu_id == CPU_ID_NONE &&
+			    child->sa.st_v2_resource_info.state == RESOURCE_INFO_DONE) {
+				/* Find and delete all Additional SAs for this connection */
+				struct state_filter sf = {
+					.connection_serialno = child->sa.st_connection->serialno,
+					.search = {
+						.order = NEW2OLD,
+						.where = HERE,
+					},
+				};
+				while (next_state(&sf)) {
+					struct child_sa *additional = IS_CHILD_SA(sf.st) ? pexpect_child_sa(sf.st) : NULL;
+					if (additional != NULL &&
+					    additional->sa.st_clonedfrom == child->sa.st_clonedfrom &&
+					    additional->sa.st_v2_resource_info.cpu_id != CPU_ID_NONE) {
+						llog(RC_LOG, child->sa.logger,
+							"deleting Additional Child SAs (cpu_id=%u) associated with this Initial SA",
+							additional->sa.st_v2_resource_info.cpu_id);
+						submit_v2_delete_exchange(ike, additional);
+					}
+				}
+			}
+
 			st = NULL;
 		} else {
 			struct child_sa *child = pexpect_child_sa(st);

--- a/programs/pluto/timer.c
+++ b/programs/pluto/timer.c
@@ -406,7 +406,6 @@ static void dispatch_event(struct state *st, enum event_type event_type,
 			if (child != NULL &&
 			    child->sa.st_v2_resource_info.cpu_id == CPU_ID_NONE &&
 			    child->sa.st_v2_resource_info.state == RESOURCE_INFO_DONE) {
-				/* Find and delete all Additional SAs for this connection */
 				struct state_filter sf = {
 					.connection_serialno = child->sa.st_connection->serialno,
 					.search = {
@@ -417,10 +416,9 @@ static void dispatch_event(struct state *st, enum event_type event_type,
 				while (next_state(&sf)) {
 					struct child_sa *additional = IS_CHILD_SA(sf.st) ? pexpect_child_sa(sf.st) : NULL;
 					if (additional != NULL &&
-					    additional->sa.st_clonedfrom == child->sa.st_clonedfrom &&
-					    additional->sa.st_v2_resource_info.cpu_id != CPU_ID_NONE) {
+					    additional->sa.st_v2_resource_info.initial_sa == child->sa.st_serialno) {
 						llog(RC_LOG, child->sa.logger,
-							"deleting Additional Child SAs (cpu_id=%u) associated with this Initial SA",
+							"deleting Additional Child SA (cpu_id=%u) associated with this Initial SA",
 							additional->sa.st_v2_resource_info.cpu_id);
 						submit_v2_delete_exchange(ike, additional);
 					}


### PR DESCRIPTION
This implements RFC 9611 - per-resource Child SA for CPU resource (only). This is initial version for review but mainly for discussion and hence I just briefly summarize what it does and few design decisions. I split it into four commits:

(1) Basics

- SA_RESOURCE_INFO notification is used for negotiation of using Additional SA, both initiator and responder must have clones= set either to 'yes' or non-zero integer
- SA_RESOURCE_INFO notification payload empty
- Maximum number of additional SA is limited to 64 to prevent exhausting responders
- TS_MAX_QUEUE is send back if the limit is reached
- All additional Child SA are created  right away (strongswan does it on-demand)
- Initial Child SA is never bound to any CPU (strongswan calls it Fallback SA)
- TS as well as proposals are the same for Initial and Additional Child SA, lifetime is synchronized
- Works even without kernel support for XFRMA_SA_PCPU, Additional SA are just not bound to CPUs
 
(2) Rekeying

- When an Initial Child SA is rekeyed, all Additional Child SA are created again for the new Initial Child SA
- Additional Child SA are terminated when their Initial Child SA expires

(3) Actual CPU binding

- Round-robin assignment of CPUs (if any) per connection, no load-balancing between connections
- Uses XFRMA_SA_PCPU to bind SA to CPUs
- Allows more Additional SA across the same CPU (but it makes no sense then)

(4) XFRMA_SA_PCPU support probing

- Kernel support is probed at startup and cached, actual binding is done only if there's support
- As mentioned above Additional Child SAs works even without actual CPU binding

Other notes:

- I did very basic testing only so far, no interoperability testing with strongswan yet
- KVM testsuite testing will be quite limited by having just one CPU per node
- Kernel 6.13+ has XFRMA_SA_PCPU
- One needs iproute-7 to see CPU assignment in ip xfrm state output (it's in Fedora Rawhide)
- I based `submit_v2_CREATE_CHILD_SA_additional_child` on  `submit_v2_CREATE_CHILD_SA_child`