### PR TITLE
testing:sanitize auto generated reqids only

### DIFF
--- a/testing/pluto/flush-on-startup-xfrm/west.console.txt
+++ b/testing/pluto/flush-on-startup-xfrm/west.console.txt
@@ -21,12 +21,12 @@ west #
 west #
  ipsec _kernel state
 src 2.2.2.2 dst 1.1.1.1
-	proto esp spi 0xSPISPI reqid REQID mode tunnel
+	proto esp spi 0xSPISPI reqid 1000 mode tunnel
 	replay-window 0 
 	aead rfc4106(gcm(aes)) 0xENCAUTHKEY 128
 	sel src 0.0.0.0/0 dst 0.0.0.0/0 
 src 1.1.1.1 dst 2.2.2.2
-	proto esp spi 0xSPISPI reqid REQID mode tunnel
+	proto esp spi 0xSPISPI reqid 1000 mode tunnel
 	replay-window 0 
 	aead rfc4106(gcm(aes)) 0xENCAUTHKEY 128
 	sel src 0.0.0.0/0 dst 0.0.0.0/0 
@@ -35,15 +35,15 @@ west #
 src 10.0.1.0/24 dst 10.0.2.0/24
 	dir out priority 0 ptype main
 	tmpl src 1.1.1.1 dst 2.2.2.2
-		proto esp reqid REQID mode tunnel
+		proto esp reqid 1000 mode tunnel
 src 10.0.2.0/24 dst 10.0.1.0/24
 	dir fwd priority 0 ptype main
 	tmpl src 2.2.2.2 dst 1.1.1.1
-		proto esp reqid REQID mode tunnel
+		proto esp reqid 1000 mode tunnel
 src 10.0.2.0/24 dst 10.0.1.0/24
 	dir in priority 0 ptype main
 	tmpl src 2.2.2.2 dst 1.1.1.1
-		proto esp reqid REQID mode tunnel
+		proto esp reqid 1000 mode tunnel
 west #
  # start pluto
 west #

--- a/testing/pluto/interop-ikev1-strongswan-10-ah-initiator-sha256/west.console.txt
+++ b/testing/pluto/interop-ikev1-strongswan-10-ah-initiator-sha256/west.console.txt
@@ -66,13 +66,13 @@ grep: strongswan: No such file or directory
 west #
  ipsec _kernel state
 src 192.1.2.45 dst 192.1.2.23
-	proto ah spi 0xSPISPI reqid REQID mode tunnel
+	proto ah spi 0xSPISPI reqid 1 mode tunnel
 	replay-window 0 flag af-unspec align4
 	auth-trunc hmac(sha256) 0xHASHKEY 128
 	lastused YYYY-MM-DD HH:MM:SS
 	dir out
 src 192.1.2.23 dst 192.1.2.45
-	proto ah spi 0xSPISPI reqid REQID mode tunnel
+	proto ah spi 0xSPISPI reqid 1 mode tunnel
 	replay-window 32 flag af-unspec align4
 	auth-trunc hmac(sha256) 0xHASHKEY 128
 	lastused YYYY-MM-DD HH:MM:SS
@@ -94,15 +94,15 @@ src 192.1.2.0/24 dst 192.1.2.0/24
 src 192.0.1.0/24 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 192.1.2.45 dst 192.1.2.23
-		proto ah spi 0xSPISPI reqid REQID mode tunnel
+		proto ah spi 0xSPISPI reqid 1 mode tunnel
 src 192.0.2.0/24 dst 192.0.1.0/24
 	dir fwd priority PRIORITY ptype main
 	tmpl src 192.1.2.23 dst 192.1.2.45
-		proto ah reqid REQID mode tunnel
+		proto ah reqid 1 mode tunnel
 src 192.0.2.0/24 dst 192.0.1.0/24
 	dir in priority PRIORITY ptype main
 	tmpl src 192.1.2.23 dst 192.1.2.45
-		proto ah reqid REQID mode tunnel
+		proto ah reqid 1 mode tunnel
 west #
  echo done
 done

--- a/testing/pluto/interop-ikev1-strongswan-11-ah-initiator-sha512/west.console.txt
+++ b/testing/pluto/interop-ikev1-strongswan-11-ah-initiator-sha512/west.console.txt
@@ -46,25 +46,25 @@ src 192.1.2.0/24 dst 192.1.2.0/24
 src 192.0.1.0/24 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 192.1.2.45 dst 192.1.2.23
-		proto ah spi 0xSPISPI reqid REQID mode tunnel
+		proto ah spi 0xSPISPI reqid 1 mode tunnel
 src 192.0.2.0/24 dst 192.0.1.0/24
 	dir fwd priority PRIORITY ptype main
 	tmpl src 192.1.2.23 dst 192.1.2.45
-		proto ah reqid REQID mode tunnel
+		proto ah reqid 1 mode tunnel
 src 192.0.2.0/24 dst 192.0.1.0/24
 	dir in priority PRIORITY ptype main
 	tmpl src 192.1.2.23 dst 192.1.2.45
-		proto ah reqid REQID mode tunnel
+		proto ah reqid 1 mode tunnel
 west #
  ipsec _kernel state
 src 192.1.2.45 dst 192.1.2.23
-	proto ah spi 0xSPISPI reqid REQID mode tunnel
+	proto ah spi 0xSPISPI reqid 1 mode tunnel
 	replay-window 0 flag af-unspec align4
 	auth-trunc hmac(sha512) 0xHASHKEY 256
 	lastused YYYY-MM-DD HH:MM:SS
 	dir out
 src 192.1.2.23 dst 192.1.2.45
-	proto ah spi 0xSPISPI reqid REQID mode tunnel
+	proto ah spi 0xSPISPI reqid 1 mode tunnel
 	replay-window 32 flag af-unspec align4
 	auth-trunc hmac(sha512) 0xHASHKEY 256
 	lastused YYYY-MM-DD HH:MM:SS

--- a/testing/pluto/interop-ikev1-strongswan-17-compress/east.console.txt
+++ b/testing/pluto/interop-ikev1-strongswan-17-compress/east.console.txt
@@ -7,14 +7,14 @@ initdone
 east #
  ipsec _kernel state
 src 192.1.2.23 dst 192.1.2.45
-	proto esp spi 0xSPISPI reqid REQID mode transport
+	proto esp spi 0xSPISPI reqid 1 mode transport
 	replay-window 0 flag af-unspec
 	auth-trunc hmac(sha1) 0xHASHKEY 96
 	enc cbc(aes) 0xENCKEY
 	lastused YYYY-MM-DD HH:MM:SS
 	dir out
 src 192.1.2.23 dst 192.1.2.45
-	proto comp spi 0xSPISPI reqid REQID mode tunnel
+	proto comp spi 0xSPISPI reqid 1 mode tunnel
 	replay-window 0 flag noecn nopmtudisc af-unspec
 	comp deflate 
 	lastused YYYY-MM-DD HH:MM:SS
@@ -23,14 +23,14 @@ src 192.1.2.23 dst 192.1.2.45
 	proto 4 spi 0xSPISPI reqid 0 mode tunnel
 	replay-window 0 flag noecn nopmtudisc af-unspec
 src 192.1.2.45 dst 192.1.2.23
-	proto esp spi 0xSPISPI reqid REQID mode transport
+	proto esp spi 0xSPISPI reqid 1 mode transport
 	replay-window 32 flag af-unspec
 	auth-trunc hmac(sha1) 0xHASHKEY 96
 	enc cbc(aes) 0xENCKEY
 	lastused YYYY-MM-DD HH:MM:SS
 	dir in
 src 192.1.2.45 dst 192.1.2.23
-	proto comp spi 0xSPISPI reqid REQID mode tunnel
+	proto comp spi 0xSPISPI reqid 1 mode tunnel
 	replay-window 0 flag noecn af-unspec
 	comp deflate 
 	dir in
@@ -55,21 +55,21 @@ src 192.1.2.0/24 dst 192.1.2.0/24
 src 192.0.1.0/24 dst 192.0.2.0/24
 	dir fwd priority PRIORITY ptype main
 	tmpl src 192.1.2.45 dst 192.1.2.23
-		proto comp reqid REQID mode tunnel
+		proto comp reqid 1 mode tunnel
 		level use
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid REQID mode transport
+		proto esp reqid 1 mode transport
 src 192.0.1.0/24 dst 192.0.2.0/24
 	dir in priority PRIORITY ptype main
 	tmpl src 192.1.2.45 dst 192.1.2.23
-		proto comp reqid REQID mode tunnel
+		proto comp reqid 1 mode tunnel
 		level use
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid REQID mode transport
+		proto esp reqid 1 mode transport
 src 192.0.2.0/24 dst 192.0.1.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 192.1.2.23 dst 192.1.2.45
-		proto comp spi 0xSPISPI reqid REQID mode tunnel
+		proto comp spi 0xSPISPI reqid 1 mode tunnel
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp spi 0xSPISPI reqid REQID mode transport
+		proto esp spi 0xSPISPI reqid 1 mode transport
 east #

--- a/testing/pluto/interop-ikev2-strongswan-07-strongswan/east.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-07-strongswan/east.console.txt
@@ -21,34 +21,34 @@ src 192.1.2.0/24 dst 192.1.2.0/24
 src 192.0.1.0/24 dst 192.0.2.0/24
 	dir fwd priority PRIORITY ptype main
 	tmpl src 192.1.2.45 dst 192.1.2.23
-		proto comp reqid REQID mode tunnel
+		proto comp reqid 1 mode tunnel
 		level use
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid REQID mode transport
+		proto esp reqid 1 mode transport
 src 192.0.1.0/24 dst 192.0.2.0/24
 	dir in priority PRIORITY ptype main
 	tmpl src 192.1.2.45 dst 192.1.2.23
-		proto comp reqid REQID mode tunnel
+		proto comp reqid 1 mode tunnel
 		level use
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid REQID mode transport
+		proto esp reqid 1 mode transport
 src 192.0.2.0/24 dst 192.0.1.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 192.1.2.23 dst 192.1.2.45
-		proto comp spi 0xSPISPI reqid REQID mode tunnel
+		proto comp spi 0xSPISPI reqid 1 mode tunnel
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp spi 0xSPISPI reqid REQID mode transport
+		proto esp spi 0xSPISPI reqid 1 mode transport
 east #
  ipsec _kernel state
 src 192.1.2.23 dst 192.1.2.45
-	proto esp spi 0xSPISPI reqid REQID mode transport
+	proto esp spi 0xSPISPI reqid 1 mode transport
 	replay-window 0 flag af-unspec
 	auth-trunc hmac(sha512) 0xHASHKEY 256
 	enc cbc(aes) 0xENCKEY
 	lastused YYYY-MM-DD HH:MM:SS
 	dir out
 src 192.1.2.23 dst 192.1.2.45
-	proto comp spi 0xSPISPI reqid REQID mode tunnel
+	proto comp spi 0xSPISPI reqid 1 mode tunnel
 	replay-window 0 flag noecn nopmtudisc af-unspec
 	comp deflate 
 	lastused YYYY-MM-DD HH:MM:SS
@@ -57,14 +57,14 @@ src 192.1.2.23 dst 192.1.2.45
 	proto 4 spi 0xSPISPI reqid 0 mode tunnel
 	replay-window 0 flag noecn nopmtudisc af-unspec
 src 192.1.2.45 dst 192.1.2.23
-	proto esp spi 0xSPISPI reqid REQID mode transport
+	proto esp spi 0xSPISPI reqid 1 mode transport
 	replay-window 32 flag af-unspec
 	auth-trunc hmac(sha512) 0xHASHKEY 256
 	enc cbc(aes) 0xENCKEY
 	lastused YYYY-MM-DD HH:MM:SS
 	dir in
 src 192.1.2.45 dst 192.1.2.23
-	proto comp spi 0xSPISPI reqid REQID mode tunnel
+	proto comp spi 0xSPISPI reqid 1 mode tunnel
 	replay-window 0 flag noecn af-unspec
 	comp deflate 
 	dir in

--- a/testing/pluto/interop-ikev2-strongswan-07-strongswan/west.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-07-strongswan/west.console.txt
@@ -49,34 +49,34 @@ src 192.1.2.0/24 dst 192.1.2.0/24
 src 192.0.1.0/24 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 192.1.2.45 dst 192.1.2.23
-		proto comp spi 0xSPISPI reqid REQID mode tunnel
+		proto comp spi 0xSPISPI reqid 1 mode tunnel
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp spi 0xSPISPI reqid REQID mode transport
+		proto esp spi 0xSPISPI reqid 1 mode transport
 src 192.0.2.0/24 dst 192.0.1.0/24
 	dir fwd priority PRIORITY ptype main
 	tmpl src 192.1.2.23 dst 192.1.2.45
-		proto comp reqid REQID mode tunnel
+		proto comp reqid 1 mode tunnel
 		level use
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid REQID mode transport
+		proto esp reqid 1 mode transport
 src 192.0.2.0/24 dst 192.0.1.0/24
 	dir in priority PRIORITY ptype main
 	tmpl src 192.1.2.23 dst 192.1.2.45
-		proto comp reqid REQID mode tunnel
+		proto comp reqid 1 mode tunnel
 		level use
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid REQID mode transport
+		proto esp reqid 1 mode transport
 west #
  ipsec _kernel state
 src 192.1.2.45 dst 192.1.2.23
-	proto esp spi 0xSPISPI reqid REQID mode transport
+	proto esp spi 0xSPISPI reqid 1 mode transport
 	replay-window 0 flag af-unspec
 	auth-trunc hmac(sha512) 0xHASHKEY 256
 	enc cbc(aes) 0xENCKEY
 	lastused YYYY-MM-DD HH:MM:SS
 	dir out
 src 192.1.2.45 dst 192.1.2.23
-	proto comp spi 0xSPISPI reqid REQID mode tunnel
+	proto comp spi 0xSPISPI reqid 1 mode tunnel
 	replay-window 0 flag noecn nopmtudisc af-unspec
 	comp deflate 
 	lastused YYYY-MM-DD HH:MM:SS
@@ -85,14 +85,14 @@ src 192.1.2.45 dst 192.1.2.23
 	proto 4 spi 0xSPISPI reqid 0 mode tunnel
 	replay-window 0 flag noecn nopmtudisc af-unspec
 src 192.1.2.23 dst 192.1.2.45
-	proto esp spi 0xSPISPI reqid REQID mode transport
+	proto esp spi 0xSPISPI reqid 1 mode transport
 	replay-window 32 flag af-unspec
 	auth-trunc hmac(sha512) 0xHASHKEY 256
 	enc cbc(aes) 0xENCKEY
 	lastused YYYY-MM-DD HH:MM:SS
 	dir in
 src 192.1.2.23 dst 192.1.2.45
-	proto comp spi 0xSPISPI reqid REQID mode tunnel
+	proto comp spi 0xSPISPI reqid 1 mode tunnel
 	replay-window 0 flag noecn af-unspec
 	comp deflate 
 	dir in

--- a/testing/pluto/interop-ikev2-strongswan-16-ah-initiator-sha512/west.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-16-ah-initiator-sha512/west.console.txt
@@ -52,13 +52,13 @@ grep: strongswan: No such file or directory
 west #
  ipsec _kernel state
 src 192.1.2.45 dst 192.1.2.23
-	proto ah spi 0xSPISPI reqid REQID mode tunnel
+	proto ah spi 0xSPISPI reqid 1 mode tunnel
 	replay-window 0 flag af-unspec align4
 	auth-trunc hmac(sha512) 0xHASHKEY 256
 	lastused YYYY-MM-DD HH:MM:SS
 	dir out
 src 192.1.2.23 dst 192.1.2.45
-	proto ah spi 0xSPISPI reqid REQID mode tunnel
+	proto ah spi 0xSPISPI reqid 1 mode tunnel
 	replay-window 32 flag af-unspec align4
 	auth-trunc hmac(sha512) 0xHASHKEY 256
 	lastused YYYY-MM-DD HH:MM:SS
@@ -80,15 +80,15 @@ src 192.1.2.0/24 dst 192.1.2.0/24
 src 192.0.1.0/24 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 192.1.2.45 dst 192.1.2.23
-		proto ah spi 0xSPISPI reqid REQID mode tunnel
+		proto ah spi 0xSPISPI reqid 1 mode tunnel
 src 192.0.2.0/24 dst 192.0.1.0/24
 	dir fwd priority PRIORITY ptype main
 	tmpl src 192.1.2.23 dst 192.1.2.45
-		proto ah reqid REQID mode tunnel
+		proto ah reqid 1 mode tunnel
 src 192.0.2.0/24 dst 192.0.1.0/24
 	dir in priority PRIORITY ptype main
 	tmpl src 192.1.2.23 dst 192.1.2.45
-		proto ah reqid REQID mode tunnel
+		proto ah reqid 1 mode tunnel
 west #
  echo done
 done

--- a/testing/pluto/interop-ikev2-strongswan-17-ah-initiator-sha256/west.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-17-ah-initiator-sha256/west.console.txt
@@ -52,13 +52,13 @@ grep: strongswan: No such file or directory
 west #
  ipsec _kernel state
 src 192.1.2.45 dst 192.1.2.23
-	proto ah spi 0xSPISPI reqid REQID mode tunnel
+	proto ah spi 0xSPISPI reqid 1 mode tunnel
 	replay-window 0 flag af-unspec align4
 	auth-trunc hmac(sha256) 0xHASHKEY 128
 	lastused YYYY-MM-DD HH:MM:SS
 	dir out
 src 192.1.2.23 dst 192.1.2.45
-	proto ah spi 0xSPISPI reqid REQID mode tunnel
+	proto ah spi 0xSPISPI reqid 1 mode tunnel
 	replay-window 32 flag af-unspec align4
 	auth-trunc hmac(sha256) 0xHASHKEY 128
 	lastused YYYY-MM-DD HH:MM:SS
@@ -80,15 +80,15 @@ src 192.1.2.0/24 dst 192.1.2.0/24
 src 192.0.1.0/24 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 192.1.2.45 dst 192.1.2.23
-		proto ah spi 0xSPISPI reqid REQID mode tunnel
+		proto ah spi 0xSPISPI reqid 1 mode tunnel
 src 192.0.2.0/24 dst 192.0.1.0/24
 	dir fwd priority PRIORITY ptype main
 	tmpl src 192.1.2.23 dst 192.1.2.45
-		proto ah reqid REQID mode tunnel
+		proto ah reqid 1 mode tunnel
 src 192.0.2.0/24 dst 192.0.1.0/24
 	dir in priority PRIORITY ptype main
 	tmpl src 192.1.2.23 dst 192.1.2.45
-		proto ah reqid REQID mode tunnel
+		proto ah reqid 1 mode tunnel
 west #
  echo done
 done

--- a/testing/pluto/interop-ikev2-strongswan-18-compress-6in6/east.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-18-compress-6in6/east.console.txt
@@ -9,14 +9,14 @@ east #
 east #
  ipsec _kernel state
 src 2001:db8:1:2::23 dst 2001:db8:1:2::45
-	proto esp spi 0xSPISPI reqid REQID mode transport
+	proto esp spi 0xSPISPI reqid 1 mode transport
 	replay-window 0 flag af-unspec
 	auth-trunc hmac(sha1) 0xHASHKEY 96
 	enc cbc(aes) 0xENCKEY
 	lastused YYYY-MM-DD HH:MM:SS
 	dir out
 src 2001:db8:1:2::23 dst 2001:db8:1:2::45
-	proto comp spi 0xSPISPI reqid REQID mode tunnel
+	proto comp spi 0xSPISPI reqid 1 mode tunnel
 	replay-window 0 flag noecn nopmtudisc af-unspec
 	comp deflate 
 	lastused YYYY-MM-DD HH:MM:SS
@@ -25,14 +25,14 @@ src 2001:db8:1:2::23 dst 2001:db8:1:2::45
 	proto 41 spi 0xSPISPI reqid 0 mode tunnel
 	replay-window 0 
 src 2001:db8:1:2::45 dst 2001:db8:1:2::23
-	proto esp spi 0xSPISPI reqid REQID mode transport
+	proto esp spi 0xSPISPI reqid 1 mode transport
 	replay-window 32 flag af-unspec
 	auth-trunc hmac(sha1) 0xHASHKEY 96
 	enc cbc(aes) 0xENCKEY
 	lastused YYYY-MM-DD HH:MM:SS
 	dir in
 src 2001:db8:1:2::45 dst 2001:db8:1:2::23
-	proto comp spi 0xSPISPI reqid REQID mode tunnel
+	proto comp spi 0xSPISPI reqid 1 mode tunnel
 	replay-window 0 flag noecn af-unspec
 	comp deflate 
 	lastused YYYY-MM-DD HH:MM:SS
@@ -76,21 +76,21 @@ src fe80::/64 dst fe80::/64
 src 2001:db8:0:1::/64 dst 2001:db8:0:2::/64
 	dir fwd priority PRIORITY ptype main
 	tmpl src 2001:db8:1:2::45 dst 2001:db8:1:2::23
-		proto comp reqid REQID mode tunnel
+		proto comp reqid 1 mode tunnel
 		level use
 	tmpl src :: dst ::
-		proto esp reqid REQID mode transport
+		proto esp reqid 1 mode transport
 src 2001:db8:0:1::/64 dst 2001:db8:0:2::/64
 	dir in priority PRIORITY ptype main
 	tmpl src 2001:db8:1:2::45 dst 2001:db8:1:2::23
-		proto comp reqid REQID mode tunnel
+		proto comp reqid 1 mode tunnel
 		level use
 	tmpl src :: dst ::
-		proto esp reqid REQID mode transport
+		proto esp reqid 1 mode transport
 src 2001:db8:0:2::/64 dst 2001:db8:0:1::/64
 	dir out priority PRIORITY ptype main
 	tmpl src 2001:db8:1:2::23 dst 2001:db8:1:2::45
-		proto comp spi 0xSPISPI reqid REQID mode tunnel
+		proto comp spi 0xSPISPI reqid 1 mode tunnel
 	tmpl src :: dst ::
-		proto esp spi 0xSPISPI reqid REQID mode transport
+		proto esp spi 0xSPISPI reqid 1 mode transport
 east #

--- a/testing/pluto/interop-ikev2-strongswan-18-compress-initiator/west.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-18-compress-initiator/west.console.txt
@@ -84,13 +84,13 @@ westnet-eastnet-ikev2{1}:   192.0.1.0/24 === 192.0.2.0/24
 west #
  ipsec _kernel state
 src 192.1.2.45 dst 192.1.2.23
-	proto esp spi 0xSPISPI reqid REQID mode transport
+	proto esp spi 0xSPISPI reqid 1 mode transport
 	replay-window 0 flag af-unspec
 	aead rfc4106(gcm(aes)) 0xENCAUTHKEY 128
 	lastused YYYY-MM-DD HH:MM:SS
 	dir out
 src 192.1.2.45 dst 192.1.2.23
-	proto comp spi 0xSPISPI reqid REQID mode tunnel
+	proto comp spi 0xSPISPI reqid 1 mode tunnel
 	replay-window 0 flag noecn nopmtudisc af-unspec
 	comp deflate 
 	lastused YYYY-MM-DD HH:MM:SS
@@ -99,13 +99,13 @@ src 192.1.2.45 dst 192.1.2.23
 	proto 4 spi 0xSPISPI reqid 0 mode tunnel
 	replay-window 0 flag noecn nopmtudisc af-unspec
 src 192.1.2.23 dst 192.1.2.45
-	proto esp spi 0xSPISPI reqid REQID mode transport
+	proto esp spi 0xSPISPI reqid 1 mode transport
 	replay-window 32 flag af-unspec
 	aead rfc4106(gcm(aes)) 0xENCAUTHKEY 128
 	lastused YYYY-MM-DD HH:MM:SS
 	dir in
 src 192.1.2.23 dst 192.1.2.45
-	proto comp spi 0xSPISPI reqid REQID mode tunnel
+	proto comp spi 0xSPISPI reqid 1 mode tunnel
 	replay-window 0 flag noecn af-unspec
 	comp deflate 
 	lastused YYYY-MM-DD HH:MM:SS
@@ -131,21 +131,21 @@ src 192.1.2.0/24 dst 192.1.2.0/24
 src 192.0.1.0/24 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 192.1.2.45 dst 192.1.2.23
-		proto comp spi 0xSPISPI reqid REQID mode tunnel
+		proto comp spi 0xSPISPI reqid 1 mode tunnel
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp spi 0xSPISPI reqid REQID mode transport
+		proto esp spi 0xSPISPI reqid 1 mode transport
 src 192.0.2.0/24 dst 192.0.1.0/24
 	dir fwd priority PRIORITY ptype main
 	tmpl src 192.1.2.23 dst 192.1.2.45
-		proto comp reqid REQID mode tunnel
+		proto comp reqid 1 mode tunnel
 		level use
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid REQID mode transport
+		proto esp reqid 1 mode transport
 src 192.0.2.0/24 dst 192.0.1.0/24
 	dir in priority PRIORITY ptype main
 	tmpl src 192.1.2.23 dst 192.1.2.45
-		proto comp reqid REQID mode tunnel
+		proto comp reqid 1 mode tunnel
 		level use
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid REQID mode transport
+		proto esp reqid 1 mode transport
 west #

--- a/testing/pluto/interop-ikev2-strongswan-18-compress/east.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-18-compress/east.console.txt
@@ -9,14 +9,14 @@ east #
 east #
  ipsec _kernel state
 src 192.1.2.23 dst 192.1.2.45
-	proto esp spi 0xSPISPI reqid REQID mode transport
+	proto esp spi 0xSPISPI reqid 1 mode transport
 	replay-window 0 flag af-unspec
 	auth-trunc hmac(sha1) 0xHASHKEY 96
 	enc cbc(aes) 0xENCKEY
 	lastused YYYY-MM-DD HH:MM:SS
 	dir out
 src 192.1.2.23 dst 192.1.2.45
-	proto comp spi 0xSPISPI reqid REQID mode tunnel
+	proto comp spi 0xSPISPI reqid 1 mode tunnel
 	replay-window 0 flag noecn nopmtudisc af-unspec
 	comp deflate 
 	lastused YYYY-MM-DD HH:MM:SS
@@ -25,14 +25,14 @@ src 192.1.2.23 dst 192.1.2.45
 	proto 4 spi 0xSPISPI reqid 0 mode tunnel
 	replay-window 0 flag noecn nopmtudisc af-unspec
 src 192.1.2.45 dst 192.1.2.23
-	proto esp spi 0xSPISPI reqid REQID mode transport
+	proto esp spi 0xSPISPI reqid 1 mode transport
 	replay-window 32 flag af-unspec
 	auth-trunc hmac(sha1) 0xHASHKEY 96
 	enc cbc(aes) 0xENCKEY
 	lastused YYYY-MM-DD HH:MM:SS
 	dir in
 src 192.1.2.45 dst 192.1.2.23
-	proto comp spi 0xSPISPI reqid REQID mode tunnel
+	proto comp spi 0xSPISPI reqid 1 mode tunnel
 	replay-window 0 flag noecn af-unspec
 	comp deflate 
 	lastused YYYY-MM-DD HH:MM:SS
@@ -58,21 +58,21 @@ src 192.1.2.0/24 dst 192.1.2.0/24
 src 192.0.1.0/24 dst 192.0.2.0/24
 	dir fwd priority PRIORITY ptype main
 	tmpl src 192.1.2.45 dst 192.1.2.23
-		proto comp reqid REQID mode tunnel
+		proto comp reqid 1 mode tunnel
 		level use
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid REQID mode transport
+		proto esp reqid 1 mode transport
 src 192.0.1.0/24 dst 192.0.2.0/24
 	dir in priority PRIORITY ptype main
 	tmpl src 192.1.2.45 dst 192.1.2.23
-		proto comp reqid REQID mode tunnel
+		proto comp reqid 1 mode tunnel
 		level use
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid REQID mode transport
+		proto esp reqid 1 mode transport
 src 192.0.2.0/24 dst 192.0.1.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 192.1.2.23 dst 192.1.2.45
-		proto comp spi 0xSPISPI reqid REQID mode tunnel
+		proto comp spi 0xSPISPI reqid 1 mode tunnel
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp spi 0xSPISPI reqid REQID mode transport
+		proto esp spi 0xSPISPI reqid 1 mode transport
 east #

--- a/testing/pluto/interop-ikev2-strongswan-21-transport-01/east.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-21-transport-01/east.console.txt
@@ -30,14 +30,14 @@ westnet-eastnet-ikev2{1}:   192.1.2.23/32 === 192.1.2.45/32
 east #
  ipsec _kernel state
 src 192.1.2.23 dst 192.1.2.45
-	proto esp spi 0xSPISPI reqid REQID mode transport
+	proto esp spi 0xSPISPI reqid 1 mode transport
 	replay-window 0 
 	auth-trunc hmac(sha1) 0xHASHKEY 96
 	enc cbc(aes) 0xENCKEY
 	dir out
 	sel src 192.1.2.23/32 dst 192.1.2.45/32 
 src 192.1.2.45 dst 192.1.2.23
-	proto esp spi 0xSPISPI reqid REQID mode transport
+	proto esp spi 0xSPISPI reqid 1 mode transport
 	replay-window 32 
 	auth-trunc hmac(sha1) 0xHASHKEY 96
 	enc cbc(aes) 0xENCKEY
@@ -61,9 +61,9 @@ src 192.1.2.0/24 dst 192.1.2.0/24
 src 192.1.2.23/32 dst 192.1.2.45/32
 	dir out priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp spi 0xSPISPI reqid REQID mode transport
+		proto esp spi 0xSPISPI reqid 1 mode transport
 src 192.1.2.45/32 dst 192.1.2.23/32
 	dir in priority PRIORITY ptype main
 	tmpl src 0.0.0.0 dst 0.0.0.0
-		proto esp reqid REQID mode transport
+		proto esp reqid 1 mode transport
 east #

--- a/testing/pluto/interop-ikev2-strongswan-38-mobike-initiator/north.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-38-mobike-initiator/north.console.txt
@@ -59,13 +59,13 @@ north #
 north #
  ipsec _kernel state
 src 192.1.3.33 dst 192.1.2.23
-	proto esp spi 0xSPISPI reqid REQID mode tunnel
+	proto esp spi 0xSPISPI reqid 1 mode tunnel
 	replay-window 0 flag af-unspec
 	aead rfc4106(gcm(aes)) 0xENCAUTHKEY 128
 	lastused YYYY-MM-DD HH:MM:SS
 	dir out
 src 192.1.2.23 dst 192.1.3.33
-	proto esp spi 0xSPISPI reqid REQID mode tunnel
+	proto esp spi 0xSPISPI reqid 1 mode tunnel
 	replay-window 32 flag af-unspec
 	aead rfc4106(gcm(aes)) 0xENCAUTHKEY 128
 	lastused YYYY-MM-DD HH:MM:SS
@@ -87,15 +87,15 @@ src 192.1.3.0/24 dst 192.1.3.0/24
 src 192.0.2.0/24 dst 192.0.3.0/24
 	dir fwd priority PRIORITY ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.33
-		proto esp reqid REQID mode tunnel
+		proto esp reqid 1 mode tunnel
 src 192.0.2.0/24 dst 192.0.3.0/24
 	dir in priority PRIORITY ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.33
-		proto esp reqid REQID mode tunnel
+		proto esp reqid 1 mode tunnel
 src 192.0.3.0/24 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 192.1.3.33 dst 192.1.2.23
-		proto esp spi 0xSPISPI reqid REQID mode tunnel
+		proto esp spi 0xSPISPI reqid 1 mode tunnel
 north #
  sleep 5
 north #
@@ -128,13 +128,13 @@ done
 north #
  ipsec _kernel state
 src 192.1.3.34 dst 192.1.2.23
-	proto esp spi 0xSPISPI reqid REQID mode tunnel
+	proto esp spi 0xSPISPI reqid 1 mode tunnel
 	replay-window 0 flag af-unspec
 	aead rfc4106(gcm(aes)) 0xENCAUTHKEY 128
 	lastused YYYY-MM-DD HH:MM:SS
 	dir out
 src 192.1.2.23 dst 192.1.3.34
-	proto esp spi 0xSPISPI reqid REQID mode tunnel
+	proto esp spi 0xSPISPI reqid 1 mode tunnel
 	replay-window 32 flag af-unspec
 	aead rfc4106(gcm(aes)) 0xENCAUTHKEY 128
 	lastused YYYY-MM-DD HH:MM:SS
@@ -156,15 +156,15 @@ src 192.1.3.0/24 dst 192.1.3.0/24
 src 192.0.2.0/24 dst 192.0.3.0/24
 	dir fwd priority PRIORITY ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.34
-		proto esp reqid REQID mode tunnel
+		proto esp reqid 1 mode tunnel
 src 192.0.2.0/24 dst 192.0.3.0/24
 	dir in priority PRIORITY ptype main
 	tmpl src 192.1.2.23 dst 192.1.3.34
-		proto esp reqid REQID mode tunnel
+		proto esp reqid 1 mode tunnel
 src 192.0.3.0/24 dst 192.0.2.0/24
 	dir out priority PRIORITY ptype main
 	tmpl src 192.1.3.34 dst 192.1.2.23
-		proto esp spi 0xSPISPI reqid REQID mode tunnel
+		proto esp spi 0xSPISPI reqid 1 mode tunnel
 north #
  if [ -f /var/run/pluto/pluto.pid ]; then ipsec whack --trafficstatus ; fi
 north #

--- a/testing/pluto/interop-ikev2-strongswan-39-mobike-responder/east.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-39-mobike-responder/east.console.txt
@@ -7,14 +7,14 @@ initdone
 east #
  ipsec _kernel state
 src 192.1.2.23 dst 192.1.33.222
-	proto esp spi 0xSPISPI reqid REQID mode tunnel
+	proto esp spi 0xSPISPI reqid 1 mode tunnel
 	replay-window 0 flag af-unspec
 	auth-trunc hmac(sha256) 0xHASHKEY 128
 	enc cbc(aes) 0xENCKEY
 	lastused YYYY-MM-DD HH:MM:SS
 	dir out
 src 192.1.33.222 dst 192.1.2.23
-	proto esp spi 0xSPISPI reqid REQID mode tunnel
+	proto esp spi 0xSPISPI reqid 1 mode tunnel
 	replay-window 32 flag af-unspec
 	auth-trunc hmac(sha256) 0xHASHKEY 128
 	enc cbc(aes) 0xENCKEY
@@ -37,15 +37,15 @@ src 192.1.2.0/24 dst 192.1.2.0/24
 src 192.0.2.0/24 dst 192.0.3.1/32
 	dir out priority PRIORITY ptype main
 	tmpl src 192.1.2.23 dst 192.1.33.222
-		proto esp spi 0xSPISPI reqid REQID mode tunnel
+		proto esp spi 0xSPISPI reqid 1 mode tunnel
 src 192.0.3.1/32 dst 192.0.2.0/24
 	dir fwd priority PRIORITY ptype main
 	tmpl src 192.1.33.222 dst 192.1.2.23
-		proto esp reqid REQID mode tunnel
+		proto esp reqid 1 mode tunnel
 src 192.0.3.1/32 dst 192.0.2.0/24
 	dir in priority PRIORITY ptype main
 	tmpl src 192.1.33.222 dst 192.1.2.23
-		proto esp reqid REQID mode tunnel
+		proto esp reqid 1 mode tunnel
 east #
  if [ -f /var/run/pluto/pluto.pid ]; then ipsec whack --trafficstatus ; fi
 east #

--- a/testing/pluto/interop-ikev2-xfrmi-strongswan-01/west.console.txt
+++ b/testing/pluto/interop-ikev2-xfrmi-strongswan-01/west.console.txt
@@ -74,12 +74,12 @@ src 192.0.1.0/24 dst 192.0.2.0/24
 src 192.0.2.0/24 dst 192.0.1.0/24
 	dir fwd priority PRIORITY ptype main
 	tmpl src 192.1.2.23 dst 192.1.2.45
-		proto esp reqid REQID mode tunnel
+		proto esp reqid 1 mode tunnel
 	if_id 0x2
 src 192.0.2.0/24 dst 192.0.1.0/24
 	dir in priority PRIORITY ptype main
 	tmpl src 192.1.2.23 dst 192.1.2.45
-		proto esp reqid REQID mode tunnel
+		proto esp reqid 1 mode tunnel
 	if_id 0x2
 west #
  ipsec _kernel state

--- a/testing/sanitizers/ip-xfrm-policy-mobike.sed
+++ b/testing/sanitizers/ip-xfrm-policy-mobike.sed
@@ -3,7 +3,7 @@
 # aggressively sanitize "ip xfrm policy" for mobike tests
 #
 / spi 0x[^ ]* /d
-/ reqid [1-9][0-9]* /d
+/ reqid [1-9][0-9]\{4,\} /d
 /src 0.0.0.0\/0 dst 0.0.0.0\/0/D
 /src ::\/0 dst ::\/0/D
 /socket \(in\|out\) priority 0 ptype main/D

--- a/testing/sanitizers/ipsec-kernel-policy.sed
+++ b/testing/sanitizers/ipsec-kernel-policy.sed
@@ -20,7 +20,7 @@
   # ip xfrm policy
 
   / spi 0x00000000 /! s/ spi 0x[^ ]* / spi 0xSPISPI /g
-  s/ reqid [1-9][0-9]* / reqid REQID /g
+  s/ reqid [1-9][0-9]\{4,\} / reqid REQID /g
   # dir ... priority 2080718 ptype ...
   s/ priority [1-9][0-9]* ptype / priority PRIORITY ptype /
 

--- a/testing/sanitizers/ipsec-kernel-state.sed
+++ b/testing/sanitizers/ipsec-kernel-state.sed
@@ -57,7 +57,7 @@
   }
 
   # fix up keys and other magic numbers; see also ipsec look
-  s/ reqid [1-9][0-9]* / reqid REQID /g
+  s/ reqid [1-9][0-9]\{4,\} / reqid REQID /g
 
   s/\tauth\(.*\) 0x[^ ]* \(.*\)$/\tauth\1 0xHASHKEY \2/g
   s/\tenc \(.*\) 0x.*$/\tenc \1 0xENCKEY/g

--- a/testing/sanitizers/misc-sanitize.sed
+++ b/testing/sanitizers/misc-sanitize.sed
@@ -44,4 +44,4 @@ s/\t seq-hi 0x0, seq [^,]*, oseq-hi 0x0, oseq .*$/\t seq-hi 0x0, seq 0xXX, oseq-
 
 # debug details aren't interesting
 s/^debug:.*/debug .../
-s/ reqid [1-9][0-9]* mode / reqid REQID mode /g
+s/ reqid [1-9][0-9]\{4,\} mode / reqid REQID mode /g

--- a/testing/sanitizers/nft.sed
+++ b/testing/sanitizers/nft.sed
@@ -2,6 +2,6 @@
 
 /^ nft /,/^[a-z][a-z]* #$/ {
 
-  s/ reqid [1-9][0-9]* / reqid REQID /
+  s/ reqid [1-9][0-9]\{4,\} / reqid REQID /
 
 }


### PR DESCRIPTION
Resolves #2891

Auto Generated reqid starts after  0x3fff(16383).
Sanitizing all reqids with length greater than or equal to 5
