### PR TITLE
ikev2: log ADDKE transforms when IKE SA is created after rekey

### DIFF
--- a/programs/pluto/ikev2_ike_sa_init.c
+++ b/programs/pluto/ikev2_ike_sa_init.c
@@ -109,6 +109,12 @@ static void jam_secured(struct jambuf *buf, struct ike_sa *ike)
 	jam_string(buf, "ke=");
 	jam_string(buf, ike->sa.st_oakley.ta_dh->common.fqn);
 
+	FOR_EACH_ITEM(ke, &ike->sa.st_oakley.ta_addke) {
+		jam(buf, " addke%d=",
+		    (ke->type - IKEv2_TRANS_TYPE_ADDKE1) + 1);
+		jam_string(buf, ke->kem->common.fqn);
+	}
+
 	jam_string(buf, "}");
 }
 

--- a/programs/pluto/ikev2_parent.c
+++ b/programs/pluto/ikev2_parent.c
@@ -212,6 +212,12 @@ void llog_v2_ike_sa_established(struct ike_sa *ike, struct child_sa *larval)
 		jam_string(buf, " ke=");
 		jam_string(buf, ike->sa.st_oakley.ta_dh->common.fqn);
 
+		FOR_EACH_ITEM(ke, &ike->sa.st_oakley.ta_addke) {
+			jam(buf, " addke%d=",
+			    (ke->type - IKEv2_TRANS_TYPE_ADDKE1) + 1);
+			jam_string(buf, ke->kem->common.fqn);
+		}
+
 		jam_string(buf, "}");
 
 	}

--- a/testing/pluto/ikev2-intermediate-01-addke-connswitch/west.console.txt
+++ b/testing/pluto/ikev2-intermediate-01-addke-connswitch/west.console.txt
@@ -20,7 +20,7 @@ west #
  ipsec up psk
 "psk" #1: initiating IKEv2 connection to 192.1.2.23 using UDP
 "psk" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
-"psk" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA2_512_256 prf=HMAC_SHA2_512 ke=DH20}, initiating IKE_INTERMEDIATE
+"psk" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA2_512_256 prf=HMAC_SHA2_512 ke=DH20 addke1=DH21}, initiating IKE_INTERMEDIATE
 "psk" #1: sent IKE_INTERMEDIATE request to 192.1.2.23:UDP/500 {addke1=DH21}
 "psk" #1: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE}
 "psk" #1: initiator processed IKE_INTERMEDIATE, initiating IKE_AUTH
@@ -44,7 +44,7 @@ west #
  ipsec up rsa-west
 "rsa-west" #3: initiating IKEv2 connection to 192.1.2.23 using UDP
 "rsa-west" #3: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
-"rsa-west" #3: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA2_512_256 prf=HMAC_SHA2_512 ke=DH20}, initiating IKE_INTERMEDIATE
+"rsa-west" #3: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA2_512_256 prf=HMAC_SHA2_512 ke=DH20 addke1=DH21}, initiating IKE_INTERMEDIATE
 "rsa-west" #3: sent IKE_INTERMEDIATE request to 192.1.2.23:UDP/500 {addke1=DH21}
 "rsa-west" #3: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE}
 "rsa-west" #3: initiator processed IKE_INTERMEDIATE, initiating IKE_AUTH

--- a/testing/pluto/ikev2-intermediate-04-addke-ml-kem-768/west.console.txt
+++ b/testing/pluto/ikev2-intermediate-04-addke-ml-kem-768/west.console.txt
@@ -41,7 +41,7 @@ west #
  ipsec auto --up westnet-eastnet-ikev2
 "westnet-eastnet-ikev2" #1: initiating IKEv2 connection to 192.1.2.23 using UDP
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
-"westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_128 integ=HMAC_SHA2_256_128 prf=HMAC_SHA2_256 ke=DH31}, initiating IKE_INTERMEDIATE
+"westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_128 integ=HMAC_SHA2_256_128 prf=HMAC_SHA2_256 ke=DH31 addke1=ML_KEM_768}, initiating IKE_INTERMEDIATE
 IMPAIR: "westnet-eastnet-ikev2" #1: adding 1 unencrypted unknown payload(s) of type 255 to IKE_INTERMEDIATE message containing 0 payloads
 "westnet-eastnet-ikev2" #1: sent IKE_INTERMEDIATE request to 192.1.2.23:UDP/500 {addke1=ML_KEM_768}
 "westnet-eastnet-ikev2" #1: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE} reassembled from N fragments

--- a/testing/pluto/ikev2-intermediate-04-addke-modp8192/west.console.txt
+++ b/testing/pluto/ikev2-intermediate-04-addke-modp8192/west.console.txt
@@ -39,7 +39,7 @@ west #
  ipsec auto --up westnet-eastnet-ikev2
 "westnet-eastnet-ikev2" #1: initiating IKEv2 connection to 192.1.2.23 using UDP
 "westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
-"westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_128 integ=HMAC_SHA2_256_128 prf=HMAC_SHA2_256 ke=DH31}, initiating IKE_INTERMEDIATE
+"westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_128 integ=HMAC_SHA2_256_128 prf=HMAC_SHA2_256 ke=DH31 addke1=MODP8192}, initiating IKE_INTERMEDIATE
 "westnet-eastnet-ikev2" #1: sent IKE_INTERMEDIATE request to 192.1.2.23:UDP/500 {addke1=MODP8192}
 "westnet-eastnet-ikev2" #1: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE}
 "westnet-eastnet-ikev2" #1: initiator processed IKE_INTERMEDIATE, initiating IKE_AUTH

--- a/testing/pluto/ikev2-intermediate-04-addke-no-nss-flag/west.console.txt
+++ b/testing/pluto/ikev2-intermediate-04-addke-no-nss-flag/west.console.txt
@@ -33,7 +33,7 @@ west #
  ipsec up west-mlkem
 "west-mlkem" #1: initiating IKEv2 connection to 192.1.2.23 using UDP
 "west-mlkem" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
-"west-mlkem" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 ke=MODP2048}, initiating IKE_INTERMEDIATE
+"west-mlkem" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 ke=MODP2048 addke1=ML_KEM_768}, initiating IKE_INTERMEDIATE
 "west-mlkem" #1: sent IKE_INTERMEDIATE request to 192.1.2.23:UDP/500 {addke1=ML_KEM_768}
 "west-mlkem" #1: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE} reassembled from N fragments
 "west-mlkem" #1: initiator processed IKE_INTERMEDIATE, initiating IKE_AUTH
@@ -57,7 +57,7 @@ west #
  ipsec up west-ecp
 "west-ecp" #3: initiating IKEv2 connection to 192.1.2.23 using UDP
 "west-ecp" #3: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
-"west-ecp" #3: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 ke=MODP2048}, initiating IKE_INTERMEDIATE
+"west-ecp" #3: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 ke=MODP2048 addke1=DH21}, initiating IKE_INTERMEDIATE
 "west-ecp" #3: sent IKE_INTERMEDIATE request to 192.1.2.23:UDP/500 {addke1=DH21}
 "west-ecp" #3: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE}
 "west-ecp" #3: initiator processed IKE_INTERMEDIATE, initiating IKE_AUTH

--- a/testing/pluto/ikev2-intermediate-05-addke-duplicate/west.console.txt
+++ b/testing/pluto/ikev2-intermediate-05-addke-duplicate/west.console.txt
@@ -23,7 +23,7 @@ Redirecting to: [initsystem]
  ipsec up algo
 "algo" #1: initiating IKEv2 connection to 192.1.2.23 using UDP
 "algo" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
-"algo" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA2_512_256 prf=HMAC_SHA2_512 ke=DH19}, initiating IKE_INTERMEDIATE
+"algo" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA2_512_256 prf=HMAC_SHA2_512 ke=DH19 addke1=DH20 addke2=DH21}, initiating IKE_INTERMEDIATE
 "algo" #1: sent IKE_INTERMEDIATE request to 192.1.2.23:UDP/500 {addke1=DH20}
 "algo" #1: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE}
 "algo" #1: initiator processed IKE_INTERMEDIATE, initiating IKE_INTERMEDIATE
@@ -49,7 +49,7 @@ Redirecting to: [initsystem]
  ipsec up algo
 "algo" #1: initiating IKEv2 connection to 192.1.2.23 using UDP
 "algo" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
-"algo" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA2_512_256 prf=HMAC_SHA2_512 ke=DH19}, initiating IKE_INTERMEDIATE
+"algo" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA2_512_256 prf=HMAC_SHA2_512 ke=DH19 addke1=DH20 addke2=DH21}, initiating IKE_INTERMEDIATE
 "algo" #1: sent IKE_INTERMEDIATE request to 192.1.2.23:UDP/500 {addke1=DH20}
 "algo" #1: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE}
 "algo" #1: initiator processed IKE_INTERMEDIATE, initiating IKE_INTERMEDIATE
@@ -76,7 +76,7 @@ Redirecting to: [initsystem]
 "algo" #1: initiating IKEv2 connection to 192.1.2.23 using UDP
 "algo" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "algo" #1: dropping ADDKE1=NONE from list of negotiated IKE_INTERMEDIATE exchanges
-"algo" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA2_512_256 prf=HMAC_SHA2_512 ke=DH19}, initiating IKE_INTERMEDIATE
+"algo" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA2_512_256 prf=HMAC_SHA2_512 ke=DH19 addke2=DH20}, initiating IKE_INTERMEDIATE
 "algo" #1: sent IKE_INTERMEDIATE request to 192.1.2.23:UDP/500 {addke2=DH20}
 "algo" #1: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE}
 "algo" #1: initiator processed IKE_INTERMEDIATE, initiating IKE_AUTH

--- a/testing/pluto/ikev2-intermediate-05-addke-modp8192-ml-kem-768/west.console.txt
+++ b/testing/pluto/ikev2-intermediate-05-addke-modp8192-ml-kem-768/west.console.txt
@@ -36,7 +36,7 @@ west #
  ipsec up west
 "west" #1: initiating IKEv2 connection to 192.1.2.23 using UDP
 "west" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
-"west" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA2_512_256 prf=HMAC_SHA2_512 ke=DH20}, initiating IKE_INTERMEDIATE
+"west" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA2_512_256 prf=HMAC_SHA2_512 ke=DH20 addke1=MODP8192 addke2=ML_KEM_768}, initiating IKE_INTERMEDIATE
 "west" #1: sent IKE_INTERMEDIATE request to 192.1.2.23:UDP/500 {addke1=MODP8192}
 "west" #1: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE}
 "west" #1: initiator processed IKE_INTERMEDIATE, initiating IKE_INTERMEDIATE

--- a/testing/pluto/ikev2-intermediate-06-addke2-dh19-addke4-none-addke6-dh20/west.console.txt
+++ b/testing/pluto/ikev2-intermediate-06-addke2-dh19-addke4-none-addke6-dh20/west.console.txt
@@ -37,7 +37,7 @@ west #
 "west" #1: initiating IKEv2 connection to 192.1.2.23 using UDP
 "west" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "west" #1: dropping ADDKE4=NONE from list of negotiated IKE_INTERMEDIATE exchanges
-"west" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA2_512_256 prf=HMAC_SHA2_512 ke=MODP8192}, initiating IKE_INTERMEDIATE
+"west" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA2_512_256 prf=HMAC_SHA2_512 ke=MODP8192 addke2=DH19 addke6=DH20}, initiating IKE_INTERMEDIATE
 "west" #1: sent IKE_INTERMEDIATE request to 192.1.2.23:UDP/500 {addke2=DH19}
 "west" #1: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE}
 "west" #1: initiator processed IKE_INTERMEDIATE, initiating IKE_INTERMEDIATE

--- a/testing/pluto/ikev2-intermediate-08-addke-ml-kem-1024/west.console.txt
+++ b/testing/pluto/ikev2-intermediate-08-addke-ml-kem-1024/west.console.txt
@@ -15,7 +15,7 @@ west #
  ipsec up west
 "west" #1: initiating IKEv2 connection to 192.1.2.23 using UDP
 "west" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
-"west" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_128 integ=HMAC_SHA2_256_128 prf=HMAC_SHA2_256 ke=DH31}, initiating IKE_INTERMEDIATE
+"west" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_128 integ=HMAC_SHA2_256_128 prf=HMAC_SHA2_256 ke=DH31 addke1=ML_KEM_1024}, initiating IKE_INTERMEDIATE
 "west" #1: sent IKE_INTERMEDIATE request to 192.1.2.23:UDP/500 {addke1=ML_KEM_1024}
 "west" #1: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE} reassembled from N fragments
 "west" #1: initiator processed IKE_INTERMEDIATE, initiating IKE_AUTH

--- a/testing/pluto/ikev2-intermediate-09-max-size-hybrid/west.console.txt
+++ b/testing/pluto/ikev2-intermediate-09-max-size-hybrid/west.console.txt
@@ -15,7 +15,7 @@ west #
  ipsec up west
 "west" #1: initiating IKEv2 connection to 192.1.2.23 using UDP
 "west" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
-"west" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_128 integ=HMAC_SHA2_256_128 prf=HMAC_SHA2_256 ke=MODP8192}, initiating IKE_INTERMEDIATE
+"west" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_128 integ=HMAC_SHA2_256_128 prf=HMAC_SHA2_256 ke=MODP8192 addke1=ML_KEM_1024}, initiating IKE_INTERMEDIATE
 "west" #1: sent IKE_INTERMEDIATE request to 192.1.2.23:UDP/500 {addke1=ML_KEM_1024}
 "west" #1: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE} reassembled from N fragments
 "west" #1: initiator processed IKE_INTERMEDIATE, initiating IKE_AUTH

--- a/testing/pluto/ikev2-ppk-intermediate-02-addke/west.console.txt
+++ b/testing/pluto/ikev2-ppk-intermediate-02-addke/west.console.txt
@@ -84,7 +84,7 @@ Redirecting to: [initsystem]
 "algo" #1: initiating IKEv2 connection to 192.1.2.23 using UDP
 "algo" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "algo" #1: dropping ADDKE1=NONE from list of negotiated IKE_INTERMEDIATE exchanges
-"algo" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA2_512_256 prf=HMAC_SHA2_512 ke=DH20}, initiating IKE_INTERMEDIATE
+"algo" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA2_512_256 prf=HMAC_SHA2_512 ke=DH20 addke2=ML_KEM_768}, initiating IKE_INTERMEDIATE
 "algo" #1: sent IKE_INTERMEDIATE request to 192.1.2.23:UDP/500 {addke2=ML_KEM_768, PPK}
 "algo" #1: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE,N(PPK_IDENTITY)}
 "algo" #1: PPK 'PPKIDA' used in IKE_INTERMEDIATE by initiator
@@ -107,7 +107,7 @@ Redirecting to: [initsystem]
 "algo" #1: initiating IKEv2 connection to 192.1.2.23 using UDP
 "algo" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
 "algo" #1: dropping ADDKE2=NONE from list of negotiated IKE_INTERMEDIATE exchanges
-"algo" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA2_512_256 prf=HMAC_SHA2_512 ke=DH20}, initiating IKE_INTERMEDIATE
+"algo" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA2_512_256 prf=HMAC_SHA2_512 ke=DH20 addke1=MODP8192}, initiating IKE_INTERMEDIATE
 "algo" #1: sent IKE_INTERMEDIATE request to 192.1.2.23:UDP/500 {addke1=MODP8192, PPK}
 "algo" #1: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE,N(PPK_IDENTITY)}
 "algo" #1: PPK 'PPKIDA' used in IKE_INTERMEDIATE by initiator
@@ -129,7 +129,7 @@ Redirecting to: [initsystem]
  ipsec up algo
 "algo" #1: initiating IKEv2 connection to 192.1.2.23 using UDP
 "algo" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
-"algo" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA2_512_256 prf=HMAC_SHA2_512 ke=DH20}, initiating IKE_INTERMEDIATE
+"algo" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_256 integ=HMAC_SHA2_512_256 prf=HMAC_SHA2_512 ke=DH20 addke1=MODP8192 addke2=ML_KEM_768}, initiating IKE_INTERMEDIATE
 "algo" #1: sent IKE_INTERMEDIATE request to 192.1.2.23:UDP/500 {addke1=MODP8192}
 "algo" #1: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE}
 "algo" #1: initiator processed IKE_INTERMEDIATE, initiating IKE_INTERMEDIATE

--- a/testing/pluto/ikev2-redirect-06-roadwarriors/west.console.txt
+++ b/testing/pluto/ikev2-redirect-06-roadwarriors/west.console.txt
@@ -108,7 +108,7 @@ Connection list:
 "east-any"[2]:   liveness: passive; dpddelay:0s; retransmit-timeout:30s
 "east-any"[2]:   nat-traversal: encapsulation:auto; keepalive:20s
 "east-any"[2]:   routing: routed-tunnel; owner: Child SA #4; established IKE SA: #3; established Child SA: #4;
-"east-any"[1]:   reqid: REQID;
+"east-any"[2]:   reqid: REQID;
 "east-any"[2]:   conn serial: $3, instantiated from: $1;
 "east-any"[2]:   IKEv2 algorithm newest: AES_GCM_16_256-HMAC_SHA2_512-DH19
 "east-any"[2]:   ESP algorithm newest: AES_GCM_16_256; pfsgroup=<Phase1>

--- a/testing/pluto/interop-ikev2-strongswan-49-intermediate-responder/west.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-49-intermediate-responder/west.console.txt
@@ -33,7 +33,7 @@ Redirecting to: [initsystem]
  ipsec up algo
 "algo" #1: initiating IKEv2 connection to 192.1.2.23 using UDP
 "algo" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
-"algo" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_128 integ=HMAC_SHA1_96 prf=HMAC_SHA1 ke=MODP8192}, initiating IKE_INTERMEDIATE
+"algo" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_128 integ=HMAC_SHA1_96 prf=HMAC_SHA1 ke=MODP8192 addke1=ML_KEM_768}, initiating IKE_INTERMEDIATE
 "algo" #1: sent IKE_INTERMEDIATE request to 192.1.2.23:UDP/500 {addke1=ML_KEM_768}
 "algo" #1: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE}
 "algo" #1: initiator processed IKE_INTERMEDIATE, initiating IKE_AUTH
@@ -54,7 +54,7 @@ Redirecting to: [initsystem]
  ipsec up algo
 "algo" #1: initiating IKEv2 connection to 192.1.2.23 using UDP
 "algo" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
-"algo" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_128 integ=HMAC_SHA1_96 prf=HMAC_SHA1 ke=MODP8192}, initiating IKE_INTERMEDIATE
+"algo" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_128 integ=HMAC_SHA1_96 prf=HMAC_SHA1 ke=MODP8192 addke1=ML_KEM_768}, initiating IKE_INTERMEDIATE
 "algo" #1: sent IKE_INTERMEDIATE request to 192.1.2.23:UDP/500 {addke1=ML_KEM_768}
 "algo" #1: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE}
 "algo" #1: initiator processed IKE_INTERMEDIATE, initiating IKE_AUTH
@@ -86,7 +86,7 @@ west #
  ipsec up intermediate
 "intermediate" #1: initiating IKEv2 connection to 192.1.2.23 using UDP
 "intermediate" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
-"intermediate" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_128 integ=HMAC_SHA1_96 prf=HMAC_SHA1 ke=MODP8192}, initiating IKE_INTERMEDIATE
+"intermediate" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_128 integ=HMAC_SHA1_96 prf=HMAC_SHA1 ke=MODP8192 addke1=ML_KEM_768}, initiating IKE_INTERMEDIATE
 IMPAIR: "intermediate" #1: adding 1 unencrypted unknown payload(s) of type 255 to IKE_INTERMEDIATE message containing 0 payloads
 "intermediate" #1: sent IKE_INTERMEDIATE request to 192.1.2.23:UDP/500 {addke1=ML_KEM_768}
 "intermediate" #1: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE}


### PR DESCRIPTION
When rekeying is complete, log the ADDKE transforms along with other
transforms in the accepted proposal.

Fixes: #2876 