### PR TITLE
feat: display reqid in connection status

### DIFF
--- a/programs/pluto/whack_connectionstatus.c
+++ b/programs/pluto/whack_connectionstatus.c
@@ -1046,6 +1046,15 @@ static void show_connection_status(struct show *s, const struct connection *c)
 		jam_connection_owners(buf, c, IKE_SA_OWNER_FLOOR, IKE_SA_OWNER_ROOF);
 		jam_connection_owners(buf, c, CHILD_SA_OWNER_FLOOR, CHILD_SA_OWNER_ROOF);
 	}
+	/*
+	 * display the reqid for a particular connection
+	 */
+	SHOW_JAMBUF(s, buf) {
+		jam_string(buf, c->name);
+		jam_string(buf, ":  ");
+		jam(buf, " reqid: "PRI_REQID";",
+		    c->child.reqid);
+	}
 
 	if (c->config->session_resumption) {
 		SHOW_JAMBUF(s, buf) {

--- a/testing/pluto/addconn-04-config-path/west.console.txt
+++ b/testing/pluto/addconn-04-config-path/west.console.txt
@@ -33,6 +33,7 @@ west #
 "tmp":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "tmp":   nat-traversal: encapsulation:auto; keepalive:20s
 "tmp":   routing: unrouted;
+"tmp":   reqid: REQID;
 "tmp":   conn serial: $1;
 west #
  ipsec whack --shutdown
@@ -66,6 +67,7 @@ west #
 "path":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "path":   nat-traversal: encapsulation:auto; keepalive:20s
 "path":   routing: unrouted;
+"path":   reqid: REQID;
 "path":   conn serial: $1;
 west #
  ipsec whack --shutdown

--- a/testing/pluto/addconn-08-ordering/west.console.txt
+++ b/testing/pluto/addconn-08-ordering/west.console.txt
@@ -31,5 +31,6 @@ west #
 "order-test":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "order-test":   nat-traversal: encapsulation:auto; keepalive:20s
 "order-test":   routing: unrouted;
+"order-test":   reqid: REQID;
 "order-test":   conn serial: $1;
 west #

--- a/testing/pluto/addresspool-6in6-strongswan-initiator-ikev2/east.console.txt
+++ b/testing/pluto/addresspool-6in6-strongswan-initiator-ikev2/east.console.txt
@@ -124,6 +124,7 @@ Connection list:
 "rw-eastnet-ipv6":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "rw-eastnet-ipv6":   nat-traversal: encapsulation:auto; keepalive:20s
 "rw-eastnet-ipv6":   routing: unrouted;
+"rw-eastnet-ipv6":   reqid: REQID;
 "rw-eastnet-ipv6":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/ah-pluto-13/east.console.txt
+++ b/testing/pluto/ah-pluto-13/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-ah-sha1-pfs":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-ah-sha1-pfs":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-ah-sha1-pfs":   routing: unrouted;
+"westnet-eastnet-ah-sha1-pfs":   reqid: REQID;
 "westnet-eastnet-ah-sha1-pfs":   conn serial: $1;
 "westnet-eastnet-ah-sha1-pfs":   IKE algorithms: AES_CBC_256-HMAC_SHA1-MODP2048
 "westnet-eastnet-ah-sha1-pfs":   AH algorithms: HMAC_SHA1_96-MODP2048

--- a/testing/pluto/ah-pluto-13/west.console.txt
+++ b/testing/pluto/ah-pluto-13/west.console.txt
@@ -46,6 +46,7 @@ west #
 "westnet-eastnet-ah-sha1-pfs":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-ah-sha1-pfs":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-ah-sha1-pfs":   routing: unrouted;
+"westnet-eastnet-ah-sha1-pfs":   reqid: REQID;
 "westnet-eastnet-ah-sha1-pfs":   conn serial: $1;
 "westnet-eastnet-ah-sha1-pfs":   IKE algorithms: AES_CBC_256-HMAC_SHA1-MODP2048
 "westnet-eastnet-ah-sha1-pfs":   AH algorithms: HMAC_SHA1_96-MODP2048

--- a/testing/pluto/algo-pluto-01/east.console.txt
+++ b/testing/pluto/algo-pluto-01/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-aes256":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-aes256":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-aes256":   routing: unrouted;
+"westnet-eastnet-aes256":   reqid: REQID;
 "westnet-eastnet-aes256":   conn serial: $1;
 "westnet-eastnet-aes256":   IKE algorithms: AES_CBC_256-HMAC_SHA1-MODP2048
 "westnet-eastnet-aes256":   ESP algorithms: AES_CBC_256-HMAC_SHA1_96

--- a/testing/pluto/algo-pluto-01/west.console.txt
+++ b/testing/pluto/algo-pluto-01/west.console.txt
@@ -48,6 +48,7 @@ west #
 "westnet-eastnet-aes256":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-aes256":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-aes256":   routing: unrouted;
+"westnet-eastnet-aes256":   reqid: REQID;
 "westnet-eastnet-aes256":   conn serial: $1;
 "westnet-eastnet-aes256":   IKE algorithms: AES_CBC_256-HMAC_SHA1-MODP2048
 "westnet-eastnet-aes256":   ESP algorithms: AES_CBC_256-HMAC_SHA1_96

--- a/testing/pluto/algo-pluto-08/east.console.txt
+++ b/testing/pluto/algo-pluto-08/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-dh15":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-dh15":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-dh15":   routing: unrouted;
+"westnet-eastnet-dh15":   reqid: REQID;
 "westnet-eastnet-dh15":   conn serial: $1;
 "westnet-eastnet-dh15":   IKE algorithms: 3DES_CBC-HMAC_SHA1-MODP3072
 "westnet-eastnet-dh15":   ESP algorithms: 3DES_CBC-HMAC_SHA1_96-MODP3072

--- a/testing/pluto/algo-pluto-08/west.console.txt
+++ b/testing/pluto/algo-pluto-08/west.console.txt
@@ -46,6 +46,7 @@ west #
 "westnet-eastnet-dh15":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-dh15":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-dh15":   routing: unrouted;
+"westnet-eastnet-dh15":   reqid: REQID;
 "westnet-eastnet-dh15":   conn serial: $1;
 "westnet-eastnet-dh15":   IKE algorithms: 3DES_CBC-HMAC_SHA1-MODP3072
 "westnet-eastnet-dh15":   ESP algorithms: 3DES_CBC-HMAC_SHA1_96-MODP3072

--- a/testing/pluto/algo-pluto-10/east.console.txt
+++ b/testing/pluto/algo-pluto-10/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-aes256":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-aes256":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-aes256":   routing: unrouted;
+"westnet-eastnet-aes256":   reqid: REQID;
 "westnet-eastnet-aes256":   conn serial: $1;
 "westnet-eastnet-aes256":   IKE algorithms: AES_CBC_256-HMAC_SHA2_256-MODP2048
 east #

--- a/testing/pluto/algo-pluto-10/west.console.txt
+++ b/testing/pluto/algo-pluto-10/west.console.txt
@@ -46,6 +46,7 @@ west #
 "westnet-eastnet-aes256":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-aes256":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-aes256":   routing: unrouted;
+"westnet-eastnet-aes256":   reqid: REQID;
 "westnet-eastnet-aes256":   conn serial: $1;
 "westnet-eastnet-aes256":   IKE algorithms: AES_CBC_256-HMAC_SHA2_256-MODP2048
 west #

--- a/testing/pluto/algo-pluto-13-invalid-3des/east.console.txt
+++ b/testing/pluto/algo-pluto-13-invalid-3des/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-aes256":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-aes256":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-aes256":   routing: unrouted;
+"westnet-eastnet-aes256":   reqid: REQID;
 "westnet-eastnet-aes256":   conn serial: $1;
 "westnet-eastnet-aes256":   IKE algorithms: AES_CBC_128-HMAC_SHA1-MODP2048, AES_CBC_128-HMAC_SHA1-MODP1536, AES_CBC_128-HMAC_SHA1-DH19, AES_CBC_128-HMAC_SHA1-DH31
 "westnet-eastnet-aes256":   ESP algorithms: 3DES_CBC-HMAC_SHA1_96

--- a/testing/pluto/algo-pluto-13-invalid-3des/west.console.txt
+++ b/testing/pluto/algo-pluto-13-invalid-3des/west.console.txt
@@ -39,6 +39,7 @@ west #
 "westnet-eastnet-aes256":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-aes256":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-aes256":   routing: unrouted;
+"westnet-eastnet-aes256":   reqid: REQID;
 "westnet-eastnet-aes256":   conn serial: $1;
 "westnet-eastnet-aes256":   IKE algorithms: AES_CBC_128-HMAC_SHA1-MODP2048, AES_CBC_128-HMAC_SHA1-MODP1536, AES_CBC_128-HMAC_SHA1-DH19, AES_CBC_128-HMAC_SHA1-DH31
 "westnet-eastnet-aes256":   ESP algorithms: 3DES_CBC_333-HMAC_SHA1_96

--- a/testing/pluto/basic-pluto-01-failtest/east.console.txt
+++ b/testing/pluto/basic-pluto-01-failtest/east.console.txt
@@ -118,6 +118,7 @@ Connection list:
 "westnet-eastnet":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet":   routing: unrouted;
+"westnet-eastnet":   reqid: REQID;
 "westnet-eastnet":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/basic-pluto-01-failtest/west.console.txt
+++ b/testing/pluto/basic-pluto-01-failtest/west.console.txt
@@ -123,6 +123,7 @@ Connection list:
 "westnet-eastnet":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet":   routing: unrouted;
+"westnet-eastnet":   reqid: REQID;
 "westnet-eastnet":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/basic-pluto-01-nosecrets/east.console.txt
+++ b/testing/pluto/basic-pluto-01-nosecrets/east.console.txt
@@ -118,6 +118,7 @@ Connection list:
 "westnet-eastnet":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet":   routing: unrouted;
+"westnet-eastnet":   reqid: REQID;
 "westnet-eastnet":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/basic-pluto-01-nosecrets/west.console.txt
+++ b/testing/pluto/basic-pluto-01-nosecrets/west.console.txt
@@ -134,6 +134,7 @@ Connection list:
 "nosecrets":   dpd: passive; delay:0s; timeout:0s
 "nosecrets":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nosecrets":   routing: unrouted;
+"nosecrets":   reqid: REQID;
 "nosecrets":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/basic-pluto-01/east.console.txt
+++ b/testing/pluto/basic-pluto-01/east.console.txt
@@ -118,6 +118,7 @@ Connection list:
 "westnet-eastnet":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet":   routing: unrouted;
+"westnet-eastnet":   reqid: REQID;
 "westnet-eastnet":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/basic-pluto-01/west.console.txt
+++ b/testing/pluto/basic-pluto-01/west.console.txt
@@ -134,6 +134,7 @@ Connection list:
 "westnet-eastnet":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet":   routing: unrouted;
+"westnet-eastnet":   reqid: REQID;
 "westnet-eastnet":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/basic-pluto-02/west.console.txt
+++ b/testing/pluto/basic-pluto-02/west.console.txt
@@ -130,6 +130,7 @@ west #
 "westnet-all":   dpd: passive; delay:0s; timeout:0s
 "westnet-all":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-all":   routing: unrouted;
+"westnet-all":   reqid: REQID;
 "westnet-all":   conn serial: $14;
 west #
  echo done

--- a/testing/pluto/basic-pluto-03/north.console.txt
+++ b/testing/pluto/basic-pluto-03/north.console.txt
@@ -129,6 +129,7 @@ Connection list:
 "northnet-eastnet-nonat":   dpd: passive; delay:0s; timeout:0s
 "northnet-eastnet-nonat":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "northnet-eastnet-nonat":   routing: unrouted;
+"northnet-eastnet-nonat":   reqid: REQID;
 "northnet-eastnet-nonat":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/basic-pluto-10-nm-configured/east.console.txt
+++ b/testing/pluto/basic-pluto-10-nm-configured/east.console.txt
@@ -118,6 +118,7 @@ Connection list:
 "westnet-eastnet":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet":   routing: unrouted;
+"westnet-eastnet":   reqid: REQID;
 "westnet-eastnet":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/basic-pluto-10-nm-configured/west.console.txt
+++ b/testing/pluto/basic-pluto-10-nm-configured/west.console.txt
@@ -134,6 +134,7 @@ Connection list:
 "westnet-eastnet":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet":   routing: unrouted;
+"westnet-eastnet":   reqid: REQID;
 "westnet-eastnet":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/basic-pluto-13-xfrm-ondemand/west.console.txt
+++ b/testing/pluto/basic-pluto-13-xfrm-ondemand/west.console.txt
@@ -32,6 +32,7 @@ west #
 "westnet-eastnet-route":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-route":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-route":   routing: routed-ondemand;
+"westnet-eastnet-route":   reqid: REQID;
 "westnet-eastnet-route":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/compress-01-ikev1/east.console.txt
+++ b/testing/pluto/compress-01-ikev1/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-compress":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-compress":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-compress":   routing: unrouted;
+"westnet-eastnet-compress":   reqid: REQID;
 "westnet-eastnet-compress":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/compress-01-ikev1/west.console.txt
+++ b/testing/pluto/compress-01-ikev1/west.console.txt
@@ -46,6 +46,7 @@ west #
 "westnet-eastnet-compress":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-compress":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-compress":   routing: unrouted;
+"westnet-eastnet-compress":   reqid: REQID;
 "westnet-eastnet-compress":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/compress-01-ikev2/east.console.txt
+++ b/testing/pluto/compress-01-ikev2/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-ipcomp":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipcomp":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipcomp":   routing: unrouted;
+"westnet-eastnet-ipcomp":   reqid: REQID;
 "westnet-eastnet-ipcomp":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/compress-01-ikev2/west.console.txt
+++ b/testing/pluto/compress-01-ikev2/west.console.txt
@@ -49,6 +49,7 @@ west #
 "westnet-eastnet-ipcomp":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipcomp":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipcomp":   routing: unrouted;
+"westnet-eastnet-ipcomp":   reqid: REQID;
 "westnet-eastnet-ipcomp":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/compress-02-cleanup-ikev1/east.console.txt
+++ b/testing/pluto/compress-02-cleanup-ikev1/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-compress":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-compress":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-compress":   routing: unrouted;
+"westnet-eastnet-compress":   reqid: REQID;
 "westnet-eastnet-compress":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/compress-02-cleanup-ikev1/west.console.txt
+++ b/testing/pluto/compress-02-cleanup-ikev1/west.console.txt
@@ -46,6 +46,7 @@ west #
 "westnet-eastnet-compress":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-compress":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-compress":   routing: unrouted;
+"westnet-eastnet-compress":   reqid: REQID;
 "westnet-eastnet-compress":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/compress-03-mismatch-ikev1/east.console.txt
+++ b/testing/pluto/compress-03-mismatch-ikev1/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-compress":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-compress":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-compress":   routing: unrouted;
+"westnet-eastnet-compress":   reqid: REQID;
 "westnet-eastnet-compress":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/compress-03-mismatch-ikev1/west.console.txt
+++ b/testing/pluto/compress-03-mismatch-ikev1/west.console.txt
@@ -46,6 +46,7 @@ west #
 "westnet-eastnet-compress":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-compress":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-compress":   routing: unrouted;
+"westnet-eastnet-compress":   reqid: REQID;
 "westnet-eastnet-compress":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/compress-03-mismatch-ikev2/east.console.txt
+++ b/testing/pluto/compress-03-mismatch-ikev2/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-ipcomp":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipcomp":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipcomp":   routing: unrouted;
+"westnet-eastnet-ipcomp":   reqid: REQID;
 "westnet-eastnet-ipcomp":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/compress-03-mismatch-ikev2/west.console.txt
+++ b/testing/pluto/compress-03-mismatch-ikev2/west.console.txt
@@ -47,6 +47,7 @@ west #
 "westnet-eastnet-ipcomp":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipcomp":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipcomp":   routing: unrouted;
+"westnet-eastnet-ipcomp":   reqid: REQID;
 "westnet-eastnet-ipcomp":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/compress-05-3des-ikev1/east.console.txt
+++ b/testing/pluto/compress-05-3des-ikev1/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-esp-3des-alg":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-esp-3des-alg":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-esp-3des-alg":   routing: unrouted;
+"westnet-eastnet-esp-3des-alg":   reqid: REQID;
 "westnet-eastnet-esp-3des-alg":   conn serial: $1;
 "westnet-eastnet-esp-3des-alg":   ESP algorithms: 3DES_CBC-HMAC_SHA1_96
 east #

--- a/testing/pluto/compress-05-3des-ikev1/west.console.txt
+++ b/testing/pluto/compress-05-3des-ikev1/west.console.txt
@@ -46,6 +46,7 @@ west #
 "westnet-eastnet-esp-3des-alg":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-esp-3des-alg":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-esp-3des-alg":   routing: unrouted;
+"westnet-eastnet-esp-3des-alg":   reqid: REQID;
 "westnet-eastnet-esp-3des-alg":   conn serial: $1;
 "westnet-eastnet-esp-3des-alg":   ESP algorithms: 3DES_CBC-HMAC_SHA1_96
 west #

--- a/testing/pluto/connalias-01-conflict/west.console.txt
+++ b/testing/pluto/connalias-01-conflict/west.console.txt
@@ -49,6 +49,7 @@ west #
 "westnet-eastnet-alias":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-alias":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-alias":   routing: unrouted;
+"westnet-eastnet-alias":   reqid: REQID;
 "westnet-eastnet-alias":   conn serial: $1;
 "westnet-eastnet-alias":   aliases: franklin
 "westnet-eastnet-second": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.0/24; unrouted; my_ip=unset; their_ip=unset;
@@ -71,6 +72,7 @@ west #
 "westnet-eastnet-second":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-second":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-second":   routing: unrouted;
+"westnet-eastnet-second":   reqid: REQID;
 "westnet-eastnet-second":   conn serial: $2;
 "westnet-eastnet-second":   aliases: abigail franklin
 west #

--- a/testing/pluto/crossing-streams-12-ikev2-permanent-ike-auth-east/west.console.txt
+++ b/testing/pluto/crossing-streams-12-ikev2-permanent-ike-auth-east/west.console.txt
@@ -115,6 +115,7 @@ west #
 "east-west":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "east-west":   nat-traversal: encapsulation:auto; keepalive:20s
 "east-west":   routing: routed-tunnel; owner: Child SA #4; established IKE SA: #1; established Child SA: #4;
+"east-west":   reqid: REQID;
 "east-west":   conn serial: $1;
 "east-west":   IKEv2 algorithm newest: AES_GCM_16_256-HMAC_SHA2_512-DH19
 "east-west":   ESP algorithm newest: AES_GCM_16_256; pfsgroup=<Phase1>

--- a/testing/pluto/crossing-streams-12-ikev2-permanent-ike-auth-west/west.console.txt
+++ b/testing/pluto/crossing-streams-12-ikev2-permanent-ike-auth-west/west.console.txt
@@ -117,6 +117,7 @@ west #
 "east-west":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "east-west":   nat-traversal: encapsulation:auto; keepalive:20s
 "east-west":   routing: routed-tunnel; owner: Child SA #3; established IKE SA: #2; established Child SA: #3;
+"east-west":   reqid: REQID;
 "east-west":   conn serial: $1;
 "east-west":   IKEv2 algorithm newest: AES_GCM_16_256-HMAC_SHA2_512-DH19
 "east-west":   ESP algorithm newest: AES_GCM_16_256; pfsgroup=<Phase1>

--- a/testing/pluto/crossing-streams-24-ikev2-delete-connswitch-github-2101/west.console.txt
+++ b/testing/pluto/crossing-streams-24-ikev2-delete-connswitch-github-2101/west.console.txt
@@ -49,6 +49,7 @@ Connection list:
 "a":   liveness: passive; dpddelay:0s; retransmit-timeout:10s
 "a":   nat-traversal: encapsulation:auto; keepalive:20s
 "a":   routing: routed-tunnel; owner: Child SA #2; established IKE SA: #3; established Child SA: #2;
+"a":   reqid: REQID;
 "a":   conn serial: $1;
 "a":   IKEv2 algorithm newest: AES_GCM_16_256-HMAC_SHA2_512-DH19
 "a":   ESP algorithm newest: AES_GCM_16_256; pfsgroup=<Phase1>
@@ -73,6 +74,7 @@ Connection list:
 "b":   liveness: passive; dpddelay:0s; retransmit-timeout:10s
 "b":   nat-traversal: encapsulation:auto; keepalive:20s
 "b":   routing: routed-tunnel; owner: Child SA #4; established Child SA: #4;
+"b":   reqid: REQID;
 "b":   conn serial: $2;
 "b":   ESP algorithm newest: AES_GCM_16_256; pfsgroup=<Phase1>
  

--- a/testing/pluto/ikev1-28-huge-lifetime/east.console.txt
+++ b/testing/pluto/ikev1-28-huge-lifetime/east.console.txt
@@ -118,6 +118,7 @@ Connection list:
 "westnet-eastnet":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet":   routing: unrouted;
+"westnet-eastnet":   reqid: REQID;
 "westnet-eastnet":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/ikev1-28-huge-lifetime/west.console.txt
+++ b/testing/pluto/ikev1-28-huge-lifetime/west.console.txt
@@ -134,6 +134,7 @@ Connection list:
 "westnet-eastnet":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet":   routing: unrouted;
+"westnet-eastnet":   reqid: REQID;
 "westnet-eastnet":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/ikev1-aggr-01-authby-default-rsasig/east.console.txt
+++ b/testing/pluto/ikev1-aggr-01-authby-default-rsasig/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-aggr":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-aggr":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-aggr":   routing: unrouted;
+"westnet-eastnet-aggr":   reqid: REQID;
 "westnet-eastnet-aggr":   conn serial: $1;
 "westnet-eastnet-aggr":   IKE algorithms: 3DES_CBC-HMAC_SHA1-MODP1536
 east #

--- a/testing/pluto/ikev1-aggr-01-authby-default-rsasig/west.console.txt
+++ b/testing/pluto/ikev1-aggr-01-authby-default-rsasig/west.console.txt
@@ -46,6 +46,7 @@ west #
 "westnet-eastnet-aggr":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-aggr":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-aggr":   routing: unrouted;
+"westnet-eastnet-aggr":   reqid: REQID;
 "westnet-eastnet-aggr":   conn serial: $1;
 "westnet-eastnet-aggr":   IKE algorithms: 3DES_CBC-HMAC_SHA1-MODP1536
 west #

--- a/testing/pluto/ikev1-aggr-02-authby-secret/east.console.txt
+++ b/testing/pluto/ikev1-aggr-02-authby-secret/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-aggr":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-aggr":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-aggr":   routing: unrouted;
+"westnet-eastnet-aggr":   reqid: REQID;
 "westnet-eastnet-aggr":   conn serial: $1;
 "westnet-eastnet-aggr":   IKE algorithms: 3DES_CBC-HMAC_SHA1-MODP1536
 east #

--- a/testing/pluto/ikev1-aggr-02-authby-secret/west.console.txt
+++ b/testing/pluto/ikev1-aggr-02-authby-secret/west.console.txt
@@ -46,6 +46,7 @@ west #
 "westnet-eastnet-aggr":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-aggr":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-aggr":   routing: unrouted;
+"westnet-eastnet-aggr":   reqid: REQID;
 "westnet-eastnet-aggr":   conn serial: $1;
 "westnet-eastnet-aggr":   IKE algorithms: 3DES_CBC-HMAC_SHA1-MODP1536
 west #

--- a/testing/pluto/ikev1-aggr-03-authby-rsasig/east.console.txt
+++ b/testing/pluto/ikev1-aggr-03-authby-rsasig/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-aggr":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-aggr":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-aggr":   routing: unrouted;
+"westnet-eastnet-aggr":   reqid: REQID;
 "westnet-eastnet-aggr":   conn serial: $1;
 "westnet-eastnet-aggr":   IKE algorithms: 3DES_CBC-HMAC_SHA1-MODP1536
 east #

--- a/testing/pluto/ikev1-aggr-03-authby-rsasig/west.console.txt
+++ b/testing/pluto/ikev1-aggr-03-authby-rsasig/west.console.txt
@@ -46,6 +46,7 @@ west #
 "westnet-eastnet-aggr":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-aggr":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-aggr":   routing: unrouted;
+"westnet-eastnet-aggr":   reqid: REQID;
 "westnet-eastnet-aggr":   conn serial: $1;
 "westnet-eastnet-aggr":   IKE algorithms: 3DES_CBC-HMAC_SHA1-MODP1536
 west #

--- a/testing/pluto/ikev1-aggr-06-use-last-ike-dh/east.console.txt
+++ b/testing/pluto/ikev1-aggr-06-use-last-ike-dh/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-aggr":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-aggr":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-aggr":   routing: unrouted;
+"westnet-eastnet-aggr":   reqid: REQID;
 "westnet-eastnet-aggr":   conn serial: $1;
 "westnet-eastnet-aggr":   IKE algorithms: AES_CBC_128-HMAC_SHA1-MODP1536, AES_CBC_128-HMAC_SHA1-MODP2048
 east #

--- a/testing/pluto/ikev1-aggr-06-use-last-ike-dh/west.console.txt
+++ b/testing/pluto/ikev1-aggr-06-use-last-ike-dh/west.console.txt
@@ -46,6 +46,7 @@ west #
 "westnet-eastnet-aggr":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-aggr":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-aggr":   routing: unrouted;
+"westnet-eastnet-aggr":   reqid: REQID;
 "westnet-eastnet-aggr":   conn serial: $1;
 "westnet-eastnet-aggr":   IKE algorithms: AES_CBC_128-HMAC_SHA1-MODP2048, AES_CBC_128-HMAC_SHA1-MODP1536, AES_CBC_128-HMAC_SHA1-DH19, AES_CBC_128-HMAC_SHA1-DH31
 west #

--- a/testing/pluto/ikev1-algo-esp-null-01/east.console.txt
+++ b/testing/pluto/ikev1-algo-esp-null-01/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-null":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-null":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-null":   routing: unrouted;
+"westnet-eastnet-null":   reqid: REQID;
 "westnet-eastnet-null":   conn serial: $1;
 "westnet-eastnet-null":   ESP algorithms: NULL-HMAC_MD5_96
 east #

--- a/testing/pluto/ikev1-algo-esp-null-01/west.console.txt
+++ b/testing/pluto/ikev1-algo-esp-null-01/west.console.txt
@@ -48,6 +48,7 @@ west #
 "westnet-eastnet-null":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-null":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-null":   routing: unrouted;
+"westnet-eastnet-null":   reqid: REQID;
 "westnet-eastnet-null":   conn serial: $1;
 "westnet-eastnet-null":   ESP algorithms: NULL-HMAC_MD5_96
 west #

--- a/testing/pluto/ikev1-algo-esp-sha2-05/east.console.txt
+++ b/testing/pluto/ikev1-algo-esp-sha2-05/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-ipv4-psk-ikev1":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-ipv4-psk-ikev1":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-ipv4-psk-ikev1":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev1":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev1":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev1":   ESP algorithms: 3DES_CBC-HMAC_SHA2_256_128
 east #

--- a/testing/pluto/ikev1-algo-esp-sha2-05/west.console.txt
+++ b/testing/pluto/ikev1-algo-esp-sha2-05/west.console.txt
@@ -32,6 +32,7 @@ west #
 "westnet-eastnet-ipv4-psk-ikev1":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-ipv4-psk-ikev1":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-ipv4-psk-ikev1":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev1":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev1":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev1":   ESP algorithms: AES_CBC-HMAC_SHA2_512_256
 west #

--- a/testing/pluto/ikev1-algo-ike-aes-01/east.console.txt
+++ b/testing/pluto/ikev1-algo-ike-aes-01/east.console.txt
@@ -118,6 +118,7 @@ Connection list:
 "westnet-eastnet-aes128":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-aes128":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-aes128":   routing: unrouted;
+"westnet-eastnet-aes128":   reqid: REQID;
 "westnet-eastnet-aes128":   conn serial: $1;
 "westnet-eastnet-aes128":   IKE algorithms: AES_CBC_256-HMAC_SHA2_256-MODP2048, AES_CBC_256-HMAC_SHA2_512-MODP2048, AES_CBC_256-HMAC_SHA1-MODP2048, AES_CBC_256-HMAC_SHA2_256-MODP1536, AES_CBC_256-HMAC_SHA2_512-MODP1536, AES_CBC_256-HMAC_SHA1-MODP1536, AES_CBC_256-HMAC_SHA2_256-DH19, AES_CBC_256-HMAC_SHA2_512-DH19, AES_CBC_256-HMAC_SHA1-DH19, AES_CBC_256-HMAC_SHA2_256-DH31, AES_CBC_256-HMAC_SHA2_512-DH31, AES_CBC_256-HMAC_SHA1-DH31
 "westnet-eastnet-aes128":   ESP algorithms: AES_CBC_128-HMAC_SHA1_96

--- a/testing/pluto/ikev1-algo-ike-aes-01/west.console.txt
+++ b/testing/pluto/ikev1-algo-ike-aes-01/west.console.txt
@@ -134,6 +134,7 @@ Connection list:
 "westnet-eastnet-aes128":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-aes128":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-aes128":   routing: unrouted;
+"westnet-eastnet-aes128":   reqid: REQID;
 "westnet-eastnet-aes128":   conn serial: $1;
 "westnet-eastnet-aes128":   IKE algorithms: AES_CBC_256-HMAC_SHA2_256-MODP2048, AES_CBC_256-HMAC_SHA2_512-MODP2048, AES_CBC_256-HMAC_SHA1-MODP2048, AES_CBC_256-HMAC_SHA2_256-MODP1536, AES_CBC_256-HMAC_SHA2_512-MODP1536, AES_CBC_256-HMAC_SHA1-MODP1536, AES_CBC_256-HMAC_SHA2_256-DH19, AES_CBC_256-HMAC_SHA2_512-DH19, AES_CBC_256-HMAC_SHA1-DH19, AES_CBC_256-HMAC_SHA2_256-DH31, AES_CBC_256-HMAC_SHA2_512-DH31, AES_CBC_256-HMAC_SHA1-DH31
 "westnet-eastnet-aes128":   ESP algorithms: AES_CBC_128-HMAC_SHA1_96

--- a/testing/pluto/ikev1-algo-ike-aes-02/east.console.txt
+++ b/testing/pluto/ikev1-algo-ike-aes-02/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-3des":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-3des":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-3des":   routing: unrouted;
+"westnet-eastnet-3des":   reqid: REQID;
 "westnet-eastnet-3des":   conn serial: $1;
 "westnet-eastnet-3des":   IKE algorithms: AES_CBC_256-HMAC_SHA2_256-MODP2048, AES_CBC_256-HMAC_SHA2_512-MODP2048, AES_CBC_256-HMAC_SHA1-MODP2048, AES_CBC_256-HMAC_SHA2_256-MODP1536, AES_CBC_256-HMAC_SHA2_512-MODP1536, AES_CBC_256-HMAC_SHA1-MODP1536, AES_CBC_256-HMAC_SHA2_256-DH19, AES_CBC_256-HMAC_SHA2_512-DH19, AES_CBC_256-HMAC_SHA1-DH19, AES_CBC_256-HMAC_SHA2_256-DH31, AES_CBC_256-HMAC_SHA2_512-DH31, AES_CBC_256-HMAC_SHA1-DH31
 "westnet-eastnet-3des":   ESP algorithms: 3DES_CBC-HMAC_MD5_96

--- a/testing/pluto/ikev1-algo-ike-aes-02/west.console.txt
+++ b/testing/pluto/ikev1-algo-ike-aes-02/west.console.txt
@@ -46,6 +46,7 @@ west #
 "westnet-eastnet-3des":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-3des":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-3des":   routing: unrouted;
+"westnet-eastnet-3des":   reqid: REQID;
 "westnet-eastnet-3des":   conn serial: $1;
 "westnet-eastnet-3des":   IKE algorithms: AES_CBC_256-HMAC_SHA2_256-MODP2048, AES_CBC_256-HMAC_SHA2_512-MODP2048, AES_CBC_256-HMAC_SHA1-MODP2048, AES_CBC_256-HMAC_SHA2_256-MODP1536, AES_CBC_256-HMAC_SHA2_512-MODP1536, AES_CBC_256-HMAC_SHA1-MODP1536, AES_CBC_256-HMAC_SHA2_256-DH19, AES_CBC_256-HMAC_SHA2_512-DH19, AES_CBC_256-HMAC_SHA1-DH19, AES_CBC_256-HMAC_SHA2_256-DH31, AES_CBC_256-HMAC_SHA2_512-DH31, AES_CBC_256-HMAC_SHA1-DH31
 "westnet-eastnet-3des":   ESP algorithms: 3DES_CBC-HMAC_MD5_96

--- a/testing/pluto/ikev1-algo-ike-sha2-01/east.console.txt
+++ b/testing/pluto/ikev1-algo-ike-sha2-01/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-sha2":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-sha2":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-sha2":   routing: unrouted;
+"westnet-eastnet-sha2":   reqid: REQID;
 "westnet-eastnet-sha2":   conn serial: $1;
 "westnet-eastnet-sha2":   IKE algorithms: AES_CBC_128-HMAC_SHA2_256-MODP2048, AES_CBC_128-HMAC_SHA2_256-MODP1536, AES_CBC_128-HMAC_SHA2_256-DH19, AES_CBC_128-HMAC_SHA2_256-DH31
 east #

--- a/testing/pluto/ikev1-algo-ike-sha2-01/west.console.txt
+++ b/testing/pluto/ikev1-algo-ike-sha2-01/west.console.txt
@@ -48,6 +48,7 @@ west #
 "westnet-eastnet-sha2":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-sha2":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-sha2":   routing: unrouted;
+"westnet-eastnet-sha2":   reqid: REQID;
 "westnet-eastnet-sha2":   conn serial: $1;
 "westnet-eastnet-sha2":   IKE algorithms: AES_CBC_128-HMAC_SHA2_256-MODP2048, AES_CBC_128-HMAC_SHA2_256-MODP1536, AES_CBC_128-HMAC_SHA2_256-DH19, AES_CBC_128-HMAC_SHA2_256-DH31
 west #

--- a/testing/pluto/ikev1-algo-ike-sha2-02/east.console.txt
+++ b/testing/pluto/ikev1-algo-ike-sha2-02/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-sha2":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-sha2":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-sha2":   routing: unrouted;
+"westnet-eastnet-sha2":   reqid: REQID;
 "westnet-eastnet-sha2":   conn serial: $1;
 "westnet-eastnet-sha2":   IKE algorithms: AES_CBC_128-HMAC_SHA2_256-MODP2048, AES_CBC_128-HMAC_SHA2_256-MODP1536, AES_CBC_128-HMAC_SHA2_256-DH19, AES_CBC_128-HMAC_SHA2_256-DH31
 east #

--- a/testing/pluto/ikev1-algo-ike-sha2-02/west.console.txt
+++ b/testing/pluto/ikev1-algo-ike-sha2-02/west.console.txt
@@ -48,6 +48,7 @@ west #
 "westnet-eastnet-sha2":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-sha2":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-sha2":   routing: unrouted;
+"westnet-eastnet-sha2":   reqid: REQID;
 "westnet-eastnet-sha2":   conn serial: $1;
 "westnet-eastnet-sha2":   IKE algorithms: AES_CBC_128-HMAC_SHA2_256-MODP2048, AES_CBC_128-HMAC_SHA2_256-MODP1536, AES_CBC_128-HMAC_SHA2_256-DH19, AES_CBC_128-HMAC_SHA2_256-DH31
 west #

--- a/testing/pluto/ikev1-algo-ike-sha2-03/east.console.txt
+++ b/testing/pluto/ikev1-algo-ike-sha2-03/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-sha2":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-sha2":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-sha2":   routing: unrouted;
+"westnet-eastnet-sha2":   reqid: REQID;
 "westnet-eastnet-sha2":   conn serial: $1;
 "westnet-eastnet-sha2":   IKE algorithms: AES_CBC_128-HMAC_SHA2_256-MODP2048, AES_CBC_128-HMAC_SHA2_256-MODP1536, AES_CBC_128-HMAC_SHA2_256-DH19, AES_CBC_128-HMAC_SHA2_256-DH31
 east #

--- a/testing/pluto/ikev1-algo-ike-sha2-03/west.console.txt
+++ b/testing/pluto/ikev1-algo-ike-sha2-03/west.console.txt
@@ -48,6 +48,7 @@ west #
 "westnet-eastnet-sha2":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-sha2":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-sha2":   routing: unrouted;
+"westnet-eastnet-sha2":   reqid: REQID;
 "westnet-eastnet-sha2":   conn serial: $1;
 "westnet-eastnet-sha2":   IKE algorithms: AES_CBC_128-HMAC_SHA2_256-MODP2048, AES_CBC_128-HMAC_SHA2_256-MODP1536, AES_CBC_128-HMAC_SHA2_256-DH19, AES_CBC_128-HMAC_SHA2_256-DH31
 west #

--- a/testing/pluto/ikev1-algo-sha2-variant-bug/east.console.txt
+++ b/testing/pluto/ikev1-algo-sha2-variant-bug/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-ipv4-psk-ikev1":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-ipv4-psk-ikev1":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-ipv4-psk-ikev1":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev1":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev1":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev1":   IKE algorithms: AES_CBC-HMAC_SHA2_512-MODP2048, AES_CBC-HMAC_SHA2_512-MODP1536, AES_CBC-HMAC_SHA2_512-DH19, AES_CBC-HMAC_SHA2_512-DH31
 "westnet-eastnet-ipv4-psk-ikev1":   ESP algorithms: AES_CBC-HMAC_SHA2_512_256

--- a/testing/pluto/ikev1-algo-sha2-variant-bug/west.console.txt
+++ b/testing/pluto/ikev1-algo-sha2-variant-bug/west.console.txt
@@ -32,6 +32,7 @@ west #
 "westnet-eastnet-ipv4-psk-ikev1":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-ipv4-psk-ikev1":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-ipv4-psk-ikev1":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev1":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev1":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev1":   IKE algorithms: AES_CBC-HMAC_SHA2_512-MODP2048, AES_CBC-HMAC_SHA2_512-MODP1536, AES_CBC-HMAC_SHA2_512-DH19, AES_CBC-HMAC_SHA2_512-DH31
 "westnet-eastnet-ipv4-psk-ikev1":   ESP algorithms: AES_CBC-HMAC_SHA2_512_256

--- a/testing/pluto/ikev1-connswitch-01/east.console.txt
+++ b/testing/pluto/ikev1-connswitch-01/east.console.txt
@@ -44,6 +44,7 @@ east #
 "westnet-eastnet":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet":   routing: unrouted;
+"westnet-eastnet":   reqid: REQID;
 "westnet-eastnet":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev1-connswitch-01/west.console.txt
+++ b/testing/pluto/ikev1-connswitch-01/west.console.txt
@@ -45,6 +45,7 @@ west #
 "westnet-eastnet-ikev1":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-ikev1":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-ikev1":   routing: unrouted;
+"westnet-eastnet-ikev1":   reqid: REQID;
 "westnet-eastnet-ikev1":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev1-connswitch-02/east.console.txt
+++ b/testing/pluto/ikev1-connswitch-02/east.console.txt
@@ -45,6 +45,7 @@ east #
 "westnet-eastnet":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet":   routing: unrouted;
+"westnet-eastnet":   reqid: REQID;
 "westnet-eastnet":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev1-connswitch-02/west.console.txt
+++ b/testing/pluto/ikev1-connswitch-02/west.console.txt
@@ -46,6 +46,7 @@ west #
 "westnet-eastnet-ikev1":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-ikev1":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-ikev1":   routing: unrouted;
+"westnet-eastnet-ikev1":   reqid: REQID;
 "westnet-eastnet-ikev1":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev1-cryptoload-00/east.console.txt
+++ b/testing/pluto/ikev1-cryptoload-00/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet":   routing: unrouted;
+"westnet-eastnet":   reqid: REQID;
 "westnet-eastnet":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev1-cryptoload-00/west.console.txt
+++ b/testing/pluto/ikev1-cryptoload-00/west.console.txt
@@ -46,6 +46,7 @@ west #
 "westnet-eastnet":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet":   routing: unrouted;
+"westnet-eastnet":   reqid: REQID;
 "westnet-eastnet":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev1-hostpair-01/east.console.txt
+++ b/testing/pluto/ikev1-hostpair-01/east.console.txt
@@ -37,6 +37,7 @@ east #
 "roadnet-eastnet-ipv4-psk-ikev1":   dpd: passive; delay:0s; timeout:0s
 "roadnet-eastnet-ipv4-psk-ikev1":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "roadnet-eastnet-ipv4-psk-ikev1":   routing: unrouted;
+"roadnet-eastnet-ipv4-psk-ikev1":   reqid: REQID;
 "roadnet-eastnet-ipv4-psk-ikev1":   conn serial: $1;
 "roadnet-eastnet-ipv4-psk-ikev1"[1]: 192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.254[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org]==={192.0.2.1/32}; routed-tunnel; my_ip=unset; their_ip=192.0.2.1;
 "roadnet-eastnet-ipv4-psk-ikev1"[1]:   host: oriented; local: 192.1.2.23; remote: 192.1.2.254; established ISAKMP SA: #3;
@@ -60,6 +61,7 @@ east #
 "roadnet-eastnet-ipv4-psk-ikev1"[1]:   dpd: passive; delay:0s; timeout:0s
 "roadnet-eastnet-ipv4-psk-ikev1"[1]:   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "roadnet-eastnet-ipv4-psk-ikev1"[1]:   routing: routed-tunnel; owner: IPsec SA #4; established ISAKMP SA: #3; established IPsec SA: #4;
+"roadnet-eastnet-ipv4-psk-ikev1"[1]:   reqid: REQID;
 "roadnet-eastnet-ipv4-psk-ikev1"[1]:   conn serial: $2, instantiated from: $1;
 "roadnet-eastnet-ipv4-psk-ikev1"[1]:   IKEv1 algorithm newest: AES_CBC_256-HMAC_SHA2_256-MODP2048
 "roadnet-eastnet-ipv4-psk-ikev1"[1]:   ESP algorithm newest: AES_CBC_128-HMAC_SHA1_96; pfsgroup=<Phase1>

--- a/testing/pluto/ikev1-hostpair-01/road.console.txt
+++ b/testing/pluto/ikev1-hostpair-01/road.console.txt
@@ -123,6 +123,7 @@ road #
 "westnet-eastnet-ipv4-psk-ikev1":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-ipv4-psk-ikev1":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-ipv4-psk-ikev1":   routing: routed-tunnel; owner: IPsec SA #2; established ISAKMP SA: #1; established IPsec SA: #2;
+"westnet-eastnet-ipv4-psk-ikev1":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev1":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev1":   IKEv1 algorithm newest: AES_CBC_256-HMAC_SHA2_256-MODP2048
 "westnet-eastnet-ipv4-psk-ikev1":   ESP algorithm newest: AES_CBC_128-HMAC_SHA1_96; pfsgroup=<Phase1>

--- a/testing/pluto/ikev1-hub-spoke/east.console.txt
+++ b/testing/pluto/ikev1-hub-spoke/east.console.txt
@@ -121,6 +121,7 @@ Connection list:
 "northnet-westnet-ipv4-psk":   dpd: passive; delay:0s; timeout:0s
 "northnet-westnet-ipv4-psk":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "northnet-westnet-ipv4-psk":   routing: unrouted;
+"northnet-westnet-ipv4-psk":   reqid: REQID;
 "northnet-westnet-ipv4-psk":   conn serial: $2;
 "westnet-northnet-ipv4-psk": 192.0.3.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-northnet-ipv4-psk":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
@@ -142,6 +143,7 @@ Connection list:
 "westnet-northnet-ipv4-psk":   dpd: passive; delay:0s; timeout:0s
 "westnet-northnet-ipv4-psk":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-northnet-ipv4-psk":   routing: unrouted;
+"westnet-northnet-ipv4-psk":   reqid: REQID;
 "westnet-northnet-ipv4-psk":   conn serial: $1;
  
 Total IPsec connections: loaded 2, routed 0, active 0

--- a/testing/pluto/ikev1-hub-spoke/north.console.txt
+++ b/testing/pluto/ikev1-hub-spoke/north.console.txt
@@ -129,6 +129,7 @@ Connection list:
 "northnet-westnet-ipv4-psk":   dpd: passive; delay:0s; timeout:0s
 "northnet-westnet-ipv4-psk":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "northnet-westnet-ipv4-psk":   routing: routed-tunnel; owner: IPsec SA #2; established ISAKMP SA: #1; established IPsec SA: #2;
+"northnet-westnet-ipv4-psk":   reqid: REQID;
 "northnet-westnet-ipv4-psk":   conn serial: $1;
 "northnet-westnet-ipv4-psk":   IKEv1 algorithm newest: AES_CBC_256-HMAC_SHA2_256-MODP2048
 "northnet-westnet-ipv4-psk":   ESP algorithm newest: AES_CBC_128-HMAC_SHA1_96; pfsgroup=<Phase1>

--- a/testing/pluto/ikev1-hub-spoke/west.console.txt
+++ b/testing/pluto/ikev1-hub-spoke/west.console.txt
@@ -118,6 +118,7 @@ Connection list:
 "westnet-northnet-ipv4-psk":   dpd: passive; delay:0s; timeout:0s
 "westnet-northnet-ipv4-psk":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-northnet-ipv4-psk":   routing: unrouted;
+"westnet-northnet-ipv4-psk":   reqid: REQID;
 "westnet-northnet-ipv4-psk":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/ikev1-impair-01-replay-duplicates/west.console.txt
+++ b/testing/pluto/ikev1-impair-01-replay-duplicates/west.console.txt
@@ -134,6 +134,7 @@ Connection list:
 "westnet-eastnet":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet":   routing: unrouted;
+"westnet-eastnet":   reqid: REQID;
 "westnet-eastnet":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/ikev1-impair-02-replay-forward/west.console.txt
+++ b/testing/pluto/ikev1-impair-02-replay-forward/west.console.txt
@@ -134,6 +134,7 @@ Connection list:
 "westnet-eastnet":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet":   routing: unrouted;
+"westnet-eastnet":   reqid: REQID;
 "westnet-eastnet":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/ikev1-isakmp-reserved-flags-01/east.console.txt
+++ b/testing/pluto/ikev1-isakmp-reserved-flags-01/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet":   routing: unrouted;
+"westnet-eastnet":   reqid: REQID;
 "westnet-eastnet":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev1-isakmp-reserved-flags-01/west.console.txt
+++ b/testing/pluto/ikev1-isakmp-reserved-flags-01/west.console.txt
@@ -48,6 +48,7 @@ west #
 "westnet-eastnet":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet":   routing: unrouted;
+"westnet-eastnet":   reqid: REQID;
 "westnet-eastnet":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev1-isakmp-reserved-flags-02/east.console.txt
+++ b/testing/pluto/ikev1-isakmp-reserved-flags-02/east.console.txt
@@ -32,6 +32,7 @@ east #
 "westnet-eastnet":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet":   routing: unrouted;
+"westnet-eastnet":   reqid: REQID;
 "westnet-eastnet":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev1-isakmp-reserved-flags-02/west.console.txt
+++ b/testing/pluto/ikev1-isakmp-reserved-flags-02/west.console.txt
@@ -46,6 +46,7 @@ west #
 "westnet-eastnet":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet":   routing: unrouted;
+"westnet-eastnet":   reqid: REQID;
 "westnet-eastnet":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev1-x509-15-pkcs7/east.console.txt
+++ b/testing/pluto/ikev1-x509-15-pkcs7/east.console.txt
@@ -45,6 +45,7 @@ east #
 "westnet-eastnet-x509":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-x509":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-x509":   routing: unrouted;
+"westnet-eastnet-x509":   reqid: REQID;
 "westnet-eastnet-x509":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-03-basic-rawrsa-pem/east.console.txt
+++ b/testing/pluto/ikev2-03-basic-rawrsa-pem/east.console.txt
@@ -105,6 +105,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-03-basic-rawrsa-pem/west.console.txt
+++ b/testing/pluto/ikev2-03-basic-rawrsa-pem/west.console.txt
@@ -65,6 +65,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-03-basic-rawrsa-rsasigkey/east.console.txt
+++ b/testing/pluto/ikev2-03-basic-rawrsa-rsasigkey/east.console.txt
@@ -121,6 +121,7 @@ Connection list:
 "west-rsasigkey-east-rsasigkey":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "west-rsasigkey-east-rsasigkey":   nat-traversal: encapsulation:auto; keepalive:20s
 "west-rsasigkey-east-rsasigkey":   routing: unrouted;
+"west-rsasigkey-east-rsasigkey":   reqid: REQID;
 "west-rsasigkey-east-rsasigkey":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/ikev2-03-basic-rawrsa/east.console.txt
+++ b/testing/pluto/ikev2-03-basic-rawrsa/east.console.txt
@@ -119,6 +119,7 @@ Connection list:
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/ikev2-03-basic-rawrsa/west.console.txt
+++ b/testing/pluto/ikev2-03-basic-rawrsa/west.console.txt
@@ -47,6 +47,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-04-basic-x509-ckaid/east.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-ckaid/east.console.txt
@@ -88,6 +88,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-04-basic-x509-ckaid/west.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-ckaid/west.console.txt
@@ -65,6 +65,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-04-basic-x509-nhelpers0/east.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-nhelpers0/east.console.txt
@@ -33,6 +33,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-04-basic-x509-nhelpers0/west.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-nhelpers0/west.console.txt
@@ -49,6 +49,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-04-basic-x509-no-ca-02/east.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-no-ca-02/east.console.txt
@@ -54,6 +54,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-04-basic-x509-no-ca-02/west.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-no-ca-02/west.console.txt
@@ -82,6 +82,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-04-basic-x509-no-ca-mismatch-02/east.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-no-ca-mismatch-02/east.console.txt
@@ -54,6 +54,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-04-basic-x509-no-ca-mismatch-02/west.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-no-ca-mismatch-02/west.console.txt
@@ -66,6 +66,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-04-basic-x509-no-ca-mismatch/east.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-no-ca-mismatch/east.console.txt
@@ -56,6 +56,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-04-basic-x509-no-ca-mismatch/west.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-no-ca-mismatch/west.console.txt
@@ -56,6 +56,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-04-basic-x509-no-ca/east.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-no-ca/east.console.txt
@@ -46,6 +46,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-04-basic-x509-no-ca/west.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-no-ca/west.console.txt
@@ -62,6 +62,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-04-basic-x509-nsspw/east.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-nsspw/east.console.txt
@@ -34,6 +34,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-04-basic-x509-nsspw/west.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509-nsspw/west.console.txt
@@ -50,6 +50,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-04-basic-x509/east.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509/east.console.txt
@@ -36,6 +36,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-04-basic-x509/west.console.txt
+++ b/testing/pluto/ikev2-04-basic-x509/west.console.txt
@@ -49,6 +49,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-09-rw-rsa/east.console.txt
+++ b/testing/pluto/ikev2-09-rw-rsa/east.console.txt
@@ -31,6 +31,7 @@ east #
 "road-eastnet-nonat":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "road-eastnet-nonat":   nat-traversal: encapsulation:auto; keepalive:20s
 "road-eastnet-nonat":   routing: unrouted;
+"road-eastnet-nonat":   reqid: REQID;
 "road-eastnet-nonat":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-09-rw-rsa/road.console.txt
+++ b/testing/pluto/ikev2-09-rw-rsa/road.console.txt
@@ -37,6 +37,7 @@ road #
 "road-eastnet-nonat":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "road-eastnet-nonat":   nat-traversal: encapsulation:auto; keepalive:20s
 "road-eastnet-nonat":   routing: unrouted;
+"road-eastnet-nonat":   reqid: REQID;
 "road-eastnet-nonat":   conn serial: $1;
 road #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-11-simple-psk/east.console.txt
+++ b/testing/pluto/ikev2-11-simple-psk/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-11-simple-psk/west.console.txt
+++ b/testing/pluto/ikev2-11-simple-psk/west.console.txt
@@ -47,6 +47,7 @@ west #
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-12-transport-psk/east.console.txt
+++ b/testing/pluto/ikev2-12-transport-psk/east.console.txt
@@ -31,6 +31,7 @@ east #
 "ipv4-psk-ikev2-transport":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "ipv4-psk-ikev2-transport":   nat-traversal: encapsulation:auto; keepalive:20s
 "ipv4-psk-ikev2-transport":   routing: unrouted;
+"ipv4-psk-ikev2-transport":   reqid: REQID;
 "ipv4-psk-ikev2-transport":   conn serial: $1;
 "ipv4-psk-ikev2-transport":   ESP algorithms: 3DES_CBC-HMAC_SHA2_256_128
 east #

--- a/testing/pluto/ikev2-12-transport-psk/west.console.txt
+++ b/testing/pluto/ikev2-12-transport-psk/west.console.txt
@@ -47,6 +47,7 @@ west #
 "ipv4-psk-ikev2-transport":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "ipv4-psk-ikev2-transport":   nat-traversal: encapsulation:auto; keepalive:20s
 "ipv4-psk-ikev2-transport":   routing: unrouted;
+"ipv4-psk-ikev2-transport":   reqid: REQID;
 "ipv4-psk-ikev2-transport":   conn serial: $1;
 "ipv4-psk-ikev2-transport":   ESP algorithms: 3DES_CBC-HMAC_SHA2_256_128
 west #

--- a/testing/pluto/ikev2-12-x509-ikev1/east.console.txt
+++ b/testing/pluto/ikev2-12-x509-ikev1/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-12-x509-ikev1/west.console.txt
+++ b/testing/pluto/ikev2-12-x509-ikev1/west.console.txt
@@ -40,6 +40,7 @@ west #
 "westnet-eastnet-ikev2":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-16-alias-whack-start/east.console.txt
+++ b/testing/pluto/ikev2-16-alias-whack-start/east.console.txt
@@ -36,6 +36,7 @@ east #
 "northnet-eastnets/0x1":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "northnet-eastnets/0x1":   nat-traversal: encapsulation:auto; keepalive:20s
 "northnet-eastnets/0x1":   routing: unrouted;
+"northnet-eastnets/0x1":   reqid: REQID;
 "northnet-eastnets/0x1":   conn serial: $1;
 "northnet-eastnets/0x1":   aliases: northnet-eastnets
 "northnet-eastnets/0x2": 192.0.22.0/24===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]---192.1.2.254...192.1.3.33[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org]===192.0.3.0/24; unrouted; my_ip=unset; their_ip=unset;
@@ -61,6 +62,7 @@ east #
 "northnet-eastnets/0x2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "northnet-eastnets/0x2":   nat-traversal: encapsulation:auto; keepalive:20s
 "northnet-eastnets/0x2":   routing: unrouted;
+"northnet-eastnets/0x2":   reqid: REQID;
 "northnet-eastnets/0x2":   conn serial: $2;
 "northnet-eastnets/0x2":   aliases: northnet-eastnets
 east #

--- a/testing/pluto/ikev2-16-alias-whack-start/north.console.txt
+++ b/testing/pluto/ikev2-16-alias-whack-start/north.console.txt
@@ -52,6 +52,7 @@ north #
 "northnet-eastnets/0x1":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "northnet-eastnets/0x1":   nat-traversal: encapsulation:auto; keepalive:20s
 "northnet-eastnets/0x1":   routing: routed-tunnel; owner: Child SA #2; established IKE SA: #1; established Child SA: #2;
+"northnet-eastnets/0x1":   reqid: REQID;
 "northnet-eastnets/0x1":   conn serial: $1;
 "northnet-eastnets/0x1":   aliases: northnet-eastnets
 "northnet-eastnets/0x1":   IKEv2 algorithm newest: AES_GCM_16_256-HMAC_SHA2_512-DH19
@@ -79,6 +80,7 @@ north #
 "northnet-eastnets/0x2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "northnet-eastnets/0x2":   nat-traversal: encapsulation:auto; keepalive:20s
 "northnet-eastnets/0x2":   routing: routed-tunnel; owner: Child SA #3; established Child SA: #3;
+"northnet-eastnets/0x2":   reqid: REQID;
 "northnet-eastnets/0x2":   conn serial: $2;
 "northnet-eastnets/0x2":   aliases: northnet-eastnets
 "northnet-eastnets/0x2":   ESP algorithm newest: AES_GCM_16_256; pfsgroup=<Phase1>

--- a/testing/pluto/ikev2-16-alias-whack-up/east.console.txt
+++ b/testing/pluto/ikev2-16-alias-whack-up/east.console.txt
@@ -36,6 +36,7 @@ east #
 "northnet-eastnets/0x1":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "northnet-eastnets/0x1":   nat-traversal: encapsulation:auto; keepalive:20s
 "northnet-eastnets/0x1":   routing: unrouted;
+"northnet-eastnets/0x1":   reqid: REQID;
 "northnet-eastnets/0x1":   conn serial: $1;
 "northnet-eastnets/0x1":   aliases: northnet-eastnets
 "northnet-eastnets/0x2": 192.0.22.0/24===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]---192.1.2.254...192.1.3.33[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=north.testing.libreswan.org, E=user-north@testing.libreswan.org]===192.0.3.0/24; unrouted; my_ip=unset; their_ip=unset;
@@ -61,6 +62,7 @@ east #
 "northnet-eastnets/0x2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "northnet-eastnets/0x2":   nat-traversal: encapsulation:auto; keepalive:20s
 "northnet-eastnets/0x2":   routing: unrouted;
+"northnet-eastnets/0x2":   reqid: REQID;
 "northnet-eastnets/0x2":   conn serial: $2;
 "northnet-eastnets/0x2":   aliases: northnet-eastnets
 east #

--- a/testing/pluto/ikev2-16-alias-whack-up/north.console.txt
+++ b/testing/pluto/ikev2-16-alias-whack-up/north.console.txt
@@ -52,6 +52,7 @@ north #
 "northnet-eastnets/0x1":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "northnet-eastnets/0x1":   nat-traversal: encapsulation:auto; keepalive:20s
 "northnet-eastnets/0x1":   routing: routed-tunnel; owner: Child SA #2; established IKE SA: #1; established Child SA: #2;
+"northnet-eastnets/0x1":   reqid: REQID;
 "northnet-eastnets/0x1":   conn serial: $1;
 "northnet-eastnets/0x1":   aliases: northnet-eastnets
 "northnet-eastnets/0x1":   IKEv2 algorithm newest: AES_GCM_16_256-HMAC_SHA2_512-DH19
@@ -79,6 +80,7 @@ north #
 "northnet-eastnets/0x2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "northnet-eastnets/0x2":   nat-traversal: encapsulation:auto; keepalive:20s
 "northnet-eastnets/0x2":   routing: routed-tunnel; owner: Child SA #3; established Child SA: #3;
+"northnet-eastnets/0x2":   reqid: REQID;
 "northnet-eastnets/0x2":   conn serial: $2;
 "northnet-eastnets/0x2":   aliases: northnet-eastnets
 "northnet-eastnets/0x2":   ESP algorithm newest: AES_GCM_16_256; pfsgroup=<Phase1>

--- a/testing/pluto/ikev2-17-rekey-ipsec/east.console.txt
+++ b/testing/pluto/ikev2-17-rekey-ipsec/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-17-rekey-ipsec/west.console.txt
+++ b/testing/pluto/ikev2-17-rekey-ipsec/west.console.txt
@@ -47,6 +47,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-21-mode-mismatch-01/east.console.txt
+++ b/testing/pluto/ikev2-21-mode-mismatch-01/east.console.txt
@@ -31,6 +31,7 @@ east #
 "ipv4-psk-ikev2-transport":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "ipv4-psk-ikev2-transport":   nat-traversal: encapsulation:auto; keepalive:20s
 "ipv4-psk-ikev2-transport":   routing: unrouted;
+"ipv4-psk-ikev2-transport":   reqid: REQID;
 "ipv4-psk-ikev2-transport":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-21-mode-mismatch-01/west.console.txt
+++ b/testing/pluto/ikev2-21-mode-mismatch-01/west.console.txt
@@ -36,6 +36,7 @@ west #
 "ipv4-psk-ikev2-transport":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "ipv4-psk-ikev2-transport":   nat-traversal: encapsulation:auto; keepalive:20s
 "ipv4-psk-ikev2-transport":   routing: unrouted;
+"ipv4-psk-ikev2-transport":   reqid: REQID;
 "ipv4-psk-ikev2-transport":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-21-mode-mismatch-02/east.console.txt
+++ b/testing/pluto/ikev2-21-mode-mismatch-02/east.console.txt
@@ -31,6 +31,7 @@ east #
 "ipv4-psk-ikev2-transport":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "ipv4-psk-ikev2-transport":   nat-traversal: encapsulation:auto; keepalive:20s
 "ipv4-psk-ikev2-transport":   routing: unrouted;
+"ipv4-psk-ikev2-transport":   reqid: REQID;
 "ipv4-psk-ikev2-transport":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-21-mode-mismatch-02/west.console.txt
+++ b/testing/pluto/ikev2-21-mode-mismatch-02/west.console.txt
@@ -36,6 +36,7 @@ west #
 "ipv4-psk-ikev2-transport":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "ipv4-psk-ikev2-transport":   nat-traversal: encapsulation:auto; keepalive:20s
 "ipv4-psk-ikev2-transport":   routing: unrouted;
+"ipv4-psk-ikev2-transport":   reqid: REQID;
 "ipv4-psk-ikev2-transport":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-28-rw-server-rekey/east.console.txt
+++ b/testing/pluto/ikev2-28-rw-server-rekey/east.console.txt
@@ -31,6 +31,7 @@ east #
 "road-eastnet-nonat":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "road-eastnet-nonat":   nat-traversal: encapsulation:auto; keepalive:20s
 "road-eastnet-nonat":   routing: unrouted;
+"road-eastnet-nonat":   reqid: REQID;
 "road-eastnet-nonat":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-28-rw-server-rekey/road.console.txt
+++ b/testing/pluto/ikev2-28-rw-server-rekey/road.console.txt
@@ -37,6 +37,7 @@ road #
 "road-eastnet-nonat":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "road-eastnet-nonat":   nat-traversal: encapsulation:auto; keepalive:20s
 "road-eastnet-nonat":   routing: unrouted;
+"road-eastnet-nonat":   reqid: REQID;
 "road-eastnet-nonat":   conn serial: $1;
 road #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-29-no-rekey/east.console.txt
+++ b/testing/pluto/ikev2-29-no-rekey/east.console.txt
@@ -119,6 +119,7 @@ Connection list:
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/ikev2-29-no-rekey/west.console.txt
+++ b/testing/pluto/ikev2-29-no-rekey/west.console.txt
@@ -47,6 +47,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits
@@ -178,6 +179,7 @@ Connection list:
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: routed-tunnel; owner: Child SA #2; established IKE SA: #1; established Child SA: #2;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 "westnet-eastnet-ikev2":   IKEv2 algorithm newest: AES_GCM_16_256-HMAC_SHA2_512-DH19
 "westnet-eastnet-ikev2":   ESP algorithm newest: AES_GCM_16_256; pfsgroup=<Phase1>
@@ -312,6 +314,7 @@ Connection list:
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: routed-ondemand;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 1, active 0

--- a/testing/pluto/ikev2-41-rw-replace/road.console.txt
+++ b/testing/pluto/ikev2-41-rw-replace/road.console.txt
@@ -140,6 +140,7 @@ Connection list:
 "road-east-x509-ipv4":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "road-east-x509-ipv4":   nat-traversal: encapsulation:auto; keepalive:20s
 "road-east-x509-ipv4":   routing: unrouted;
+"road-east-x509-ipv4":   reqid: REQID;
 "road-east-x509-ipv4":   conn serial: $1;
 "road-east-x509-ipv4"[1]: 192.0.2.100/32===192.1.3.209[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org]---192.1.3.254...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===0.0.0.0/0; routed-tunnel; my_ip=192.0.2.100; their_ip=unset;
 "road-east-x509-ipv4"[1]:   host: oriented; local: 192.1.3.209; nexthop: 192.1.3.254; remote: 192.1.2.23; established IKE SA: #1;
@@ -164,6 +165,7 @@ Connection list:
 "road-east-x509-ipv4"[1]:   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "road-east-x509-ipv4"[1]:   nat-traversal: encapsulation:auto; keepalive:20s
 "road-east-x509-ipv4"[1]:   routing: routed-tunnel; owner: Child SA #2; established IKE SA: #1; established Child SA: #2;
+"road-east-x509-ipv4"[1]:   reqid: REQID;
 "road-east-x509-ipv4"[1]:   conn serial: $2, instantiated from: $1;
 "road-east-x509-ipv4"[1]:   IKEv2 algorithm newest: AES_GCM_16_256-HMAC_SHA2_512-DH19
 "road-east-x509-ipv4"[1]:   ESP algorithm newest: AES_GCM_16_256; pfsgroup=<Phase1>
@@ -314,6 +316,7 @@ Connection list:
 "road-east-x509-ipv4":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "road-east-x509-ipv4":   nat-traversal: encapsulation:auto; keepalive:20s
 "road-east-x509-ipv4":   routing: unrouted;
+"road-east-x509-ipv4":   reqid: REQID;
 "road-east-x509-ipv4":   conn serial: $1;
 "road-east-x509-ipv4"[1]: 192.0.2.100/32===192.1.3.209[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org]---192.1.3.254...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===0.0.0.0/0; routed-tunnel; my_ip=192.0.2.100; their_ip=unset;
 "road-east-x509-ipv4"[1]:   host: oriented; local: 192.1.3.209; nexthop: 192.1.3.254; remote: 192.1.2.23; established IKE SA: #3;
@@ -338,6 +341,7 @@ Connection list:
 "road-east-x509-ipv4"[1]:   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "road-east-x509-ipv4"[1]:   nat-traversal: encapsulation:auto; keepalive:20s
 "road-east-x509-ipv4"[1]:   routing: routed-tunnel; owner: Child SA #2; established IKE SA: #3; established Child SA: #2;
+"road-east-x509-ipv4"[1]:   reqid: REQID;
 "road-east-x509-ipv4"[1]:   conn serial: $2, instantiated from: $1;
 "road-east-x509-ipv4"[1]:   IKEv2 algorithm newest: AES_GCM_16_256-HMAC_SHA2_512-DH19
 "road-east-x509-ipv4"[1]:   ESP algorithm newest: AES_GCM_16_256; pfsgroup=<Phase1>

--- a/testing/pluto/ikev2-42-rw-replace-responder/road.console.txt
+++ b/testing/pluto/ikev2-42-rw-replace-responder/road.console.txt
@@ -162,6 +162,7 @@ Connection list:
 "road-east-x509-ipv4":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "road-east-x509-ipv4":   nat-traversal: encapsulation:auto; keepalive:20s
 "road-east-x509-ipv4":   routing: unrouted;
+"road-east-x509-ipv4":   reqid: REQID;
 "road-east-x509-ipv4":   conn serial: $1;
 "road-east-x509-ipv4"[1]: 192.0.2.100/32===192.1.3.209[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org]---192.1.3.254...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]===0.0.0.0/0; routed-tunnel; my_ip=192.0.2.100; their_ip=unset;
 "road-east-x509-ipv4"[1]:   host: oriented; local: 192.1.3.209; nexthop: 192.1.3.254; remote: 192.1.2.23; established IKE SA: #3;
@@ -186,6 +187,7 @@ Connection list:
 "road-east-x509-ipv4"[1]:   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "road-east-x509-ipv4"[1]:   nat-traversal: encapsulation:auto; keepalive:20s
 "road-east-x509-ipv4"[1]:   routing: routed-tunnel; owner: Child SA #2; established IKE SA: #3; established Child SA: #2;
+"road-east-x509-ipv4"[1]:   reqid: REQID;
 "road-east-x509-ipv4"[1]:   conn serial: $2, instantiated from: $1;
 "road-east-x509-ipv4"[1]:   IKEv2 algorithm newest: AES_GCM_16_256-HMAC_SHA2_512-DH19
 "road-east-x509-ipv4"[1]:   ESP algorithm newest: AES_GCM_16_256; pfsgroup=<Phase1>

--- a/testing/pluto/ikev2-47-priority/east.console.txt
+++ b/testing/pluto/ikev2-47-priority/east.console.txt
@@ -119,6 +119,7 @@ Connection list:
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/ikev2-47-priority/west.console.txt
+++ b/testing/pluto/ikev2-47-priority/west.console.txt
@@ -135,6 +135,7 @@ Connection list:
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/ikev2-49-hub-spoke/east.console.txt
+++ b/testing/pluto/ikev2-49-hub-spoke/east.console.txt
@@ -122,6 +122,7 @@ Connection list:
 "northnet-westnet-ipv4-psk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "northnet-westnet-ipv4-psk":   nat-traversal: encapsulation:auto; keepalive:20s
 "northnet-westnet-ipv4-psk":   routing: unrouted;
+"northnet-westnet-ipv4-psk":   reqid: REQID;
 "northnet-westnet-ipv4-psk":   conn serial: $2;
 "westnet-northnet-ipv4-psk": 192.0.3.0/24===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-northnet-ipv4-psk":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
@@ -144,6 +145,7 @@ Connection list:
 "westnet-northnet-ipv4-psk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-northnet-ipv4-psk":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-northnet-ipv4-psk":   routing: unrouted;
+"westnet-northnet-ipv4-psk":   reqid: REQID;
 "westnet-northnet-ipv4-psk":   conn serial: $1;
  
 Total IPsec connections: loaded 2, routed 0, active 0

--- a/testing/pluto/ikev2-49-hub-spoke/north.console.txt
+++ b/testing/pluto/ikev2-49-hub-spoke/north.console.txt
@@ -130,6 +130,7 @@ Connection list:
 "northnet-westnet-ipv4-psk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "northnet-westnet-ipv4-psk":   nat-traversal: encapsulation:auto; keepalive:20s
 "northnet-westnet-ipv4-psk":   routing: routed-tunnel; owner: Child SA #2; established IKE SA: #1; established Child SA: #2;
+"northnet-westnet-ipv4-psk":   reqid: REQID;
 "northnet-westnet-ipv4-psk":   conn serial: $1;
 "northnet-westnet-ipv4-psk":   IKEv2 algorithm newest: AES_GCM_16_256-HMAC_SHA2_512-DH19
 "northnet-westnet-ipv4-psk":   ESP algorithm newest: AES_GCM_16_256; pfsgroup=<Phase1>

--- a/testing/pluto/ikev2-49-hub-spoke/west.console.txt
+++ b/testing/pluto/ikev2-49-hub-spoke/west.console.txt
@@ -119,6 +119,7 @@ Connection list:
 "westnet-northnet-ipv4-psk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-northnet-ipv4-psk":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-northnet-ipv4-psk":   routing: unrouted;
+"westnet-northnet-ipv4-psk":   reqid: REQID;
 "westnet-northnet-ipv4-psk":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/ikev2-53-clean-pending/west.console.txt
+++ b/testing/pluto/ikev2-53-clean-pending/west.console.txt
@@ -28,6 +28,7 @@ west #
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:20s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted-bare-negotiation; owner: IKE SA #1; negotiating IKE SA: #1;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 #1: "westnet-eastnet-ipv4-psk-ikev2":500 sent IKE_SA_INIT request; RETRANSMIT in XXs; idle;
 #1: pending Child SA for "westnet-eastnet-ipv4-psk-ikev2"
@@ -57,6 +58,7 @@ west #
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:20s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted-bare-negotiation; owner: IKE SA #1; negotiating IKE SA: #1;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 #1: "westnet-eastnet-ipv4-psk-ikev2":500 sent IKE_SA_INIT request; RETRANSMIT in XXs; idle;
 #1: pending Child SA for "westnet-eastnet-ipv4-psk-ikev2"
@@ -88,6 +90,7 @@ west #
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:20s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted-bare-negotiation; owner: IKE SA #2; negotiating IKE SA: #2;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 #2: "westnet-eastnet-ipv4-psk-ikev2":500 sent IKE_SA_INIT request; RETRANSMIT in XXs; idle;
 #2: pending Child SA for "westnet-eastnet-ipv4-psk-ikev2"

--- a/testing/pluto/ikev2-55-ipseckey-01/east.console.txt
+++ b/testing/pluto/ikev2-55-ipseckey-01/east.console.txt
@@ -31,6 +31,7 @@ east #
 "road-east-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "road-east-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "road-east-ikev2":   routing: unrouted;
+"road-east-ikev2":   reqid: REQID;
 "road-east-ikev2":   conn serial: $1;
 east #
  # eash should have only one pub key not road.

--- a/testing/pluto/ikev2-55-ipseckey-02/east.console.txt
+++ b/testing/pluto/ikev2-55-ipseckey-02/east.console.txt
@@ -31,6 +31,7 @@ east #
 "road-east":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "road-east":   nat-traversal: encapsulation:auto; keepalive:20s
 "road-east":   routing: unrouted;
+"road-east":   reqid: REQID;
 "road-east":   conn serial: $2;
 east #
  # eash should have only one pub key not road.

--- a/testing/pluto/ikev2-55-ipseckey-03/east.console.txt
+++ b/testing/pluto/ikev2-55-ipseckey-03/east.console.txt
@@ -31,6 +31,7 @@ east #
 "road-east-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "road-east-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "road-east-ikev2":   routing: unrouted;
+"road-east-ikev2":   reqid: REQID;
 "road-east-ikev2":   conn serial: $1;
 east #
  # east should have only one public key of its own

--- a/testing/pluto/ikev2-55-ipseckey-04/east.console.txt
+++ b/testing/pluto/ikev2-55-ipseckey-04/east.console.txt
@@ -31,6 +31,7 @@ east #
 "road-east-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "road-east-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "road-east-ikev2":   routing: unrouted;
+"road-east-ikev2":   reqid: REQID;
 "road-east-ikev2":   conn serial: $1;
 east #
  # east should have only one public key of its own

--- a/testing/pluto/ikev2-55-ipseckey-05/east.console.txt
+++ b/testing/pluto/ikev2-55-ipseckey-05/east.console.txt
@@ -31,6 +31,7 @@ east #
 "road-east-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "road-east-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "road-east-ikev2":   routing: unrouted;
+"road-east-ikev2":   reqid: REQID;
 "road-east-ikev2":   conn serial: $1;
 east #
  # east should have only one public key of its own

--- a/testing/pluto/ikev2-55-ipseckey-06/east.console.txt
+++ b/testing/pluto/ikev2-55-ipseckey-06/east.console.txt
@@ -31,6 +31,7 @@ east #
 "road-east-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "road-east-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "road-east-ikev2":   routing: unrouted;
+"road-east-ikev2":   reqid: REQID;
 "road-east-ikev2":   conn serial: $1;
 east #
  # east should have only one public key of its own

--- a/testing/pluto/ikev2-55-ipseckey-08/east.console.txt
+++ b/testing/pluto/ikev2-55-ipseckey-08/east.console.txt
@@ -31,6 +31,7 @@ east #
 "east-any":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "east-any":   nat-traversal: encapsulation:auto; keepalive:20s
 "east-any":   routing: unrouted;
+"east-any":   reqid: REQID;
 "east-any":   conn serial: $1;
 east #
  # east should have only one public key of its own

--- a/testing/pluto/ikev2-55-ipseckey-09/east.console.txt
+++ b/testing/pluto/ikev2-55-ipseckey-09/east.console.txt
@@ -31,6 +31,7 @@ east #
 "road-east":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "road-east":   nat-traversal: encapsulation:auto; keepalive:20s
 "road-east":   routing: unrouted;
+"road-east":   reqid: REQID;
 "road-east":   conn serial: $1;
 east #
  # eash should have only one pub key not road.

--- a/testing/pluto/ikev2-63-anyid-nat/road.console.txt
+++ b/testing/pluto/ikev2-63-anyid-nat/road.console.txt
@@ -31,6 +31,7 @@ road #
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 road #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-algo-03-aes-ccm/east.console.txt
+++ b/testing/pluto/ikev2-algo-03-aes-ccm/east.console.txt
@@ -119,6 +119,7 @@ Connection list:
 "westnet-eastnet-ipv4-psk-ikev2-ccm-a":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2-ccm-a":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2-ccm-a":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2-ccm-a":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2-ccm-a":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2-ccm-a":   ESP algorithms: AES_CCM_8_128
  

--- a/testing/pluto/ikev2-algo-03-aes-ccm/west.console.txt
+++ b/testing/pluto/ikev2-algo-03-aes-ccm/west.console.txt
@@ -142,6 +142,7 @@ Connection list:
 "westnet-eastnet-ipv4-psk-ikev2-ccm-a":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2-ccm-a":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2-ccm-a":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2-ccm-a":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2-ccm-a":   conn serial: $2;
 "westnet-eastnet-ipv4-psk-ikev2-ccm-a":   ESP algorithms: AES_CCM_8_128
  

--- a/testing/pluto/ikev2-algo-04-aes-gcm256/east.console.txt
+++ b/testing/pluto/ikev2-algo-04-aes-gcm256/east.console.txt
@@ -119,6 +119,7 @@ Connection list:
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2-gcm-c":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   ESP algorithms: AES_GCM_16_256
  

--- a/testing/pluto/ikev2-algo-04-aes-gcm256/west.console.txt
+++ b/testing/pluto/ikev2-algo-04-aes-gcm256/west.console.txt
@@ -137,6 +137,7 @@ Connection list:
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2-gcm-c":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   ESP algorithms: AES_GCM_16_256
  

--- a/testing/pluto/ikev2-algo-06-aes-aes_xcbc/east.console.txt
+++ b/testing/pluto/ikev2-algo-06-aes-aes_xcbc/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2":   IKE algorithms: AES_CBC-AES_XCBC-DH19+DH20+DH21+DH31+MODP4096+MODP3072+MODP2048+MODP8192
 "westnet-eastnet-ipv4-psk-ikev2":   ESP algorithms: AES_CBC-AES_XCBC_96

--- a/testing/pluto/ikev2-algo-06-aes-aes_xcbc/west.console.txt
+++ b/testing/pluto/ikev2-algo-06-aes-aes_xcbc/west.console.txt
@@ -47,6 +47,7 @@ west #
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2":   IKE algorithms: AES_CBC-AES_XCBC-DH19+DH20+DH21+DH31+MODP4096+MODP3072+MODP2048+MODP8192
 "westnet-eastnet-ipv4-psk-ikev2":   ESP algorithms: AES_CBC-AES_XCBC_96

--- a/testing/pluto/ikev2-algo-07-aes_ctr/east.console.txt
+++ b/testing/pluto/ikev2-algo-07-aes_ctr/east.console.txt
@@ -119,6 +119,7 @@ Connection list:
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2":   IKE algorithms: AES_CTR_128-HMAC_SHA1-MODP2048
 "westnet-eastnet-ipv4-psk-ikev2":   ESP algorithms: AES_CTR_256-HMAC_SHA1_96

--- a/testing/pluto/ikev2-algo-07-aes_ctr/west.console.txt
+++ b/testing/pluto/ikev2-algo-07-aes_ctr/west.console.txt
@@ -135,6 +135,7 @@ Connection list:
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2":   IKE algorithms: AES_CTR_128-HMAC_SHA1-MODP2048
 "westnet-eastnet-ipv4-psk-ikev2":   ESP algorithms: AES_CTR_256-HMAC_SHA1_96

--- a/testing/pluto/ikev2-algo-10-aes-gcm128/east.console.txt
+++ b/testing/pluto/ikev2-algo-10-aes-gcm128/east.console.txt
@@ -119,6 +119,7 @@ Connection list:
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2-gcm-c":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   ESP algorithms: AES_GCM_16_128
  

--- a/testing/pluto/ikev2-algo-10-aes-gcm128/west.console.txt
+++ b/testing/pluto/ikev2-algo-10-aes-gcm128/west.console.txt
@@ -137,6 +137,7 @@ Connection list:
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2-gcm-c":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2-gcm-c":   ESP algorithms: AES_GCM_16_128
  

--- a/testing/pluto/ikev2-algo-12-aes-aes_cmac/east.console.txt
+++ b/testing/pluto/ikev2-algo-12-aes-aes_cmac/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2":   ESP algorithms: AES_CBC-AES_CMAC_96
 east #

--- a/testing/pluto/ikev2-algo-12-aes-aes_cmac/west.console.txt
+++ b/testing/pluto/ikev2-algo-12-aes-aes_cmac/west.console.txt
@@ -47,6 +47,7 @@ west #
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2":   ESP algorithms: AES_CBC-AES_CMAC_96
 west #

--- a/testing/pluto/ikev2-algo-13-esp-null/east.console.txt
+++ b/testing/pluto/ikev2-algo-13-esp-null/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-esp-null":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-esp-null":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-esp-null":   routing: unrouted;
+"westnet-eastnet-esp-null":   reqid: REQID;
 "westnet-eastnet-esp-null":   conn serial: $1;
 "westnet-eastnet-esp-null":   ESP algorithms: NULL-HMAC_MD5_96, NULL-HMAC_SHA1_96
 east #

--- a/testing/pluto/ikev2-algo-15-esp-null-none/east.console.txt
+++ b/testing/pluto/ikev2-algo-15-esp-null-none/east.console.txt
@@ -33,6 +33,7 @@ east #
 "esp=null-none":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "esp=null-none":   nat-traversal: encapsulation:auto; keepalive:20s
 "esp=null-none":   routing: unrouted;
+"esp=null-none":   reqid: REQID;
 "esp=null-none":   conn serial: $1;
 "esp=null-none":   IKE algorithms: AES_CBC_128-HMAC_SHA1-MODP2048
 "esp=null-none":   ESP algorithms: NULL-NONE

--- a/testing/pluto/ikev2-algo-17-no-sha1-01/east.console.txt
+++ b/testing/pluto/ikev2-algo-17-no-sha1-01/east.console.txt
@@ -119,6 +119,7 @@ Connection list:
 "westnet-eastnet-no-sha1":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-no-sha1":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-no-sha1":   routing: unrouted;
+"westnet-eastnet-no-sha1":   reqid: REQID;
 "westnet-eastnet-no-sha1":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/ikev2-algo-17-no-sha1-01/west.console.txt
+++ b/testing/pluto/ikev2-algo-17-no-sha1-01/west.console.txt
@@ -119,6 +119,7 @@ Connection list:
 "westnet-eastnet-no-sha1":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-no-sha1":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-no-sha1":   routing: unrouted;
+"westnet-eastnet-no-sha1":   reqid: REQID;
 "westnet-eastnet-no-sha1":   conn serial: $1;
 "westnet-eastnet-no-sha1":   ESP algorithms: AES_CBC_128-HMAC_SHA1_96
  

--- a/testing/pluto/ikev2-algo-ike-sha2-01/east.console.txt
+++ b/testing/pluto/ikev2-algo-ike-sha2-01/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2":   IKE algorithms: 3DES_CBC-HMAC_SHA2_256-DH19+DH20+DH21+DH31+MODP4096+MODP3072+MODP2048+MODP8192
 east #

--- a/testing/pluto/ikev2-algo-ike-sha2-01/west.console.txt
+++ b/testing/pluto/ikev2-algo-ike-sha2-01/west.console.txt
@@ -47,6 +47,7 @@ west #
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2":   IKE algorithms: 3DES_CBC-HMAC_SHA2_256-DH19+DH20+DH21+DH31+MODP4096+MODP3072+MODP2048+MODP8192
 west #

--- a/testing/pluto/ikev2-algo-ike-sha2-02/east.console.txt
+++ b/testing/pluto/ikev2-algo-ike-sha2-02/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2":   IKE algorithms: AES_CBC_128-HMAC_SHA2_256-DH19+DH20+DH21+DH31+MODP4096+MODP3072+MODP2048+MODP8192
 east #

--- a/testing/pluto/ikev2-algo-ike-sha2-02/west.console.txt
+++ b/testing/pluto/ikev2-algo-ike-sha2-02/west.console.txt
@@ -47,6 +47,7 @@ west #
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2":   IKE algorithms: AES_CBC_128-HMAC_SHA2_256-DH19+DH20+DH21+DH31+MODP4096+MODP3072+MODP2048+MODP8192
 west #

--- a/testing/pluto/ikev2-algo-ike-sha2-03/east.console.txt
+++ b/testing/pluto/ikev2-algo-ike-sha2-03/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2":   IKE algorithms: AES_CBC-HMAC_SHA2_256-DH19+DH20+DH21+DH31+MODP4096+MODP3072+MODP2048+MODP8192
 east #

--- a/testing/pluto/ikev2-algo-ike-sha2-03/west.console.txt
+++ b/testing/pluto/ikev2-algo-ike-sha2-03/west.console.txt
@@ -47,6 +47,7 @@ west #
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2":   IKE algorithms: AES_CBC-HMAC_SHA2_256-DH19+DH20+DH21+DH31+MODP4096+MODP3072+MODP2048+MODP8192
 west #

--- a/testing/pluto/ikev2-algo-pluto-09/east.console.txt
+++ b/testing/pluto/ikev2-algo-pluto-09/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-dh19":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-dh19":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-dh19":   routing: unrouted;
+"westnet-eastnet-dh19":   reqid: REQID;
 "westnet-eastnet-dh19":   conn serial: $1;
 "westnet-eastnet-dh19":   IKE algorithms: AES_CBC-HMAC_SHA1-DH19
 "westnet-eastnet-dh19":   ESP algorithms: AES_CBC-HMAC_SHA1_96-DH19

--- a/testing/pluto/ikev2-algo-pluto-09/west.console.txt
+++ b/testing/pluto/ikev2-algo-pluto-09/west.console.txt
@@ -47,6 +47,7 @@ west #
 "westnet-eastnet-dh19":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-dh19":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-dh19":   routing: unrouted;
+"westnet-eastnet-dh19":   reqid: REQID;
 "westnet-eastnet-dh19":   conn serial: $1;
 "westnet-eastnet-dh19":   IKE algorithms: AES_CBC-HMAC_SHA1-DH19
 "westnet-eastnet-dh19":   ESP algorithms: AES_CBC-HMAC_SHA1_96-DH19

--- a/testing/pluto/ikev2-algo-sha2-01/east.console.txt
+++ b/testing/pluto/ikev2-algo-sha2-01/east.console.txt
@@ -119,6 +119,7 @@ Connection list:
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2":   ESP algorithms: AES_CBC_128-HMAC_SHA2_256_128
  

--- a/testing/pluto/ikev2-algo-sha2-01/west.console.txt
+++ b/testing/pluto/ikev2-algo-sha2-01/west.console.txt
@@ -135,6 +135,7 @@ Connection list:
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2":   ESP algorithms: AES_CBC_128-HMAC_SHA2_256_128
  

--- a/testing/pluto/ikev2-algo-sha2-02/east.console.txt
+++ b/testing/pluto/ikev2-algo-sha2-02/east.console.txt
@@ -119,6 +119,7 @@ Connection list:
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2":   ESP algorithms: AES_CBC-HMAC_SHA2_384_192
  

--- a/testing/pluto/ikev2-algo-sha2-02/west.console.txt
+++ b/testing/pluto/ikev2-algo-sha2-02/west.console.txt
@@ -135,6 +135,7 @@ Connection list:
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2":   ESP algorithms: AES_CBC-HMAC_SHA2_384_192
  

--- a/testing/pluto/ikev2-algo-sha2-03/east.console.txt
+++ b/testing/pluto/ikev2-algo-sha2-03/east.console.txt
@@ -119,6 +119,7 @@ Connection list:
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2":   ESP algorithms: AES_CBC-HMAC_SHA2_384_192
  

--- a/testing/pluto/ikev2-algo-sha2-03/west.console.txt
+++ b/testing/pluto/ikev2-algo-sha2-03/west.console.txt
@@ -135,6 +135,7 @@ Connection list:
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2":   ESP algorithms: AES_CBC-HMAC_SHA2_384_192
  

--- a/testing/pluto/ikev2-algo-sha2-04/east.console.txt
+++ b/testing/pluto/ikev2-algo-sha2-04/east.console.txt
@@ -119,6 +119,7 @@ Connection list:
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2":   ESP algorithms: AES_CBC-HMAC_SHA2_512_256
  

--- a/testing/pluto/ikev2-algo-sha2-04/west.console.txt
+++ b/testing/pluto/ikev2-algo-sha2-04/west.console.txt
@@ -135,6 +135,7 @@ Connection list:
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2":   ESP algorithms: AES_CBC-HMAC_SHA2_512_256
  

--- a/testing/pluto/ikev2-algo-sha2-05/east.console.txt
+++ b/testing/pluto/ikev2-algo-sha2-05/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2":   ESP algorithms: AES_CBC-HMAC_SHA2_256_128
 east #

--- a/testing/pluto/ikev2-algo-sha2-05/west.console.txt
+++ b/testing/pluto/ikev2-algo-sha2-05/west.console.txt
@@ -33,6 +33,7 @@ west #
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2":   ESP algorithms: AES_CBC-HMAC_SHA2_512_256
 west #

--- a/testing/pluto/ikev2-allow-narrow-01/east.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-01/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-allow-narrow-01/west.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-01/west.console.txt
@@ -47,6 +47,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-allow-narrow-02/east.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-02/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-allow-narrow-02/west.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-02/west.console.txt
@@ -33,6 +33,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-allow-narrow-03/east.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-03/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-allow-narrow-03/west.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-03/west.console.txt
@@ -38,6 +38,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-allow-narrow-04/east.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-04/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-allow-narrow-04/west.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-04/west.console.txt
@@ -36,6 +36,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-allow-narrow-05/east.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-05/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-allow-narrow-05/west.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-05/west.console.txt
@@ -36,6 +36,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-allow-narrow-07/east.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-07/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-allow-narrow-07/west.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-07/west.console.txt
@@ -36,6 +36,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-allow-narrow-10-protoport/east.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-10-protoport/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-allow-narrow-10-protoport/west.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-10-protoport/west.console.txt
@@ -36,6 +36,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-allow-narrow-11-subnet/east.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-11-subnet/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-allow-narrow-11-subnet/west.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-11-subnet/west.console.txt
@@ -36,6 +36,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-allow-narrow-12-subnet-protoport/east.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-12-subnet-protoport/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-allow-narrow-12-subnet-protoport/west.console.txt
+++ b/testing/pluto/ikev2-allow-narrow-12-subnet-protoport/west.console.txt
@@ -36,6 +36,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-asymmetric-03-null-rsacert/east.console.txt
+++ b/testing/pluto/ikev2-asymmetric-03-null-rsacert/east.console.txt
@@ -119,6 +119,7 @@ Connection list:
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/ikev2-asymmetric-03-null-rsacert/west.console.txt
+++ b/testing/pluto/ikev2-asymmetric-03-null-rsacert/west.console.txt
@@ -47,6 +47,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-asymmetric-04-null-rsaraw/east.console.txt
+++ b/testing/pluto/ikev2-asymmetric-04-null-rsaraw/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-asymmetric-04-null-rsaraw/west.console.txt
+++ b/testing/pluto/ikev2-asymmetric-04-null-rsaraw/west.console.txt
@@ -47,6 +47,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-asymmetric-07-psk-rsaraw/east.console.txt
+++ b/testing/pluto/ikev2-asymmetric-07-psk-rsaraw/east.console.txt
@@ -37,6 +37,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-asymmetric-07-psk-rsaraw/west.console.txt
+++ b/testing/pluto/ikev2-asymmetric-07-psk-rsaraw/west.console.txt
@@ -47,6 +47,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-asymmetric-08-psk-rsacert/east.console.txt
+++ b/testing/pluto/ikev2-asymmetric-08-psk-rsacert/east.console.txt
@@ -43,6 +43,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-asymmetric-08-psk-rsacert/west.console.txt
+++ b/testing/pluto/ikev2-asymmetric-08-psk-rsacert/west.console.txt
@@ -61,6 +61,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-asymmetric-09-rsaraw-null/east.console.txt
+++ b/testing/pluto/ikev2-asymmetric-09-rsaraw-null/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-asymmetric-09-rsaraw-null/west.console.txt
+++ b/testing/pluto/ikev2-asymmetric-09-rsaraw-null/west.console.txt
@@ -47,6 +47,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-asymmetric-10-rsaraw-psk/east.console.txt
+++ b/testing/pluto/ikev2-asymmetric-10-rsaraw-psk/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-asymmetric-10-rsaraw-psk/west.console.txt
+++ b/testing/pluto/ikev2-asymmetric-10-rsaraw-psk/west.console.txt
@@ -51,6 +51,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-asymmetric-12-rsacert-null/east.console.txt
+++ b/testing/pluto/ikev2-asymmetric-12-rsacert-null/east.console.txt
@@ -44,6 +44,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-asymmetric-12-rsacert-null/west.console.txt
+++ b/testing/pluto/ikev2-asymmetric-12-rsacert-null/west.console.txt
@@ -57,6 +57,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-asymmetric-13-rsacert-psk/east.console.txt
+++ b/testing/pluto/ikev2-asymmetric-13-rsacert-psk/east.console.txt
@@ -44,6 +44,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-asymmetric-13-rsacert-psk/west.console.txt
+++ b/testing/pluto/ikev2-asymmetric-13-rsacert-psk/west.console.txt
@@ -57,6 +57,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-asymmetric-15-rsaraw-rsaraw/east.console.txt
+++ b/testing/pluto/ikev2-asymmetric-15-rsaraw-rsaraw/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-asymmetric-15-rsaraw-rsaraw/west.console.txt
+++ b/testing/pluto/ikev2-asymmetric-15-rsaraw-rsaraw/west.console.txt
@@ -47,6 +47,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-asymmetric-16-auth-mismatch/east.console.txt
+++ b/testing/pluto/ikev2-asymmetric-16-auth-mismatch/east.console.txt
@@ -33,6 +33,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-asymmetric-16-auth-mismatch/west.console.txt
+++ b/testing/pluto/ikev2-asymmetric-16-auth-mismatch/west.console.txt
@@ -54,6 +54,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-asymmetric-17-auth-mismatch-reverse/east.console.txt
+++ b/testing/pluto/ikev2-asymmetric-17-auth-mismatch-reverse/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-asymmetric-17-auth-mismatch-reverse/west.console.txt
+++ b/testing/pluto/ikev2-asymmetric-17-auth-mismatch-reverse/west.console.txt
@@ -46,6 +46,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-child-rekey-06-deadlock/east.console.txt
+++ b/testing/pluto/ikev2-child-rekey-06-deadlock/east.console.txt
@@ -31,6 +31,7 @@ east #
 "east":   liveness: passive; dpddelay:0s; retransmit-timeout:15s
 "east":   nat-traversal: encapsulation:auto; keepalive:20s
 "east":   routing: unrouted;
+"east":   reqid: REQID;
 "east":   conn serial: $1;
 east #
  ipsec whack --impair revival

--- a/testing/pluto/ikev2-child-rekey-06-deadlock/west.console.txt
+++ b/testing/pluto/ikev2-child-rekey-06-deadlock/west.console.txt
@@ -56,6 +56,7 @@ west #
 "west":   liveness: passive; dpddelay:0s; retransmit-timeout:15s
 "west":   nat-traversal: encapsulation:auto; keepalive:20s
 "west":   routing: unrouted;
+"west":   reqid: REQID;
 "west":   conn serial: $1;
 west #
  ipsec auto --up west

--- a/testing/pluto/ikev2-child-restart-mismatch/west.console.txt
+++ b/testing/pluto/ikev2-child-restart-mismatch/west.console.txt
@@ -97,6 +97,7 @@ west #
 "westnet-eastnet-ikev2b":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2b":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2b":   routing: unrouted;
+"westnet-eastnet-ikev2b":   reqid: REQID;
 "westnet-eastnet-ikev2b":   conn serial: $2;
 "westnet-eastnet-ikev2c": 192.0.1.0/24===192.1.2.45[@west]...192.1.2.23[@east]===192.0.201.0/24; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet-ikev2c":   host: oriented; local: 192.1.2.45; remote: 192.1.2.23;
@@ -119,6 +120,7 @@ west #
 "westnet-eastnet-ikev2c":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2c":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2c":   routing: unrouted;
+"westnet-eastnet-ikev2c":   reqid: REQID;
 "westnet-eastnet-ikev2c":   conn serial: $3;
 west #
  echo done

--- a/testing/pluto/ikev2-connswitch-01/west.console.txt
+++ b/testing/pluto/ikev2-connswitch-01/west.console.txt
@@ -46,6 +46,7 @@ west #
 "westnet-eastnet-ikev1":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev1":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev1":   routing: unrouted;
+"westnet-eastnet-ikev1":   reqid: REQID;
 "westnet-eastnet-ikev1":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-delete-01/west.console.txt
+++ b/testing/pluto/ikev2-delete-01/west.console.txt
@@ -157,6 +157,7 @@ Connection list:
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: routed-tunnel; owner: Child SA #2; established IKE SA: #1; established Child SA: #2;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2":   IKEv2 algorithm newest: AES_GCM_16_256-HMAC_SHA2_512-DH19
 "westnet-eastnet-ipv4-psk-ikev2":   ESP algorithm newest: AES_GCM_16_256; pfsgroup=<Phase1>
@@ -293,6 +294,7 @@ Connection list:
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: routed-ondemand;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 1, active 0

--- a/testing/pluto/ikev2-delete-04/west.console.txt
+++ b/testing/pluto/ikev2-delete-04/west.console.txt
@@ -33,6 +33,7 @@ west #
 "west-east-delete1":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "west-east-delete1":   nat-traversal: encapsulation:auto; keepalive:20s
 "west-east-delete1":   routing: unrouted;
+"west-east-delete1":   reqid: REQID;
 "west-east-delete1":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-hostpair-01/east.console.txt
+++ b/testing/pluto/ikev2-hostpair-01/east.console.txt
@@ -38,6 +38,7 @@ east #
 "roadnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "roadnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "roadnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"roadnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "roadnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 "roadnet-eastnet-ipv4-psk-ikev2"[1]: 192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.2.254[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org]==={192.0.2.1/32}; routed-tunnel; my_ip=unset; their_ip=192.0.2.1;
 "roadnet-eastnet-ipv4-psk-ikev2"[1]:   host: oriented; local: 192.1.2.23; remote: 192.1.2.254; established IKE SA: #3;
@@ -62,6 +63,7 @@ east #
 "roadnet-eastnet-ipv4-psk-ikev2"[1]:   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "roadnet-eastnet-ipv4-psk-ikev2"[1]:   nat-traversal: encapsulation:auto; keepalive:20s
 "roadnet-eastnet-ipv4-psk-ikev2"[1]:   routing: routed-tunnel; owner: Child SA #4; established IKE SA: #3; established Child SA: #4;
+"roadnet-eastnet-ipv4-psk-ikev2"[1]:   reqid: REQID;
 "roadnet-eastnet-ipv4-psk-ikev2"[1]:   conn serial: $2, instantiated from: $1;
 "roadnet-eastnet-ipv4-psk-ikev2"[1]:   IKEv2 algorithm newest: AES_GCM_16_256-HMAC_SHA2_512-DH19
 "roadnet-eastnet-ipv4-psk-ikev2"[1]:   ESP algorithm newest: AES_GCM_16_256; pfsgroup=<Phase1>

--- a/testing/pluto/ikev2-hostpair-01/road.console.txt
+++ b/testing/pluto/ikev2-hostpair-01/road.console.txt
@@ -106,6 +106,7 @@ road #
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 "westnet-eastnet-ipv4-psk-ikev2"[1]: 192.0.2.1/32===192.1.3.210[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org]---192.1.3.254...192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]; routed-tunnel; my_ip=192.0.2.1; their_ip=unset;
 "westnet-eastnet-ipv4-psk-ikev2"[1]:   host: oriented; local: 192.1.3.210; nexthop: 192.1.3.254; remote: 192.1.2.23; established IKE SA: #1;
@@ -130,6 +131,7 @@ road #
 "westnet-eastnet-ipv4-psk-ikev2"[1]:   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2"[1]:   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2"[1]:   routing: routed-tunnel; owner: Child SA #2; established IKE SA: #1; established Child SA: #2;
+"westnet-eastnet-ipv4-psk-ikev2"[1]:   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2"[1]:   conn serial: $2, instantiated from: $1;
 "westnet-eastnet-ipv4-psk-ikev2"[1]:   IKEv2 algorithm newest: AES_GCM_16_256-HMAC_SHA2_512-DH19
 "westnet-eastnet-ipv4-psk-ikev2"[1]:   ESP algorithm newest: AES_GCM_16_256; pfsgroup=<Phase1>

--- a/testing/pluto/ikev2-ikeport-02-initiator/east.console.txt
+++ b/testing/pluto/ikev2-ikeport-02-initiator/east.console.txt
@@ -119,6 +119,7 @@ Connection list:
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/ikev2-ikeport-02-initiator/west.console.txt
+++ b/testing/pluto/ikev2-ikeport-02-initiator/west.console.txt
@@ -47,6 +47,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-ikeport-03-responder/east.console.txt
+++ b/testing/pluto/ikev2-ikeport-03-responder/east.console.txt
@@ -121,6 +121,7 @@ Connection list:
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/ikev2-ikeport-03-responder/west.console.txt
+++ b/testing/pluto/ikev2-ikeport-03-responder/west.console.txt
@@ -46,6 +46,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-ikeport-06-host-to-host/east.console.txt
+++ b/testing/pluto/ikev2-ikeport-06-host-to-host/east.console.txt
@@ -119,6 +119,7 @@ Connection list:
 "west-east-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "west-east-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "west-east-ikev2":   routing: unrouted;
+"west-east-ikev2":   reqid: REQID;
 "west-east-ikev2":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/ikev2-ikeport-06-host-to-host/west.console.txt
+++ b/testing/pluto/ikev2-ikeport-06-host-to-host/west.console.txt
@@ -32,6 +32,7 @@ west #
 "west-east-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "west-east-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "west-east-ikev2":   routing: unrouted;
+"west-east-ikev2":   reqid: REQID;
 "west-east-ikev2":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-impair-01-replay-duplicates/west.console.txt
+++ b/testing/pluto/ikev2-impair-01-replay-duplicates/west.console.txt
@@ -135,6 +135,7 @@ Connection list:
 "westnet-eastnet":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet":   routing: unrouted;
+"westnet-eastnet":   reqid: REQID;
 "westnet-eastnet":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/ikev2-impair-02-replay-forward/west.console.txt
+++ b/testing/pluto/ikev2-impair-02-replay-forward/west.console.txt
@@ -135,6 +135,7 @@ Connection list:
 "westnet-eastnet":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet":   routing: unrouted;
+"westnet-eastnet":   reqid: REQID;
 "westnet-eastnet":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/ikev2-intermediate-03-unsolicited/west.console.txt
+++ b/testing/pluto/ikev2-intermediate-03-unsolicited/west.console.txt
@@ -47,6 +47,7 @@ west #
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-ipv6-transport-mode-02-xfrm-xfrm/road.console.txt
+++ b/testing/pluto/ikev2-ipv6-transport-mode-02-xfrm-xfrm/road.console.txt
@@ -45,6 +45,7 @@ road #
 "v6-transport":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "v6-transport":   nat-traversal: encapsulation:auto; keepalive:20s
 "v6-transport":   routing: unrouted;
+"v6-transport":   reqid: REQID;
 "v6-transport":   conn serial: $1;
 road #
  echo "initdone"

--- a/testing/pluto/ikev2-liveness-09-revival/west.console.txt
+++ b/testing/pluto/ikev2-liveness-09-revival/west.console.txt
@@ -103,6 +103,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: active; dpddelay:3s; retransmit-timeout:10s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: routed-ondemand;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  ipsec _kernel policy
@@ -138,6 +139,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: active; dpddelay:3s; retransmit-timeout:10s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: routed-negotiation; owner: IKE SA #3; negotiating IKE SA: #3;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  ipsec _kernel policy

--- a/testing/pluto/ikev2-mobike-07-unsolicited-response/west.console.txt
+++ b/testing/pluto/ikev2-mobike-07-unsolicited-response/west.console.txt
@@ -47,6 +47,7 @@ west #
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-nss-cert-08-mismatch/east.console.txt
+++ b/testing/pluto/ikev2-nss-cert-08-mismatch/east.console.txt
@@ -41,6 +41,7 @@ east #
 "nss-cert":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert":   routing: unrouted;
+"nss-cert":   reqid: REQID;
 "nss-cert":   conn serial: $1;
 east #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-ppk-intermediate-01-insist-yes/east.console.txt
+++ b/testing/pluto/ikev2-ppk-intermediate-01-insist-yes/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-ipv4-psk-ppk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ppk":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ppk":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ppk":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ppk":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-ppk-intermediate-01-insist-yes/west.console.txt
+++ b/testing/pluto/ikev2-ppk-intermediate-01-insist-yes/west.console.txt
@@ -46,6 +46,7 @@ west #
 "westnet-eastnet-ipv4-psk-ppk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ppk":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ppk":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ppk":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ppk":   conn serial: $1;
 west #
  ipsec whack --impair revival

--- a/testing/pluto/ikev2-ppk-static-01-insist-yes/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-01-insist-yes/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-ipv4-psk-ppk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ppk":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ppk":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ppk":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ppk":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-ppk-static-01-insist-yes/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-01-insist-yes/west.console.txt
@@ -46,6 +46,7 @@ west #
 "westnet-eastnet-ipv4-psk-ppk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ppk":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ppk":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ppk":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ppk":   conn serial: $1;
 west #
  ipsec whack --impair revival

--- a/testing/pluto/ikev2-ppk-static-02-insist-insist/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-02-insist-insist/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-ipv4-psk-ppk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ppk":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ppk":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ppk":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ppk":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-ppk-static-02-insist-insist/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-02-insist-insist/west.console.txt
@@ -46,6 +46,7 @@ west #
 "westnet-eastnet-ipv4-psk-ppk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ppk":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ppk":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ppk":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ppk":   conn serial: $1;
 west #
  ipsec whack --impair revival

--- a/testing/pluto/ikev2-ppk-static-03-no-insist-fail/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-03-no-insist-fail/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-ipv4-psk-ppk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ppk":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ppk":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ppk":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ppk":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-ppk-static-03-no-insist-fail/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-03-no-insist-fail/west.console.txt
@@ -35,6 +35,7 @@ west #
 "westnet-eastnet-ipv4-psk-ppk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ppk":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ppk":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ppk":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ppk":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-ppk-static-04-insist-no-fail/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-04-insist-no-fail/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-ipv4-psk-ppk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ppk":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ppk":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ppk":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ppk":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-ppk-static-04-insist-no-fail/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-04-insist-no-fail/west.console.txt
@@ -35,6 +35,7 @@ west #
 "westnet-eastnet-ipv4-psk-ppk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ppk":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ppk":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ppk":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ppk":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-ppk-static-05-insist-nokey-insist-fail/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-05-insist-nokey-insist-fail/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-ipv4-psk-ppk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ppk":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ppk":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ppk":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ppk":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-ppk-static-05-insist-nokey-insist-fail/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-05-insist-nokey-insist-fail/west.console.txt
@@ -35,6 +35,7 @@ west #
 "westnet-eastnet-ipv4-psk-ppk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ppk":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ppk":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ppk":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ppk":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-ppk-static-06-insist-insist-nokey-fail/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-06-insist-insist-nokey-fail/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-ipv4-psk-ppk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ppk":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ppk":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ppk":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ppk":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-ppk-static-06-insist-insist-nokey-fail/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-06-insist-insist-nokey-fail/west.console.txt
@@ -35,6 +35,7 @@ west #
 "westnet-eastnet-ipv4-psk-ppk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ppk":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ppk":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ppk":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ppk":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-ppk-static-07-large-id/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-07-large-id/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-ipv4-psk-ppk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ppk":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ppk":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ppk":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ppk":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-ppk-static-07-large-id/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-07-large-id/west.console.txt
@@ -46,6 +46,7 @@ west #
 "westnet-eastnet-ipv4-psk-ppk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ppk":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ppk":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ppk":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ppk":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-ppk-static-08-no_ppk-responder/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-08-no_ppk-responder/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-ipv4-psk-ppk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ppk":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ppk":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ppk":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ppk":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-ppk-static-08-no_ppk-responder/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-08-no_ppk-responder/west.console.txt
@@ -46,6 +46,7 @@ west #
 "westnet-eastnet-ipv4-psk-ppk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ppk":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ppk":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ppk":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ppk":   conn serial: $1;
 west #
  ipsec whack --impair revival

--- a/testing/pluto/ikev2-ppk-static-09-no_ppk-initiator/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-09-no_ppk-initiator/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-ipv4-psk-ppk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ppk":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ppk":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ppk":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ppk":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-ppk-static-09-no_ppk-initiator/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-09-no_ppk-initiator/west.console.txt
@@ -46,6 +46,7 @@ west #
 "westnet-eastnet-ipv4-psk-ppk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ppk":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ppk":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ppk":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ppk":   conn serial: $1;
 west #
  ipsec whack --impair revival

--- a/testing/pluto/ikev2-ppk-static-10-yes-no/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-10-yes-no/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-ipv4-psk-ppk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ppk":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ppk":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ppk":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ppk":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-ppk-static-10-yes-no/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-10-yes-no/west.console.txt
@@ -46,6 +46,7 @@ west #
 "westnet-eastnet-ipv4-psk-ppk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ppk":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ppk":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ppk":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ppk":   conn serial: $1;
 west #
  ipsec whack --impair revival

--- a/testing/pluto/ikev2-ppk-static-11-multiple-ppk-ids/east.console.txt
+++ b/testing/pluto/ikev2-ppk-static-11-multiple-ppk-ids/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-ipv4-psk-ppk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ppk":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ppk":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ppk":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ppk":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-ppk-static-11-multiple-ppk-ids/west.console.txt
+++ b/testing/pluto/ikev2-ppk-static-11-multiple-ppk-ids/west.console.txt
@@ -46,6 +46,7 @@ west #
 "westnet-eastnet-ipv4-psk-ppk":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ppk":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ppk":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ppk":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ppk":   conn serial: $1;
 west #
  ipsec whack --impair revival

--- a/testing/pluto/ikev2-redirect-06-roadwarriors/east.console.txt
+++ b/testing/pluto/ikev2-redirect-06-roadwarriors/east.console.txt
@@ -71,6 +71,7 @@ Connection list:
 "east-any":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "east-any":   nat-traversal: encapsulation:auto; keepalive:20s
 "east-any":   routing: unrouted;
+"east-any":   reqid: REQID;
 "east-any":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/ikev2-redirect-06-roadwarriors/north.console.txt
+++ b/testing/pluto/ikev2-redirect-06-roadwarriors/north.console.txt
@@ -97,6 +97,7 @@ Connection list:
 "north-east":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "north-east":   nat-traversal: encapsulation:auto; keepalive:20s
 "north-east":   routing: routed-tunnel; owner: Child SA #4; established IKE SA: #3; established Child SA: #4;
+"north-east":   reqid: REQID;
 "north-east":   conn serial: $1;
 "north-east":   IKEv2 algorithm newest: AES_GCM_16_256-HMAC_SHA2_512-DH19
 "north-east":   ESP algorithm newest: AES_GCM_16_256; pfsgroup=<Phase1>

--- a/testing/pluto/ikev2-redirect-06-roadwarriors/road.console.txt
+++ b/testing/pluto/ikev2-redirect-06-roadwarriors/road.console.txt
@@ -97,6 +97,7 @@ Connection list:
 "road-east":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "road-east":   nat-traversal: encapsulation:auto; keepalive:20s
 "road-east":   routing: routed-tunnel; owner: Child SA #4; established IKE SA: #3; established Child SA: #4;
+"road-east":   reqid: REQID;
 "road-east":   conn serial: $1;
 "road-east":   IKEv2 algorithm newest: AES_GCM_16_256-HMAC_SHA2_512-DH19
 "road-east":   ESP algorithm newest: AES_GCM_16_256; pfsgroup=<Phase1>

--- a/testing/pluto/ikev2-redirect-06-roadwarriors/west.console.txt
+++ b/testing/pluto/ikev2-redirect-06-roadwarriors/west.console.txt
@@ -56,6 +56,7 @@ Connection list:
 "east-any":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "east-any":   nat-traversal: encapsulation:auto; keepalive:20s
 "east-any":   routing: unrouted;
+"east-any":   reqid: REQID;
 "east-any":   conn serial: $1;
 "east-any"[1]: 0.0.0.0/0===192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]...192.1.3.209[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=road.testing.libreswan.org, E=user-road@testing.libreswan.org]==={192.0.2.101/32}; routed-tunnel; my_ip=unset; their_ip=192.0.2.101;
 "east-any"[1]:   host: oriented; local: 192.1.2.45; remote: 192.1.3.209; established IKE SA: #1;
@@ -80,6 +81,7 @@ Connection list:
 "east-any"[1]:   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "east-any"[1]:   nat-traversal: encapsulation:auto; keepalive:20s
 "east-any"[1]:   routing: routed-tunnel; owner: Child SA #2; established IKE SA: #1; established Child SA: #2;
+"east-any"[1]:   reqid: REQID;
 "east-any"[1]:   conn serial: $2, instantiated from: $1;
 "east-any"[1]:   IKEv2 algorithm newest: AES_GCM_16_256-HMAC_SHA2_512-DH19
 "east-any"[1]:   ESP algorithm newest: AES_GCM_16_256; pfsgroup=<Phase1>
@@ -106,6 +108,7 @@ Connection list:
 "east-any"[2]:   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "east-any"[2]:   nat-traversal: encapsulation:auto; keepalive:20s
 "east-any"[2]:   routing: routed-tunnel; owner: Child SA #4; established IKE SA: #3; established Child SA: #4;
+"east-any"[1]:   reqid: REQID;
 "east-any"[2]:   conn serial: $3, instantiated from: $1;
 "east-any"[2]:   IKEv2 algorithm newest: AES_GCM_16_256-HMAC_SHA2_512-DH19
 "east-any"[2]:   ESP algorithm newest: AES_GCM_16_256; pfsgroup=<Phase1>

--- a/testing/pluto/ikev2-systemrole-01-host-to-host/east.console.txt
+++ b/testing/pluto/ikev2-systemrole-01-host-to-host/east.console.txt
@@ -153,6 +153,7 @@ Connection list:
 "192.1.2.23-to-192.1.2.45":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "192.1.2.23-to-192.1.2.45":   nat-traversal: encapsulation:auto; keepalive:20s
 "192.1.2.23-to-192.1.2.45":   routing: routed-ondemand;
+"192.1.2.23-to-192.1.2.45":   reqid: REQID;
 "192.1.2.23-to-192.1.2.45":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 1, active 0

--- a/testing/pluto/ikev2-systemrole-01-host-to-host/west.console.txt
+++ b/testing/pluto/ikev2-systemrole-01-host-to-host/west.console.txt
@@ -153,6 +153,7 @@ Connection list:
 "192.1.2.45-to-192.1.2.23":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "192.1.2.45-to-192.1.2.23":   nat-traversal: encapsulation:auto; keepalive:20s
 "192.1.2.45-to-192.1.2.23":   routing: routed-ondemand;
+"192.1.2.45-to-192.1.2.23":   reqid: REQID;
 "192.1.2.45-to-192.1.2.23":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 1, active 0

--- a/testing/pluto/ikev2-systemrole-02-net-to-net/east.console.txt
+++ b/testing/pluto/ikev2-systemrole-02-net-to-net/east.console.txt
@@ -153,6 +153,7 @@ Connection list:
 "192.1.2.23-to-192.1.2.45":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "192.1.2.23-to-192.1.2.45":   nat-traversal: encapsulation:auto; keepalive:20s
 "192.1.2.23-to-192.1.2.45":   routing: routed-ondemand;
+"192.1.2.23-to-192.1.2.45":   reqid: REQID;
 "192.1.2.23-to-192.1.2.45":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 1, active 0

--- a/testing/pluto/ikev2-systemrole-02-net-to-net/west.console.txt
+++ b/testing/pluto/ikev2-systemrole-02-net-to-net/west.console.txt
@@ -153,6 +153,7 @@ Connection list:
 "192.1.2.45-to-192.1.2.23":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "192.1.2.45-to-192.1.2.23":   nat-traversal: encapsulation:auto; keepalive:20s
 "192.1.2.45-to-192.1.2.23":   routing: routed-ondemand;
+"192.1.2.45-to-192.1.2.23":   reqid: REQID;
 "192.1.2.45-to-192.1.2.23":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 1, active 0

--- a/testing/pluto/ikev2-systemrole-03-certs/west.console.txt
+++ b/testing/pluto/ikev2-systemrole-03-certs/west.console.txt
@@ -63,6 +63,7 @@ west #
 "192.1.2.45-to-192.1.2.23":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "192.1.2.45-to-192.1.2.23":   nat-traversal: encapsulation:auto; keepalive:20s
 "192.1.2.45-to-192.1.2.23":   routing: routed-ondemand;
+"192.1.2.45-to-192.1.2.23":   reqid: REQID;
 "192.1.2.45-to-192.1.2.23":   conn serial: $1;
 west #
  # connection is ondemand, but we will --up so we can see X.509 auth

--- a/testing/pluto/ikev2-systemrole-04-mesh/east.console.txt
+++ b/testing/pluto/ikev2-systemrole-04-mesh/east.console.txt
@@ -154,6 +154,7 @@ Connection list:
 "clear":   liveness: passive; dpddelay:0s; retransmit-timeout:0s
 "clear":   nat-traversal: encapsulation:no; keepalive:no
 "clear":   routing: unrouted;
+"clear":   reqid: REQID;
 "clear":   conn serial: $3;
 "clear#192.1.2.254/32": 192.1.2.23---192.1.2.254...%any===192.1.2.254/32; routed-never-negotiate; my_ip=unset; their_ip=unset;
 "clear#192.1.2.254/32":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.254; remote: %any;
@@ -176,6 +177,7 @@ Connection list:
 "clear#192.1.2.254/32":   liveness: passive; dpddelay:0s; retransmit-timeout:0s
 "clear#192.1.2.254/32":   nat-traversal: encapsulation:no; keepalive:no
 "clear#192.1.2.254/32":   routing: routed-never-negotiate;
+"clear#192.1.2.254/32":   reqid: REQID;
 "clear#192.1.2.254/32":   conn serial: $6, instantiated from: $3;
 "private": 192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]---192.1.2.254...%opportunisticgroup[%fromcert]; unrouted; my_ip=unset; their_ip=unset;
 "private":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.254; remote: %opportunisticgroup;
@@ -200,6 +202,7 @@ Connection list:
 "private":   liveness: passive; dpddelay:0s; retransmit-timeout:2s
 "private":   nat-traversal: encapsulation:auto; keepalive:20s
 "private":   routing: unrouted;
+"private":   reqid: REQID;
 "private":   conn serial: $1;
 "private#10.1.0.0/24": 192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]---192.1.2.254...%opportunistic[%fromcert]===10.1.0.0/24; routed-ondemand; my_ip=unset; their_ip=unset;
 "private#10.1.0.0/24":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.254; remote: %opportunistic;
@@ -224,6 +227,7 @@ Connection list:
 "private#10.1.0.0/24":   liveness: passive; dpddelay:0s; retransmit-timeout:2s
 "private#10.1.0.0/24":   nat-traversal: encapsulation:auto; keepalive:20s
 "private#10.1.0.0/24":   routing: routed-ondemand;
+"private#10.1.0.0/24":   reqid: REQID;
 "private#10.1.0.0/24":   conn serial: $4, instantiated from: $1;
 "private-or-clear": 192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]---192.1.2.254...%opportunisticgroup[%fromcert]; unrouted; my_ip=unset; their_ip=unset;
 "private-or-clear":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.254; remote: %opportunisticgroup;
@@ -248,6 +252,7 @@ Connection list:
 "private-or-clear":   liveness: passive; dpddelay:0s; retransmit-timeout:2s
 "private-or-clear":   nat-traversal: encapsulation:auto; keepalive:20s
 "private-or-clear":   routing: unrouted;
+"private-or-clear":   reqid: REQID;
 "private-or-clear":   conn serial: $2;
 "private-or-clear#192.1.2.0/24": 192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]---192.1.2.254...%opportunistic[%fromcert]===192.1.2.0/24; routed-ondemand; my_ip=unset; their_ip=unset;
 "private-or-clear#192.1.2.0/24":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.254; remote: %opportunistic;
@@ -272,6 +277,7 @@ Connection list:
 "private-or-clear#192.1.2.0/24":   liveness: passive; dpddelay:0s; retransmit-timeout:2s
 "private-or-clear#192.1.2.0/24":   nat-traversal: encapsulation:auto; keepalive:20s
 "private-or-clear#192.1.2.0/24":   routing: routed-ondemand;
+"private-or-clear#192.1.2.0/24":   reqid: REQID;
 "private-or-clear#192.1.2.0/24":   conn serial: $5, instantiated from: $2;
  
 Total IPsec connections: loaded 6, routed 3, active 0

--- a/testing/pluto/ikev2-systemrole-04-mesh/west.console.txt
+++ b/testing/pluto/ikev2-systemrole-04-mesh/west.console.txt
@@ -154,6 +154,7 @@ Connection list:
 "clear":   liveness: passive; dpddelay:0s; retransmit-timeout:0s
 "clear":   nat-traversal: encapsulation:no; keepalive:no
 "clear":   routing: unrouted;
+"clear":   reqid: REQID;
 "clear":   conn serial: $3;
 "clear#192.1.2.254/32": 192.1.2.45---192.1.2.254...%any===192.1.2.254/32; routed-never-negotiate; my_ip=unset; their_ip=unset;
 "clear#192.1.2.254/32":   host: oriented; local: 192.1.2.45; nexthop: 192.1.2.254; remote: %any;
@@ -176,6 +177,7 @@ Connection list:
 "clear#192.1.2.254/32":   liveness: passive; dpddelay:0s; retransmit-timeout:0s
 "clear#192.1.2.254/32":   nat-traversal: encapsulation:no; keepalive:no
 "clear#192.1.2.254/32":   routing: routed-never-negotiate;
+"clear#192.1.2.254/32":   reqid: REQID;
 "clear#192.1.2.254/32":   conn serial: $6, instantiated from: $3;
 "private": 192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]---192.1.2.254...%opportunisticgroup[%fromcert]; unrouted; my_ip=unset; their_ip=unset;
 "private":   host: oriented; local: 192.1.2.45; nexthop: 192.1.2.254; remote: %opportunisticgroup;
@@ -200,6 +202,7 @@ Connection list:
 "private":   liveness: passive; dpddelay:0s; retransmit-timeout:2s
 "private":   nat-traversal: encapsulation:auto; keepalive:20s
 "private":   routing: unrouted;
+"private":   reqid: REQID;
 "private":   conn serial: $1;
 "private#10.1.0.0/24": 192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]---192.1.2.254...%opportunistic[%fromcert]===10.1.0.0/24; routed-ondemand; my_ip=unset; their_ip=unset;
 "private#10.1.0.0/24":   host: oriented; local: 192.1.2.45; nexthop: 192.1.2.254; remote: %opportunistic;
@@ -224,6 +227,7 @@ Connection list:
 "private#10.1.0.0/24":   liveness: passive; dpddelay:0s; retransmit-timeout:2s
 "private#10.1.0.0/24":   nat-traversal: encapsulation:auto; keepalive:20s
 "private#10.1.0.0/24":   routing: routed-ondemand;
+"private#10.1.0.0/24":   reqid: REQID;
 "private#10.1.0.0/24":   conn serial: $4, instantiated from: $1;
 "private-or-clear": 192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]---192.1.2.254...%opportunisticgroup[%fromcert]; unrouted; my_ip=unset; their_ip=unset;
 "private-or-clear":   host: oriented; local: 192.1.2.45; nexthop: 192.1.2.254; remote: %opportunisticgroup;
@@ -248,6 +252,7 @@ Connection list:
 "private-or-clear":   liveness: passive; dpddelay:0s; retransmit-timeout:2s
 "private-or-clear":   nat-traversal: encapsulation:auto; keepalive:20s
 "private-or-clear":   routing: unrouted;
+"private-or-clear":   reqid: REQID;
 "private-or-clear":   conn serial: $2;
 "private-or-clear#192.1.2.0/24": 192.1.2.45[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org]---192.1.2.254...%opportunistic[%fromcert]===192.1.2.0/24; routed-ondemand; my_ip=unset; their_ip=unset;
 "private-or-clear#192.1.2.0/24":   host: oriented; local: 192.1.2.45; nexthop: 192.1.2.254; remote: %opportunistic;
@@ -272,6 +277,7 @@ Connection list:
 "private-or-clear#192.1.2.0/24":   liveness: passive; dpddelay:0s; retransmit-timeout:2s
 "private-or-clear#192.1.2.0/24":   nat-traversal: encapsulation:auto; keepalive:20s
 "private-or-clear#192.1.2.0/24":   routing: routed-ondemand;
+"private-or-clear#192.1.2.0/24":   reqid: REQID;
 "private-or-clear#192.1.2.0/24":   conn serial: $5, instantiated from: $2;
  
 Total IPsec connections: loaded 6, routed 3, active 0

--- a/testing/pluto/ikev2-tcp-10-rekey-child/west.console.txt
+++ b/testing/pluto/ikev2-tcp-10-rekey-child/west.console.txt
@@ -47,6 +47,7 @@ west #
 "west":   liveness: passive; dpddelay:0s; retransmit-timeout:10s
 "west":   nat-traversal: encapsulation:auto; keepalive:20s
 "west":   routing: unrouted;
+"west":   reqid: REQID;
 "west":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-tcp-10-rekey-ike/west.console.txt
+++ b/testing/pluto/ikev2-tcp-10-rekey-ike/west.console.txt
@@ -47,6 +47,7 @@ west #
 "west":   liveness: passive; dpddelay:0s; retransmit-timeout:10s
 "west":   nat-traversal: encapsulation:auto; keepalive:20s
 "west":   routing: unrouted;
+"west":   reqid: REQID;
 "west":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-tfc-01/west.console.txt
+++ b/testing/pluto/ikev2-tfc-01/west.console.txt
@@ -47,6 +47,7 @@ west #
 "tfc":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "tfc":   nat-traversal: encapsulation:auto; keepalive:20s
 "tfc":   routing: unrouted;
+"tfc":   reqid: REQID;
 "tfc":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-tfc-02/west.console.txt
+++ b/testing/pluto/ikev2-tfc-02/west.console.txt
@@ -47,6 +47,7 @@ west #
 "tfc":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "tfc":   nat-traversal: encapsulation:auto; keepalive:20s
 "tfc":   routing: unrouted;
+"tfc":   reqid: REQID;
 "tfc":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-tfc-03/west.console.txt
+++ b/testing/pluto/ikev2-tfc-03/west.console.txt
@@ -47,6 +47,7 @@ west #
 "tfc":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "tfc":   nat-traversal: encapsulation:auto; keepalive:20s
 "tfc":   routing: unrouted;
+"tfc":   reqid: REQID;
 "tfc":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ikev2-x509-24-fakewest/east.console.txt
+++ b/testing/pluto/ikev2-x509-24-fakewest/east.console.txt
@@ -54,6 +54,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ikev2-x509-24-fakewest/west.console.txt
+++ b/testing/pluto/ikev2-x509-24-fakewest/west.console.txt
@@ -68,6 +68,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/ikev2-x509-38-failureshunt/east.console.txt
+++ b/testing/pluto/ikev2-x509-38-failureshunt/east.console.txt
@@ -122,6 +122,7 @@ Connection list:
 "failureshunt":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "failureshunt":   nat-traversal: encapsulation:auto; keepalive:20s
 "failureshunt":   routing: unrouted;
+"failureshunt":   reqid: REQID;
 "failureshunt":   conn serial: $1;
 "westnet-eastnet": 192.1.2.23...192.1.2.45; unrouted; my_ip=unset; their_ip=unset;
 "westnet-eastnet":   host: oriented; local: 192.1.2.23; remote: 192.1.2.45;
@@ -144,6 +145,7 @@ Connection list:
 "westnet-eastnet":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet":   routing: unrouted;
+"westnet-eastnet":   reqid: REQID;
 "westnet-eastnet":   conn serial: $2;
  
 Total IPsec connections: loaded 2, routed 0, active 0

--- a/testing/pluto/ikev2-xfrmi-11-default-manual-route/east.console.txt
+++ b/testing/pluto/ikev2-xfrmi-11-default-manual-route/east.console.txt
@@ -127,6 +127,7 @@ Connection list:
 "westnet-eastnet":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet":   routing: routed-tunnel; owner: Child SA #2; established IKE SA: #1; established Child SA: #2;
+"westnet-eastnet":   reqid: REQID;
 "westnet-eastnet":   conn serial: $1;
 "westnet-eastnet":   IKEv2 algorithm newest: AES_GCM_16_256-HMAC_SHA2_512-DH19
 "westnet-eastnet":   ESP algorithm newest: AES_GCM_16_256; pfsgroup=<Phase1>

--- a/testing/pluto/ikev2-xfrmi-11-default-manual-route/west.console.txt
+++ b/testing/pluto/ikev2-xfrmi-11-default-manual-route/west.console.txt
@@ -176,6 +176,7 @@ Connection list:
 "west":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "west":   nat-traversal: encapsulation:auto; keepalive:20s
 "west":   routing: routed-tunnel; owner: Child SA #2; established IKE SA: #1; established Child SA: #2;
+"west":   reqid: REQID;
 "west":   conn serial: $1;
 "west":   IKEv2 algorithm newest: AES_GCM_16_256-HMAC_SHA2_512-DH19
 "west":   ESP algorithm newest: AES_GCM_16_256; pfsgroup=<Phase1>

--- a/testing/pluto/interop-ikev2-strongswan-15-child-sa-responder/west.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-15-child-sa-responder/west.console.txt
@@ -86,6 +86,7 @@ west #
 "westnet-eastnet-ikev2a":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2a":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2a":   routing: routed-tunnel; owner: Child SA #2; established IKE SA: #1; established Child SA: #2;
+"westnet-eastnet-ikev2a":   reqid: REQID;
 "westnet-eastnet-ikev2a":   conn serial: $1;
 "westnet-eastnet-ikev2a":   IKE algorithms: 3DES_CBC-HMAC_MD5-MODP2048
 "westnet-eastnet-ikev2a":   IKEv2 algorithm newest: 3DES_CBC_192-HMAC_MD5-MODP2048
@@ -112,6 +113,7 @@ west #
 "westnet-eastnet-ikev2b":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2b":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2b":   routing: routed-tunnel; owner: Child SA #3; established Child SA: #3;
+"westnet-eastnet-ikev2b":   reqid: REQID;
 "westnet-eastnet-ikev2b":   conn serial: $2;
 "westnet-eastnet-ikev2b":   IKE algorithms: 3DES_CBC-HMAC_MD5-MODP2048
 "westnet-eastnet-ikev2b":   ESP algorithms: AES_CBC_128-HMAC_SHA2_512_256
@@ -137,6 +139,7 @@ west #
 "westnet-eastnet-ikev2c":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2c":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2c":   routing: routed-tunnel; owner: Child SA #4; established Child SA: #4;
+"westnet-eastnet-ikev2c":   reqid: REQID;
 "westnet-eastnet-ikev2c":   conn serial: $3;
 "westnet-eastnet-ikev2c":   IKE algorithms: 3DES_CBC-HMAC_MD5-MODP2048
 "westnet-eastnet-ikev2c":   ESP algorithms: AES_CBC_128-HMAC_SHA2_512_256

--- a/testing/pluto/interop-ikev2-strongswan-22-cp-responder-psk/road.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-22-cp-responder-psk/road.console.txt
@@ -121,6 +121,7 @@ Connection list:
 "westnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"westnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "westnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/interop-ikev2-strongswan-23-initiator-cp/east.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-23-initiator-cp/east.console.txt
@@ -121,6 +121,7 @@ Connection list:
 "roadnet-eastnet-ipv4-psk-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "roadnet-eastnet-ipv4-psk-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "roadnet-eastnet-ipv4-psk-ikev2":   routing: unrouted;
+"roadnet-eastnet-ipv4-psk-ikev2":   reqid: REQID;
 "roadnet-eastnet-ipv4-psk-ikev2":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/interop-ikev2-strongswan-29-rekey/east.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-29-rekey/east.console.txt
@@ -34,6 +34,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: routed-tunnel; owner: Child SA #2; established IKE SA: #4; established Child SA: #2;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 "westnet-eastnet-ikev2":   IKEv2 algorithm newest: AES_CBC_256-HMAC_SHA2_512-MODP2048
 "westnet-eastnet-ikev2":   ESP algorithm newest: AES_CBC_256-HMAC_SHA2_512_256; pfsgroup=<Phase1>

--- a/testing/pluto/interop-ikev2-strongswan-29-responder-rekey/east.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-29-responder-rekey/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: routed-tunnel; owner: Child SA #2; established IKE SA: #4; established Child SA: #2;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 "westnet-eastnet-ikev2":   IKE algorithms: AES_CBC_256-HMAC_SHA2_512-MODP2048
 "westnet-eastnet-ikev2":   IKEv2 algorithm newest: AES_CBC_256-HMAC_SHA2_512-MODP2048

--- a/testing/pluto/interop-ikev2-strongswan-35-initiator-rekey/west.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-35-initiator-rekey/west.console.txt
@@ -89,6 +89,7 @@ west #
 "westnet-eastnet":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet":   routing: routed-tunnel; owner: Child SA #3; established IKE SA: #1; established Child SA: #3;
+"westnet-eastnet":   reqid: REQID;
 "westnet-eastnet":   conn serial: $1;
 "westnet-eastnet":   IKE algorithms: AES_CBC_256-HMAC_SHA2_512-MODP2048
 "westnet-eastnet":   IKEv2 algorithm newest: AES_CBC_256-HMAC_SHA2_512-MODP2048

--- a/testing/pluto/ipv6-4in6-01-ikev1/west.console.txt
+++ b/testing/pluto/ipv6-4in6-01-ikev1/west.console.txt
@@ -44,6 +44,7 @@ west #
 "westnet-eastnet-4in6":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-4in6":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-4in6":   routing: unrouted;
+"westnet-eastnet-4in6":   reqid: REQID;
 "westnet-eastnet-4in6":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ipv6-4in6-02-ikev2/west.console.txt
+++ b/testing/pluto/ipv6-4in6-02-ikev2/west.console.txt
@@ -45,6 +45,7 @@ west #
 "westnet-eastnet-4in6":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-4in6":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-4in6":   routing: unrouted;
+"westnet-eastnet-4in6":   reqid: REQID;
 "westnet-eastnet-4in6":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ipv6-6in4-01-ikev1/west.console.txt
+++ b/testing/pluto/ipv6-6in4-01-ikev1/west.console.txt
@@ -46,6 +46,7 @@ west #
 "westnet-eastnet-6in4":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-6in4":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-6in4":   routing: unrouted;
+"westnet-eastnet-6in4":   reqid: REQID;
 "westnet-eastnet-6in4":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ipv6-6in4-02-ikev2/west.console.txt
+++ b/testing/pluto/ipv6-6in4-02-ikev2/west.console.txt
@@ -47,6 +47,7 @@ west #
 "westnet-eastnet-6in4":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-6in4":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-6in4":   routing: unrouted;
+"westnet-eastnet-6in4":   reqid: REQID;
 "westnet-eastnet-6in4":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/ipv6-transport-mode-02-xfrm-xfrm/east.console.txt
+++ b/testing/pluto/ipv6-transport-mode-02-xfrm-xfrm/east.console.txt
@@ -124,6 +124,7 @@ Connection list:
 "v6-transport":   dpd: passive; delay:0s; timeout:0s
 "v6-transport":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "v6-transport":   routing: unrouted;
+"v6-transport":   reqid: REQID;
 "v6-transport":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/ipv6-transport-mode-02-xfrm-xfrm/west.console.txt
+++ b/testing/pluto/ipv6-transport-mode-02-xfrm-xfrm/west.console.txt
@@ -140,6 +140,7 @@ Connection list:
 "v6-transport":   dpd: passive; delay:0s; timeout:0s
 "v6-transport":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "v6-transport":   routing: unrouted;
+"v6-transport":   reqid: REQID;
 "v6-transport":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/ipv6-tunnel-mode-02-xfrm-xfrm/east.console.txt
+++ b/testing/pluto/ipv6-tunnel-mode-02-xfrm-xfrm/east.console.txt
@@ -124,6 +124,7 @@ Connection list:
 "v6-tunnel":   dpd: passive; delay:0s; timeout:0s
 "v6-tunnel":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "v6-tunnel":   routing: unrouted;
+"v6-tunnel":   reqid: REQID;
 "v6-tunnel":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/ipv6-tunnel-mode-02-xfrm-xfrm/west.console.txt
+++ b/testing/pluto/ipv6-tunnel-mode-02-xfrm-xfrm/west.console.txt
@@ -140,6 +140,7 @@ Connection list:
 "v6-tunnel":   dpd: passive; delay:0s; timeout:0s
 "v6-tunnel":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "v6-tunnel":   routing: unrouted;
+"v6-tunnel":   reqid: REQID;
 "v6-tunnel":   conn serial: $1;
  
 Total IPsec connections: loaded 1, routed 0, active 0

--- a/testing/pluto/ipv6-tunnel-mode-03-rw/east.console.txt
+++ b/testing/pluto/ipv6-tunnel-mode-03-rw/east.console.txt
@@ -30,6 +30,7 @@ east #
 "v6-tunnel-east-road":   dpd: passive; delay:0s; timeout:0s
 "v6-tunnel-east-road":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "v6-tunnel-east-road":   routing: unrouted;
+"v6-tunnel-east-road":   reqid: REQID;
 "v6-tunnel-east-road":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ipv6-tunnel-mode-03-rw/road.console.txt
+++ b/testing/pluto/ipv6-tunnel-mode-03-rw/road.console.txt
@@ -46,6 +46,7 @@ road #
 "v6-tunnel-east-road":   dpd: passive; delay:0s; timeout:0s
 "v6-tunnel-east-road":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "v6-tunnel-east-road":   routing: unrouted;
+"v6-tunnel-east-road":   reqid: REQID;
 "v6-tunnel-east-road":   conn serial: $1;
 road #
  echo "initdone"

--- a/testing/pluto/ipv6-tunnel-mode-04-rw/east.console.txt
+++ b/testing/pluto/ipv6-tunnel-mode-04-rw/east.console.txt
@@ -30,6 +30,7 @@ east #
 "v6-tunnel-east-road":   dpd: passive; delay:0s; timeout:0s
 "v6-tunnel-east-road":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "v6-tunnel-east-road":   routing: unrouted;
+"v6-tunnel-east-road":   reqid: REQID;
 "v6-tunnel-east-road":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/ipv6-tunnel-mode-04-rw/road.console.txt
+++ b/testing/pluto/ipv6-tunnel-mode-04-rw/road.console.txt
@@ -46,6 +46,7 @@ road #
 "v6-tunnel-east-road":   dpd: passive; delay:0s; timeout:0s
 "v6-tunnel-east-road":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "v6-tunnel-east-road":   routing: unrouted;
+"v6-tunnel-east-road":   reqid: REQID;
 "v6-tunnel-east-road":   conn serial: $1;
 road #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/multinet-01/east.console.txt
+++ b/testing/pluto/multinet-01/east.console.txt
@@ -33,6 +33,7 @@ east #
 "westnet-eastnet-subnets/1x1":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-subnets/1x1":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-subnets/1x1":   routing: unrouted;
+"westnet-eastnet-subnets/1x1":   reqid: REQID;
 "westnet-eastnet-subnets/1x1":   conn serial: $1;
 "westnet-eastnet-subnets/1x1":   aliases: westnet-eastnet-subnets
 "westnet-eastnet-subnets/1x2": 192.0.2.64/30===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.0/28; unrouted; my_ip=unset; their_ip=unset;
@@ -55,6 +56,7 @@ east #
 "westnet-eastnet-subnets/1x2":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-subnets/1x2":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-subnets/1x2":   routing: unrouted;
+"westnet-eastnet-subnets/1x2":   reqid: REQID;
 "westnet-eastnet-subnets/1x2":   conn serial: $2;
 "westnet-eastnet-subnets/1x2":   aliases: westnet-eastnet-subnets
 "westnet-eastnet-subnets/2x1": 192.0.2.16/28===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.128/28; unrouted; my_ip=unset; their_ip=unset;
@@ -77,6 +79,7 @@ east #
 "westnet-eastnet-subnets/2x1":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-subnets/2x1":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-subnets/2x1":   routing: unrouted;
+"westnet-eastnet-subnets/2x1":   reqid: REQID;
 "westnet-eastnet-subnets/2x1":   conn serial: $3;
 "westnet-eastnet-subnets/2x1":   aliases: westnet-eastnet-subnets
 "westnet-eastnet-subnets/2x2": 192.0.2.64/30===192.1.2.23[@east]...192.1.2.45[@west]===192.0.1.128/28; unrouted; my_ip=unset; their_ip=unset;
@@ -99,6 +102,7 @@ east #
 "westnet-eastnet-subnets/2x2":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-subnets/2x2":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-subnets/2x2":   routing: unrouted;
+"westnet-eastnet-subnets/2x2":   reqid: REQID;
 "westnet-eastnet-subnets/2x2":   conn serial: $4;
 "westnet-eastnet-subnets/2x2":   aliases: westnet-eastnet-subnets
 east #

--- a/testing/pluto/multinet-01/west.console.txt
+++ b/testing/pluto/multinet-01/west.console.txt
@@ -49,6 +49,7 @@ west #
 "westnet-eastnet-subnets/1x1":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-subnets/1x1":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-subnets/1x1":   routing: unrouted;
+"westnet-eastnet-subnets/1x1":   reqid: REQID;
 "westnet-eastnet-subnets/1x1":   conn serial: $1;
 "westnet-eastnet-subnets/1x1":   aliases: westnet-eastnet-subnets
 "westnet-eastnet-subnets/1x2": 192.0.1.0/28===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.64/30; unrouted; my_ip=unset; their_ip=unset;
@@ -71,6 +72,7 @@ west #
 "westnet-eastnet-subnets/1x2":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-subnets/1x2":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-subnets/1x2":   routing: unrouted;
+"westnet-eastnet-subnets/1x2":   reqid: REQID;
 "westnet-eastnet-subnets/1x2":   conn serial: $2;
 "westnet-eastnet-subnets/1x2":   aliases: westnet-eastnet-subnets
 "westnet-eastnet-subnets/2x1": 192.0.1.128/28===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.16/28; unrouted; my_ip=unset; their_ip=unset;
@@ -93,6 +95,7 @@ west #
 "westnet-eastnet-subnets/2x1":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-subnets/2x1":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-subnets/2x1":   routing: unrouted;
+"westnet-eastnet-subnets/2x1":   reqid: REQID;
 "westnet-eastnet-subnets/2x1":   conn serial: $3;
 "westnet-eastnet-subnets/2x1":   aliases: westnet-eastnet-subnets
 "westnet-eastnet-subnets/2x2": 192.0.1.128/28===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.64/30; unrouted; my_ip=unset; their_ip=unset;
@@ -115,6 +118,7 @@ west #
 "westnet-eastnet-subnets/2x2":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-subnets/2x2":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-subnets/2x2":   routing: unrouted;
+"westnet-eastnet-subnets/2x2":   reqid: REQID;
 "westnet-eastnet-subnets/2x2":   conn serial: $4;
 "westnet-eastnet-subnets/2x2":   aliases: westnet-eastnet-subnets
 west #
@@ -211,6 +215,7 @@ west #
 "westnet-eastnet-subnets/1x1":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-subnets/1x1":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-subnets/1x1":   routing: unrouted;
+"westnet-eastnet-subnets/1x1":   reqid: REQID;
 "westnet-eastnet-subnets/1x1":   conn serial: $1;
 "westnet-eastnet-subnets/1x1":   aliases: westnet-eastnet-subnets
 "westnet-eastnet-subnets/1x2": 192.0.1.0/28===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.64/30; unrouted; my_ip=unset; their_ip=unset;
@@ -233,6 +238,7 @@ west #
 "westnet-eastnet-subnets/1x2":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-subnets/1x2":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-subnets/1x2":   routing: unrouted;
+"westnet-eastnet-subnets/1x2":   reqid: REQID;
 "westnet-eastnet-subnets/1x2":   conn serial: $2;
 "westnet-eastnet-subnets/1x2":   aliases: westnet-eastnet-subnets
 "westnet-eastnet-subnets/2x1": 192.0.1.128/28===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.16/28; unrouted; my_ip=unset; their_ip=unset;
@@ -255,6 +261,7 @@ west #
 "westnet-eastnet-subnets/2x1":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-subnets/2x1":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-subnets/2x1":   routing: unrouted;
+"westnet-eastnet-subnets/2x1":   reqid: REQID;
 "westnet-eastnet-subnets/2x1":   conn serial: $3;
 "westnet-eastnet-subnets/2x1":   aliases: westnet-eastnet-subnets
 "westnet-eastnet-subnets/2x2": 192.0.1.128/28===192.1.2.45[@west]...192.1.2.23[@east]===192.0.2.64/30; unrouted; my_ip=unset; their_ip=unset;
@@ -277,6 +284,7 @@ west #
 "westnet-eastnet-subnets/2x2":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-subnets/2x2":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-subnets/2x2":   routing: unrouted;
+"westnet-eastnet-subnets/2x2":   reqid: REQID;
 "westnet-eastnet-subnets/2x2":   conn serial: $4;
 "westnet-eastnet-subnets/2x2":   aliases: westnet-eastnet-subnets
 west #

--- a/testing/pluto/nat-pluto-04/road.console.txt
+++ b/testing/pluto/nat-pluto-04/road.console.txt
@@ -30,6 +30,7 @@ road #
 "road-eastnet-nat":   dpd: passive; delay:0s; timeout:0s
 "road-eastnet-nat":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "road-eastnet-nat":   routing: unrouted;
+"road-eastnet-nat":   reqid: REQID;
 "road-eastnet-nat":   conn serial: $1;
 road #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-01-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-01-ikev1/east.console.txt
@@ -32,6 +32,7 @@ east #
 "nss-cert":   dpd: passive; delay:0s; timeout:0s
 "nss-cert":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert":   routing: unrouted;
+"nss-cert":   reqid: REQID;
 "nss-cert":   conn serial: $1;
 east #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-01-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-01-ikev1/west.console.txt
@@ -32,6 +32,7 @@ west #
 "nss-cert":   dpd: passive; delay:0s; timeout:0s
 "nss-cert":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert":   routing: unrouted;
+"nss-cert":   reqid: REQID;
 "nss-cert":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-01-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-01-ikev2/east.console.txt
@@ -33,6 +33,7 @@ east #
 "nss-cert":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert":   routing: unrouted;
+"nss-cert":   reqid: REQID;
 "nss-cert":   conn serial: $1;
 east #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-01-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-01-ikev2/west.console.txt
@@ -33,6 +33,7 @@ west #
 "nss-cert":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert":   routing: unrouted;
+"nss-cert":   reqid: REQID;
 "nss-cert":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-02-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-02-ikev1/east.console.txt
@@ -41,6 +41,7 @@ east #
 "nss-cert":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert":   routing: unrouted;
+"nss-cert":   reqid: REQID;
 "nss-cert":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/nss-cert-02-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-02-ikev1/west.console.txt
@@ -41,6 +41,7 @@ west #
 "nss-cert":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert":   routing: unrouted;
+"nss-cert":   reqid: REQID;
 "nss-cert":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-02-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-02-ikev2/east.console.txt
@@ -41,6 +41,7 @@ east #
 "nss-cert":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert":   routing: unrouted;
+"nss-cert":   reqid: REQID;
 "nss-cert":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/nss-cert-02-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-02-ikev2/west.console.txt
@@ -41,6 +41,7 @@ west #
 "nss-cert":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert":   routing: unrouted;
+"nss-cert":   reqid: REQID;
 "nss-cert":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-03-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-03-ikev1/east.console.txt
@@ -40,6 +40,7 @@ east #
 "nss-cert":   dpd: passive; delay:0s; timeout:0s
 "nss-cert":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert":   routing: unrouted;
+"nss-cert":   reqid: REQID;
 "nss-cert":   conn serial: $1;
 east #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-03-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-03-ikev1/west.console.txt
@@ -40,6 +40,7 @@ west #
 "nss-cert":   dpd: passive; delay:0s; timeout:0s
 "nss-cert":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert":   routing: unrouted;
+"nss-cert":   reqid: REQID;
 "nss-cert":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-03-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-03-ikev2/east.console.txt
@@ -41,6 +41,7 @@ east #
 "nss-cert":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert":   routing: unrouted;
+"nss-cert":   reqid: REQID;
 "nss-cert":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/nss-cert-03-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-03-ikev2/west.console.txt
@@ -41,6 +41,7 @@ west #
 "nss-cert":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert":   routing: unrouted;
+"nss-cert":   reqid: REQID;
 "nss-cert":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-04-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-04-ikev1/east.console.txt
@@ -48,6 +48,7 @@ east #
 "nss-cert":   dpd: passive; delay:0s; timeout:0s
 "nss-cert":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert":   routing: unrouted;
+"nss-cert":   reqid: REQID;
 "nss-cert":   conn serial: $1;
 east #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-04-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-04-ikev1/west.console.txt
@@ -60,6 +60,7 @@ west #
 "nss-cert":   dpd: passive; delay:0s; timeout:0s
 "nss-cert":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert":   routing: unrouted;
+"nss-cert":   reqid: REQID;
 "nss-cert":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-04-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-04-ikev2/east.console.txt
@@ -49,6 +49,7 @@ east #
 "nss-cert":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert":   routing: unrouted;
+"nss-cert":   reqid: REQID;
 "nss-cert":   conn serial: $1;
 east #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-04-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-04-ikev2/west.console.txt
@@ -61,6 +61,7 @@ west #
 "nss-cert":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert":   routing: unrouted;
+"nss-cert":   reqid: REQID;
 "nss-cert":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-05-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-05-ikev1/east.console.txt
@@ -54,6 +54,7 @@ east #
 "nss-cert":   dpd: passive; delay:0s; timeout:0s
 "nss-cert":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert":   routing: unrouted;
+"nss-cert":   reqid: REQID;
 "nss-cert":   conn serial: $1;
 east #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-05-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-05-ikev1/west.console.txt
@@ -60,6 +60,7 @@ west #
 "nss-cert":   dpd: passive; delay:0s; timeout:0s
 "nss-cert":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert":   routing: unrouted;
+"nss-cert":   reqid: REQID;
 "nss-cert":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-05-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-05-ikev2/east.console.txt
@@ -55,6 +55,7 @@ east #
 "nss-cert":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert":   routing: unrouted;
+"nss-cert":   reqid: REQID;
 "nss-cert":   conn serial: $1;
 east #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-05-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-05-ikev2/west.console.txt
@@ -61,6 +61,7 @@ west #
 "nss-cert":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert":   routing: unrouted;
+"nss-cert":   reqid: REQID;
 "nss-cert":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-06-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-06-ikev1/east.console.txt
@@ -57,6 +57,7 @@ east #
 "nss-cert-correct":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-correct":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-correct":   routing: unrouted;
+"nss-cert-correct":   reqid: REQID;
 "nss-cert-correct":   conn serial: $1;
 "nss-cert-wrong": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]---192.1.2.45...%any[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=signedbyother.testing.libreswan.org, E=user-signedbyother@testing.libreswan.org]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=unset;
 "nss-cert-wrong":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.45; remote: %any;
@@ -80,6 +81,7 @@ east #
 "nss-cert-wrong":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-wrong":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-wrong":   routing: unrouted;
+"nss-cert-wrong":   reqid: REQID;
 "nss-cert-wrong":   conn serial: $2;
 east #
  echo "initdone"

--- a/testing/pluto/nss-cert-06-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-06-ikev1/west.console.txt
@@ -48,6 +48,7 @@ west #
 "nss-cert":   dpd: passive; delay:0s; timeout:0s
 "nss-cert":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert":   routing: unrouted;
+"nss-cert":   reqid: REQID;
 "nss-cert":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-06-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-06-ikev2/east.console.txt
@@ -58,6 +58,7 @@ east #
 "nss-cert-correct":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert-correct":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert-correct":   routing: unrouted;
+"nss-cert-correct":   reqid: REQID;
 "nss-cert-correct":   conn serial: $1;
 "nss-cert-wrong": 192.0.2.254/32===192.1.2.23[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=east.testing.libreswan.org, E=user-east@testing.libreswan.org]---192.1.2.45...%any[C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=signedbyother.testing.libreswan.org, E=user-signedbyother@testing.libreswan.org]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=unset;
 "nss-cert-wrong":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.45; remote: %any;
@@ -82,6 +83,7 @@ east #
 "nss-cert-wrong":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert-wrong":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert-wrong":   routing: unrouted;
+"nss-cert-wrong":   reqid: REQID;
 "nss-cert-wrong":   conn serial: $2;
 east #
  echo "initdone"

--- a/testing/pluto/nss-cert-06-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-06-ikev2/west.console.txt
@@ -49,6 +49,7 @@ west #
 "nss-cert":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert":   routing: unrouted;
+"nss-cert":   reqid: REQID;
 "nss-cert":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-chain-01-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-chain-01-ikev1/east.console.txt
@@ -42,6 +42,7 @@ east #
 "nss-cert-chain":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-chain":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-chain":   routing: unrouted;
+"nss-cert-chain":   reqid: REQID;
 "nss-cert-chain":   conn serial: $1;
 east #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-chain-01-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-chain-01-ikev1/west.console.txt
@@ -42,6 +42,7 @@ west #
 "nss-cert-chain":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-chain":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-chain":   routing: unrouted;
+"nss-cert-chain":   reqid: REQID;
 "nss-cert-chain":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-chain-01-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-chain-01-ikev2/east.console.txt
@@ -43,6 +43,7 @@ east #
 "nss-cert-chain":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert-chain":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert-chain":   routing: unrouted;
+"nss-cert-chain":   reqid: REQID;
 "nss-cert-chain":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/nss-cert-chain-01-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-chain-01-ikev2/west.console.txt
@@ -43,6 +43,7 @@ west #
 "nss-cert-chain":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert-chain":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert-chain":   routing: unrouted;
+"nss-cert-chain":   reqid: REQID;
 "nss-cert-chain":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-chain-02-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-chain-02-ikev1/east.console.txt
@@ -43,6 +43,7 @@ east #
 "nss-cert-chain":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-chain":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-chain":   routing: unrouted;
+"nss-cert-chain":   reqid: REQID;
 "nss-cert-chain":   conn serial: $1;
 east #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-chain-02-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-chain-02-ikev1/west.console.txt
@@ -43,6 +43,7 @@ west #
 "nss-cert-chain":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-chain":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-chain":   routing: unrouted;
+"nss-cert-chain":   reqid: REQID;
 "nss-cert-chain":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-chain-02-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-chain-02-ikev2/east.console.txt
@@ -44,6 +44,7 @@ east #
 "nss-cert-chain":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert-chain":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert-chain":   routing: unrouted;
+"nss-cert-chain":   reqid: REQID;
 "nss-cert-chain":   conn serial: $1;
 east #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-chain-02-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-chain-02-ikev2/west.console.txt
@@ -44,6 +44,7 @@ west #
 "nss-cert-chain":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert-chain":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert-chain":   routing: unrouted;
+"nss-cert-chain":   reqid: REQID;
 "nss-cert-chain":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-chain-03-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-chain-03-ikev1/east.console.txt
@@ -57,6 +57,7 @@ east #
 "nss-cert-chain":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-chain":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-chain":   routing: unrouted;
+"nss-cert-chain":   reqid: REQID;
 "nss-cert-chain":   conn serial: $1;
 east #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-chain-03-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-chain-03-ikev1/west.console.txt
@@ -57,6 +57,7 @@ west #
 "nss-cert-chain":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-chain":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-chain":   routing: unrouted;
+"nss-cert-chain":   reqid: REQID;
 "nss-cert-chain":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-chain-03-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-chain-03-ikev2/east.console.txt
@@ -58,6 +58,7 @@ east #
 "nss-cert-chain":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert-chain":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert-chain":   routing: unrouted;
+"nss-cert-chain":   reqid: REQID;
 "nss-cert-chain":   conn serial: $1;
 east #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-chain-03-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-chain-03-ikev2/west.console.txt
@@ -58,6 +58,7 @@ west #
 "nss-cert-chain":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert-chain":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert-chain":   routing: unrouted;
+"nss-cert-chain":   reqid: REQID;
 "nss-cert-chain":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-chain-04-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-chain-04-ikev1/east.console.txt
@@ -57,6 +57,7 @@ east #
 "road-A":   dpd: passive; delay:0s; timeout:0s
 "road-A":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "road-A":   routing: unrouted;
+"road-A":   reqid: REQID;
 "road-A":   conn serial: $1;
 "road-chain-B": 192.0.2.254/32===192.1.2.23[@east.testing.libreswan.org]---192.1.2.45...%any[@west_chain_endcert.testing.libreswan.org]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=unset;
 "road-chain-B":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.45; remote: %any;
@@ -80,6 +81,7 @@ east #
 "road-chain-B":   dpd: passive; delay:0s; timeout:0s
 "road-chain-B":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "road-chain-B":   routing: unrouted;
+"road-chain-B":   reqid: REQID;
 "road-chain-B":   conn serial: $2;
 east #
  echo "initdone"

--- a/testing/pluto/nss-cert-chain-04-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-chain-04-ikev1/west.console.txt
@@ -52,6 +52,7 @@ west #
 "road-chain-B":   dpd: passive; delay:0s; timeout:0s
 "road-chain-B":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "road-chain-B":   routing: unrouted;
+"road-chain-B":   reqid: REQID;
 "road-chain-B":   conn serial: $1;
 west #
  ipsec certutil -L

--- a/testing/pluto/nss-cert-chain-04-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-chain-04-ikev2/east.console.txt
@@ -58,6 +58,7 @@ east #
 "road-A":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "road-A":   nat-traversal: encapsulation:auto; keepalive:20s
 "road-A":   routing: unrouted;
+"road-A":   reqid: REQID;
 "road-A":   conn serial: $1;
 "road-chain-B": 192.0.2.254/32===192.1.2.23[@east.testing.libreswan.org]---192.1.2.45...%any[@west_chain_endcert.testing.libreswan.org]===192.0.1.254/32; unrouted; my_ip=192.0.2.254; their_ip=unset;
 "road-chain-B":   host: oriented; local: 192.1.2.23; nexthop: 192.1.2.45; remote: %any;
@@ -82,6 +83,7 @@ east #
 "road-chain-B":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "road-chain-B":   nat-traversal: encapsulation:auto; keepalive:20s
 "road-chain-B":   routing: unrouted;
+"road-chain-B":   reqid: REQID;
 "road-chain-B":   conn serial: $2;
 east #
  echo "initdone"

--- a/testing/pluto/nss-cert-chain-04-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-chain-04-ikev2/west.console.txt
@@ -53,6 +53,7 @@ west #
 "road-chain-B":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "road-chain-B":   nat-traversal: encapsulation:auto; keepalive:20s
 "road-chain-B":   routing: unrouted;
+"road-chain-B":   reqid: REQID;
 "road-chain-B":   conn serial: $1;
 west #
  ipsec certutil -L

--- a/testing/pluto/nss-cert-nosecret/east.console.txt
+++ b/testing/pluto/nss-cert-nosecret/east.console.txt
@@ -47,6 +47,7 @@ east #
 "nss-cert":   dpd: passive; delay:0s; timeout:0s
 "nss-cert":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert":   routing: unrouted;
+"nss-cert":   reqid: REQID;
 "nss-cert":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/nss-cert-nosecret/west.console.txt
+++ b/testing/pluto/nss-cert-nosecret/west.console.txt
@@ -89,6 +89,7 @@ west #
 "nss-cert":   dpd: passive; delay:0s; timeout:0s
 "nss-cert":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert":   routing: unrouted;
+"nss-cert":   reqid: REQID;
 "nss-cert":   conn serial: $1;
 west #
  ipsec whack --impair suppress_retransmits

--- a/testing/pluto/nss-cert-ocsp-01-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-01-ikev1/east.console.txt
@@ -46,6 +46,7 @@ east #
 "nss-cert-ocsp":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-01-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-01-ikev1/west.console.txt
@@ -40,6 +40,7 @@ west #
 "nss-cert-ocsp":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-01-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-01-ikev2/east.console.txt
@@ -47,6 +47,7 @@ east #
 "nss-cert-ocsp":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-01-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-01-ikev2/west.console.txt
@@ -41,6 +41,7 @@ west #
 "nss-cert-ocsp":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-02-revoked-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-02-revoked-ikev1/east.console.txt
@@ -55,6 +55,7 @@ east #
 "nss-cert-ocsp":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-02-revoked-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-02-revoked-ikev1/west.console.txt
@@ -57,6 +57,7 @@ west #
 "nss-cert-ocsp":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-02-revoked-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-02-revoked-ikev2/east.console.txt
@@ -56,6 +56,7 @@ east #
 "nss-cert-ocsp":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-02-revoked-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-02-revoked-ikev2/west.console.txt
@@ -60,6 +60,7 @@ west #
 "nss-cert-ocsp":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-03-bogus-uri-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-03-bogus-uri-ikev1/east.console.txt
@@ -48,6 +48,7 @@ east #
 "nss-cert-ocsp":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-03-bogus-uri-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-03-bogus-uri-ikev1/west.console.txt
@@ -40,6 +40,7 @@ west #
 "nss-cert-ocsp":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-03-bogus-uri-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-03-bogus-uri-ikev2/east.console.txt
@@ -47,6 +47,7 @@ east #
 "nss-cert-ocsp":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-03-bogus-uri-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-03-bogus-uri-ikev2/west.console.txt
@@ -41,6 +41,7 @@ west #
 "nss-cert-ocsp":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-03-bogus-uri-strict-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-03-bogus-uri-strict-ikev1/east.console.txt
@@ -48,6 +48,7 @@ east #
 "nss-cert-ocsp":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-03-bogus-uri-strict-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-03-bogus-uri-strict-ikev1/west.console.txt
@@ -40,6 +40,7 @@ west #
 "nss-cert-ocsp":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-04-revoked-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-04-revoked-ikev1/east.console.txt
@@ -55,6 +55,7 @@ east #
 "nss-cert-ocsp":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-04-revoked-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-04-revoked-ikev1/west.console.txt
@@ -55,6 +55,7 @@ west #
 "nss-cert-ocsp":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-05-no-trust-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-05-no-trust-ikev1/east.console.txt
@@ -48,6 +48,7 @@ east #
 "nss-cert-ocsp":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-05-no-trust-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-05-no-trust-ikev1/west.console.txt
@@ -40,6 +40,7 @@ west #
 "nss-cert-ocsp":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-05-no-trust-ikev2/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-05-no-trust-ikev2/east.console.txt
@@ -47,6 +47,7 @@ east #
 "nss-cert-ocsp":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-05-no-trust-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-05-no-trust-ikev2/west.console.txt
@@ -41,6 +41,7 @@ west #
 "nss-cert-ocsp":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-05-no-trust-strict-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-05-no-trust-strict-ikev1/east.console.txt
@@ -48,6 +48,7 @@ east #
 "nss-cert-ocsp":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-05-no-trust-strict-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-05-no-trust-strict-ikev1/west.console.txt
@@ -40,6 +40,7 @@ west #
 "nss-cert-ocsp":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-06-no-trust-revoked-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-06-no-trust-revoked-ikev1/east.console.txt
@@ -55,6 +55,7 @@ east #
 "nss-cert-ocsp":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-06-no-trust-revoked-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-06-no-trust-revoked-ikev1/west.console.txt
@@ -55,6 +55,7 @@ west #
 "nss-cert-ocsp":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-07-nic-no-ocsp-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-07-nic-no-ocsp-ikev1/west.console.txt
@@ -57,6 +57,7 @@ west #
 "nss-cert-ocsp":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-07-nic-no-ocsp-ikev2/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-07-nic-no-ocsp-ikev2/west.console.txt
@@ -58,6 +58,7 @@ west #
 "nss-cert-ocsp":   liveness: passive; dpddelay:0s; retransmit-timeout:10s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-08-post-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-08-post-ikev1/east.console.txt
@@ -55,6 +55,7 @@ east #
 "nss-cert-ocsp":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-08-post-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-08-post-ikev1/west.console.txt
@@ -57,6 +57,7 @@ west #
 "nss-cert-ocsp":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-09-chain-ikev1/east.console.txt
+++ b/testing/pluto/nss-cert-ocsp-09-chain-ikev1/east.console.txt
@@ -48,6 +48,7 @@ east #
 "nss-cert-ocsp":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/nss-cert-ocsp-09-chain-ikev1/west.console.txt
+++ b/testing/pluto/nss-cert-ocsp-09-chain-ikev1/west.console.txt
@@ -48,6 +48,7 @@ west #
 "nss-cert-ocsp":   dpd: passive; delay:0s; timeout:0s
 "nss-cert-ocsp":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "nss-cert-ocsp":   routing: unrouted;
+"nss-cert-ocsp":   reqid: REQID;
 "nss-cert-ocsp":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/psk-pluto-02/road.console.txt
+++ b/testing/pluto/psk-pluto-02/road.console.txt
@@ -32,6 +32,7 @@ road #
 "road-eastnet-psk":   dpd: passive; delay:0s; timeout:0s
 "road-eastnet-psk":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "road-eastnet-psk":   routing: unrouted;
+"road-eastnet-psk":   reqid: REQID;
 "road-eastnet-psk":   conn serial: $1;
 "road-eastnet-psk":   IKE algorithms: 3DES_CBC-HMAC_SHA1-MODP2048, 3DES_CBC-HMAC_SHA1-MODP1536, 3DES_CBC-HMAC_SHA1-DH19, 3DES_CBC-HMAC_SHA1-DH31
 road #

--- a/testing/pluto/replay-window-ikev1/east.console.txt
+++ b/testing/pluto/replay-window-ikev1/east.console.txt
@@ -30,6 +30,7 @@ east #
 "westnet-eastnet-null":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-null":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-null":   routing: unrouted;
+"westnet-eastnet-null":   reqid: REQID;
 "westnet-eastnet-null":   conn serial: $7;
 east #
  echo "initdone"

--- a/testing/pluto/replay-window-ikev2/east.console.txt
+++ b/testing/pluto/replay-window-ikev2/east.console.txt
@@ -31,6 +31,7 @@ east #
 "westnet-eastnet-null":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-null":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-null":   routing: unrouted;
+"westnet-eastnet-null":   reqid: REQID;
 "westnet-eastnet-null":   conn serial: $7;
 east #
  echo "initdone"

--- a/testing/pluto/whack-rereadcerts-01/east.console.txt
+++ b/testing/pluto/whack-rereadcerts-01/east.console.txt
@@ -36,6 +36,7 @@ east #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/whack-rereadcerts-01/west.console.txt
+++ b/testing/pluto/whack-rereadcerts-01/west.console.txt
@@ -49,6 +49,7 @@ west #
 "westnet-eastnet-ikev2":   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "westnet-eastnet-ikev2":   nat-traversal: encapsulation:auto; keepalive:20s
 "westnet-eastnet-ikev2":   routing: unrouted;
+"westnet-eastnet-ikev2":   reqid: REQID;
 "westnet-eastnet-ikev2":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/x509-pluto-01/east.console.txt
+++ b/testing/pluto/x509-pluto-01/east.console.txt
@@ -43,6 +43,7 @@ east #
 "westnet-eastnet-x509-nosend":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-x509-nosend":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-x509-nosend":   routing: unrouted;
+"westnet-eastnet-x509-nosend":   reqid: REQID;
 "westnet-eastnet-x509-nosend":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/x509-pluto-01/west.console.txt
+++ b/testing/pluto/x509-pluto-01/west.console.txt
@@ -59,6 +59,7 @@ west #
 "westnet-eastnet-x509-nosend":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-x509-nosend":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-x509-nosend":   routing: unrouted;
+"westnet-eastnet-x509-nosend":   reqid: REQID;
 "westnet-eastnet-x509-nosend":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/x509-pluto-02/east.console.txt
+++ b/testing/pluto/x509-pluto-02/east.console.txt
@@ -40,6 +40,7 @@ east #
 "north-east-x509-pluto-02":   dpd: passive; delay:0s; timeout:0s
 "north-east-x509-pluto-02":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "north-east-x509-pluto-02":   routing: unrouted;
+"north-east-x509-pluto-02":   reqid: REQID;
 "north-east-x509-pluto-02":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/x509-pluto-02/north.console.txt
+++ b/testing/pluto/x509-pluto-02/north.console.txt
@@ -43,6 +43,7 @@ north #
 "north-east-x509-pluto-02":   dpd: passive; delay:0s; timeout:0s
 "north-east-x509-pluto-02":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "north-east-x509-pluto-02":   routing: unrouted;
+"north-east-x509-pluto-02":   reqid: REQID;
 "north-east-x509-pluto-02":   conn serial: $1;
 north #
  echo "initdone"

--- a/testing/pluto/x509-pluto-03/east.console.txt
+++ b/testing/pluto/x509-pluto-03/east.console.txt
@@ -40,6 +40,7 @@ east #
 "westnet-eastnet-x509-cr":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-x509-cr":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-x509-cr":   routing: unrouted;
+"westnet-eastnet-x509-cr":   reqid: REQID;
 "westnet-eastnet-x509-cr":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/x509-pluto-03/west.console.txt
+++ b/testing/pluto/x509-pluto-03/west.console.txt
@@ -56,6 +56,7 @@ west #
 "westnet-eastnet-x509-cr":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-x509-cr":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-x509-cr":   routing: unrouted;
+"westnet-eastnet-x509-cr":   reqid: REQID;
 "westnet-eastnet-x509-cr":   conn serial: $1;
 west #
  echo "initdone"

--- a/testing/pluto/x509-pluto-04/east.console.txt
+++ b/testing/pluto/x509-pluto-04/east.console.txt
@@ -50,6 +50,7 @@ east #
 "westnet-eastnet-x509-cr":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-x509-cr":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-x509-cr":   routing: unrouted;
+"westnet-eastnet-x509-cr":   reqid: REQID;
 "westnet-eastnet-x509-cr":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/x509-pluto-05/east.console.txt
+++ b/testing/pluto/x509-pluto-05/east.console.txt
@@ -43,6 +43,7 @@ east #
 "westnet-eastnet-x509":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-x509":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-x509":   routing: unrouted;
+"westnet-eastnet-x509":   reqid: REQID;
 "westnet-eastnet-x509":   conn serial: $1;
 east #
  echo "initdone"

--- a/testing/pluto/xauth-pluto-05-xfrm/road.console.txt
+++ b/testing/pluto/xauth-pluto-05-xfrm/road.console.txt
@@ -40,6 +40,7 @@ road #
 "modecfg-road-eastnet-psk":   dpd: passive; delay:0s; timeout:0s
 "modecfg-road-eastnet-psk":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "modecfg-road-eastnet-psk":   routing: unrouted;
+"modecfg-road-eastnet-psk":   reqid: REQID;
 "modecfg-road-eastnet-psk":   conn serial: $2;
 "modecfg-road-eastnet-psk":   IKE algorithms: 3DES_CBC-HMAC_SHA1-MODP2048, 3DES_CBC-HMAC_SHA1-MODP1536, 3DES_CBC-HMAC_SHA1-DH19, 3DES_CBC-HMAC_SHA1-DH31
 road #

--- a/testing/pluto/xauth-pluto-05/road.console.txt
+++ b/testing/pluto/xauth-pluto-05/road.console.txt
@@ -40,6 +40,7 @@ road #
 "modecfg-road-eastnet-psk":   dpd: passive; delay:0s; timeout:0s
 "modecfg-road-eastnet-psk":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "modecfg-road-eastnet-psk":   routing: unrouted;
+"modecfg-road-eastnet-psk":   reqid: REQID;
 "modecfg-road-eastnet-psk":   conn serial: $2;
 "modecfg-road-eastnet-psk":   IKE algorithms: 3DES_CBC-HMAC_SHA1-MODP2048, 3DES_CBC-HMAC_SHA1-MODP1536, 3DES_CBC-HMAC_SHA1-DH19, 3DES_CBC-HMAC_SHA1-DH31
 road #

--- a/testing/pluto/xauth-pluto-06/road.console.txt
+++ b/testing/pluto/xauth-pluto-06/road.console.txt
@@ -36,6 +36,7 @@ road #
 "modecfg-road-eastnet-psk":   dpd: passive; delay:0s; timeout:0s
 "modecfg-road-eastnet-psk":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "modecfg-road-eastnet-psk":   routing: unrouted;
+"modecfg-road-eastnet-psk":   reqid: REQID;
 "modecfg-road-eastnet-psk":   conn serial: $2;
 "modecfg-road-eastnet-psk":   IKE algorithms: 3DES_CBC-HMAC_SHA1-MODP2048, 3DES_CBC-HMAC_SHA1-MODP1536, 3DES_CBC-HMAC_SHA1-DH19, 3DES_CBC-HMAC_SHA1-DH31
 road #

--- a/testing/pluto/xauth-pluto-09/road.console.txt
+++ b/testing/pluto/xauth-pluto-09/road.console.txt
@@ -36,6 +36,7 @@ road #
 "modecfg-road-eastnet-psk":   dpd: passive; delay:0s; timeout:0s
 "modecfg-road-eastnet-psk":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "modecfg-road-eastnet-psk":   routing: unrouted;
+"modecfg-road-eastnet-psk":   reqid: REQID;
 "modecfg-road-eastnet-psk":   conn serial: $2;
 "modecfg-road-eastnet-psk":   IKE algorithms: 3DES_CBC-HMAC_SHA1-MODP2048, 3DES_CBC-HMAC_SHA1-MODP1536, 3DES_CBC-HMAC_SHA1-DH19, 3DES_CBC-HMAC_SHA1-DH31
 road #

--- a/testing/pluto/xauth-pluto-19/road.console.txt
+++ b/testing/pluto/xauth-pluto-19/road.console.txt
@@ -40,6 +40,7 @@ road #
 "modecfg-road-eastnet-psk":   dpd: passive; delay:0s; timeout:0s
 "modecfg-road-eastnet-psk":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "modecfg-road-eastnet-psk":   routing: unrouted;
+"modecfg-road-eastnet-psk":   reqid: REQID;
 "modecfg-road-eastnet-psk":   conn serial: $2;
 "modecfg-road-eastnet-psk":   IKE algorithms: 3DES_CBC-HMAC_SHA1-MODP2048, 3DES_CBC-HMAC_SHA1-MODP1536, 3DES_CBC-HMAC_SHA1-DH19, 3DES_CBC-HMAC_SHA1-DH31
 road #

--- a/testing/pluto/xfrm-algo-aes_gcm-01/east.console.txt
+++ b/testing/pluto/xfrm-algo-aes_gcm-01/east.console.txt
@@ -118,6 +118,7 @@ Connection list:
 "westnet-eastnet-gcm":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-gcm":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-gcm":   routing: unrouted;
+"westnet-eastnet-gcm":   reqid: REQID;
 "westnet-eastnet-gcm":   conn serial: $1;
 "westnet-eastnet-gcm":   IKE algorithms: AES_CBC_256-HMAC_SHA2_256-MODP2048, AES_CBC_256-HMAC_SHA2_512-MODP2048, AES_CBC_256-HMAC_SHA1-MODP2048, AES_CBC_256-HMAC_SHA2_256-MODP1536, AES_CBC_256-HMAC_SHA2_512-MODP1536, AES_CBC_256-HMAC_SHA1-MODP1536, AES_CBC_256-HMAC_SHA2_256-DH19, AES_CBC_256-HMAC_SHA2_512-DH19, AES_CBC_256-HMAC_SHA1-DH19, AES_CBC_256-HMAC_SHA2_256-DH31, AES_CBC_256-HMAC_SHA2_512-DH31, AES_CBC_256-HMAC_SHA1-DH31
 "westnet-eastnet-gcm":   ESP algorithms: AES_GCM_16_192

--- a/testing/pluto/xfrm-algo-aes_gcm-01/west.console.txt
+++ b/testing/pluto/xfrm-algo-aes_gcm-01/west.console.txt
@@ -134,6 +134,7 @@ Connection list:
 "westnet-eastnet-gcm":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-gcm":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-gcm":   routing: unrouted;
+"westnet-eastnet-gcm":   reqid: REQID;
 "westnet-eastnet-gcm":   conn serial: $1;
 "westnet-eastnet-gcm":   IKE algorithms: AES_CBC_256-HMAC_SHA2_256-MODP2048, AES_CBC_256-HMAC_SHA2_512-MODP2048, AES_CBC_256-HMAC_SHA1-MODP2048, AES_CBC_256-HMAC_SHA2_256-MODP1536, AES_CBC_256-HMAC_SHA2_512-MODP1536, AES_CBC_256-HMAC_SHA1-MODP1536, AES_CBC_256-HMAC_SHA2_256-DH19, AES_CBC_256-HMAC_SHA2_512-DH19, AES_CBC_256-HMAC_SHA1-DH19, AES_CBC_256-HMAC_SHA2_256-DH31, AES_CBC_256-HMAC_SHA2_512-DH31, AES_CBC_256-HMAC_SHA1-DH31
 "westnet-eastnet-gcm":   ESP algorithms: AES_GCM_16_192

--- a/testing/pluto/xfrm-algo-aes_gcm-02/east.console.txt
+++ b/testing/pluto/xfrm-algo-aes_gcm-02/east.console.txt
@@ -118,6 +118,7 @@ Connection list:
 "westnet-eastnet-gcm":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-gcm":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-gcm":   routing: unrouted;
+"westnet-eastnet-gcm":   reqid: REQID;
 "westnet-eastnet-gcm":   conn serial: $1;
 "westnet-eastnet-gcm":   IKE algorithms: AES_CBC_256-HMAC_SHA2_256-MODP2048, AES_CBC_256-HMAC_SHA2_512-MODP2048, AES_CBC_256-HMAC_SHA1-MODP2048, AES_CBC_256-HMAC_SHA2_256-MODP1536, AES_CBC_256-HMAC_SHA2_512-MODP1536, AES_CBC_256-HMAC_SHA1-MODP1536, AES_CBC_256-HMAC_SHA2_256-DH19, AES_CBC_256-HMAC_SHA2_512-DH19, AES_CBC_256-HMAC_SHA1-DH19, AES_CBC_256-HMAC_SHA2_256-DH31, AES_CBC_256-HMAC_SHA2_512-DH31, AES_CBC_256-HMAC_SHA1-DH31
 "westnet-eastnet-gcm":   ESP algorithms: AES_GCM_16_256

--- a/testing/pluto/xfrm-algo-aes_gcm-02/west.console.txt
+++ b/testing/pluto/xfrm-algo-aes_gcm-02/west.console.txt
@@ -134,6 +134,7 @@ Connection list:
 "westnet-eastnet-gcm":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-gcm":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-gcm":   routing: unrouted;
+"westnet-eastnet-gcm":   reqid: REQID;
 "westnet-eastnet-gcm":   conn serial: $1;
 "westnet-eastnet-gcm":   IKE algorithms: AES_CBC_256-HMAC_SHA2_256-MODP2048, AES_CBC_256-HMAC_SHA2_512-MODP2048, AES_CBC_256-HMAC_SHA1-MODP2048, AES_CBC_256-HMAC_SHA2_256-MODP1536, AES_CBC_256-HMAC_SHA2_512-MODP1536, AES_CBC_256-HMAC_SHA1-MODP1536, AES_CBC_256-HMAC_SHA2_256-DH19, AES_CBC_256-HMAC_SHA2_512-DH19, AES_CBC_256-HMAC_SHA1-DH19, AES_CBC_256-HMAC_SHA2_256-DH31, AES_CBC_256-HMAC_SHA2_512-DH31, AES_CBC_256-HMAC_SHA1-DH31
 "westnet-eastnet-gcm":   ESP algorithms: AES_GCM_16_256

--- a/testing/pluto/xfrm-algo-aes_gcm-03/east.console.txt
+++ b/testing/pluto/xfrm-algo-aes_gcm-03/east.console.txt
@@ -118,6 +118,7 @@ Connection list:
 "westnet-eastnet-gcm":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-gcm":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-gcm":   routing: unrouted;
+"westnet-eastnet-gcm":   reqid: REQID;
 "westnet-eastnet-gcm":   conn serial: $1;
 "westnet-eastnet-gcm":   IKE algorithms: AES_CBC_256-HMAC_SHA2_256-MODP2048, AES_CBC_256-HMAC_SHA2_512-MODP2048, AES_CBC_256-HMAC_SHA1-MODP2048, AES_CBC_256-HMAC_SHA2_256-MODP1536, AES_CBC_256-HMAC_SHA2_512-MODP1536, AES_CBC_256-HMAC_SHA1-MODP1536, AES_CBC_256-HMAC_SHA2_256-DH19, AES_CBC_256-HMAC_SHA2_512-DH19, AES_CBC_256-HMAC_SHA1-DH19, AES_CBC_256-HMAC_SHA2_256-DH31, AES_CBC_256-HMAC_SHA2_512-DH31, AES_CBC_256-HMAC_SHA1-DH31
 "westnet-eastnet-gcm":   ESP algorithms: AES_GCM_16

--- a/testing/pluto/xfrm-algo-aes_gcm-03/west.console.txt
+++ b/testing/pluto/xfrm-algo-aes_gcm-03/west.console.txt
@@ -134,6 +134,7 @@ Connection list:
 "westnet-eastnet-gcm":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-gcm":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-gcm":   routing: unrouted;
+"westnet-eastnet-gcm":   reqid: REQID;
 "westnet-eastnet-gcm":   conn serial: $1;
 "westnet-eastnet-gcm":   IKE algorithms: AES_CBC_256-HMAC_SHA2_256-MODP2048, AES_CBC_256-HMAC_SHA2_512-MODP2048, AES_CBC_256-HMAC_SHA1-MODP2048, AES_CBC_256-HMAC_SHA2_256-MODP1536, AES_CBC_256-HMAC_SHA2_512-MODP1536, AES_CBC_256-HMAC_SHA1-MODP1536, AES_CBC_256-HMAC_SHA2_256-DH19, AES_CBC_256-HMAC_SHA2_512-DH19, AES_CBC_256-HMAC_SHA1-DH19, AES_CBC_256-HMAC_SHA2_256-DH31, AES_CBC_256-HMAC_SHA2_512-DH31, AES_CBC_256-HMAC_SHA1-DH31
 "westnet-eastnet-gcm":   ESP algorithms: AES_GCM_16

--- a/testing/pluto/xfrm-algo-null-01/east.console.txt
+++ b/testing/pluto/xfrm-algo-null-01/east.console.txt
@@ -118,6 +118,7 @@ Connection list:
 "westnet-eastnet-null":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-null":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-null":   routing: unrouted;
+"westnet-eastnet-null":   reqid: REQID;
 "westnet-eastnet-null":   conn serial: $1;
 "westnet-eastnet-null":   ESP algorithms: NULL-HMAC_MD5_96
  

--- a/testing/pluto/xfrm-algo-null-01/west.console.txt
+++ b/testing/pluto/xfrm-algo-null-01/west.console.txt
@@ -134,6 +134,7 @@ Connection list:
 "westnet-eastnet-null":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-null":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-null":   routing: unrouted;
+"westnet-eastnet-null":   reqid: REQID;
 "westnet-eastnet-null":   conn serial: $1;
 "westnet-eastnet-null":   ESP algorithms: NULL-HMAC_MD5_96
  

--- a/testing/pluto/xfrm-algo-null-02/east.console.txt
+++ b/testing/pluto/xfrm-algo-null-02/east.console.txt
@@ -118,6 +118,7 @@ Connection list:
 "westnet-eastnet-esp-null-alg":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-esp-null-alg":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-esp-null-alg":   routing: unrouted;
+"westnet-eastnet-esp-null-alg":   reqid: REQID;
 "westnet-eastnet-esp-null-alg":   conn serial: $1;
 "westnet-eastnet-esp-null-alg":   ESP algorithms: NULL-HMAC_SHA1_96
  

--- a/testing/pluto/xfrm-algo-null-02/west.console.txt
+++ b/testing/pluto/xfrm-algo-null-02/west.console.txt
@@ -134,6 +134,7 @@ Connection list:
 "westnet-eastnet-esp-null-alg":   dpd: passive; delay:0s; timeout:0s
 "westnet-eastnet-esp-null-alg":   nat-traversal: encapsulation:auto; keepalive:20s; ikev1-method:rfc+drafts
 "westnet-eastnet-esp-null-alg":   routing: unrouted;
+"westnet-eastnet-esp-null-alg":   reqid: REQID;
 "westnet-eastnet-esp-null-alg":   conn serial: $1;
 "westnet-eastnet-esp-null-alg":   ESP algorithms: NULL-HMAC_SHA1_96
  

--- a/testing/sanitizers/ipsec-status.sed
+++ b/testing/sanitizers/ipsec-status.sed
@@ -1,5 +1,6 @@
 s/^secctx-attr-type=.*/secctx-attr-type=XXXX/g
 s/^secctx-attr-value=.*/secctx-attr-type=XXXX/g
+s/reqid: [1-9][0-9]*/reqid: REQID/g
 # Fedora default
 s/\/var\/lib\/unbound/UNBOUND/g
 # Debian default


### PR DESCRIPTION
Explicitly display the connection's reqid (shows the reqid when `ipsec status` is used).
Updated tests as well