### PR TITLE
pfkeyv2: replace outbound kernel policy when one is already installed

### DIFF
--- a/programs/pluto/kernel_policy.c
+++ b/programs/pluto/kernel_policy.c
@@ -961,6 +961,7 @@ bool install_outbound_ipsec_kernel_policies(struct child_sa *child,
 		PEXPECT(logger, spd->wip.ok);
 		enum kernel_policy_op op =
 			(spd->wip.conflicting.bare_shunt != NULL ? KERNEL_POLICY_OP_REPLACE :
+			 outbound_kernel_policy_installed(c) ? KERNEL_POLICY_OP_REPLACE :
 			 KERNEL_POLICY_OP_ADD);
 		if (spd->block) {
 			llog(RC_LOG, logger, "state spd requires a block (and no CAT?)");

--- a/programs/pluto/routing.c
+++ b/programs/pluto/routing.c
@@ -443,6 +443,28 @@ bool kernel_route_installed(const struct connection *c)
 	bad_case(r);
 }
 
+bool outbound_kernel_policy_installed(const struct connection *c)
+{
+	enum routing r = c->routing.state;
+	switch (r) {
+	case RT_UNROUTED:
+	case RT_UNROUTED_BARE_NEGOTIATION:
+	case RT_UNROUTED_INBOUND:
+		return false;
+	case RT_ROUTED_NEVER_NEGOTIATE:
+	case RT_ROUTED_ONDEMAND:
+	case RT_UNROUTED_NEGOTIATION:
+	case RT_ROUTED_NEGOTIATION:
+	case RT_ROUTED_FAILURE:
+	case RT_UNROUTED_INBOUND_NEGOTIATION:
+	case RT_ROUTED_INBOUND_NEGOTIATION:
+	case RT_UNROUTED_TUNNEL:
+	case RT_ROUTED_TUNNEL:
+		return true;
+	}
+	bad_case(r);
+}
+
 bool kernel_policy_installed(const struct connection *c)
 {
 	switch (c->routing.state) {

--- a/programs/pluto/routing.h
+++ b/programs/pluto/routing.h
@@ -76,6 +76,7 @@ enum shunt_kind spd_shunt_kind(const struct spd *spd);
 
 bool kernel_route_installed(const struct connection *c);
 bool kernel_policy_installed(const struct connection *c);
+bool outbound_kernel_policy_installed(const struct connection *c);
 
 void connection_routing_init(struct connection *);
 bool pexpect_connection_is_unrouted(struct connection *c, struct logger *, where_t where);

--- a/testing/pluto/TESTLIST
+++ b/testing/pluto/TESTLIST
@@ -1779,8 +1779,8 @@ kvmplutotest	pfkeyv2-tunnel-6in6-esp-ikev2		good
 kvmplutotest	pfkeyv2-esn-esp-freebsd			good
 kvmplutotest	pfkeyv2-esn-ah-freebsd			good
 
-kvmplutotest	pfkeyv2-ondemand-transport		wip #netbsd-wip
-kvmplutotest	pfkeyv2-ondemand-tunnel			wip #netbsd-wip
+kvmplutotest	pfkeyv2-ondemand-transport		good
+kvmplutotest	pfkeyv2-ondemand-tunnel			good
 kvmplutotest	host-to-host-transport-freebsd		good	github/2602
 kvmplutotest	host-to-host-transport-netbsd		good	github/2602
 kvmplutotest	host-to-host-transport-openbsd		good	github/2602

--- a/testing/pluto/pfkeyv2-ondemand-transport/all.console.txt
+++ b/testing/pluto/pfkeyv2-ondemand-transport/all.console.txt
@@ -48,7 +48,7 @@ No SAD entries.
 
 netbsdwest# ipsec _kernel policy
 
-192.0.1.0/24[any] 192.0.2.0/24[any] 255(reserved)
+192.1.2.45[any] 192.1.2.23[any] 255(reserved)
 	out ipsec
 	esp/transport//require
 	spid=1 seq=0 pid=PID
@@ -56,12 +56,15 @@ netbsdwest# ipsec _kernel policy
 
 # trigger acquire
 
-netbsdwest# ../../guestbin/ping-once.sh --fire-and-forget -I 192.0.1.254 192.0.2.254
+netbsdwest# ../../guestbin/ping-once.sh --fire-and-forget 192.1.2.23
 
 fired and forgotten
 
-netbsdwest# sleep 5 # negotiate
+netbsdwest# ../../guestbin/wait-for-pluto.sh '^".*#2: initiator established Child SA'
 
-netbsdwest# ../../guestbin/ping-once.sh --up -I 192.0.1.254 192.0.2.254
+"eastnet-westnet-ikev2" #2: initiator established Child SA using #1; IPsec transport [192.1.2.45/32===192.1.2.23/32] {ESP=>0xESPESP <0xESPESP xfrm=AES_CBC_128-HMAC_SHA1_96 DPD=passive}
+
+netbsdwest# ../../guestbin/ping-once.sh --up 192.1.2.23
 
 up
+

--- a/testing/pluto/pfkeyv2-ondemand-transport/all.netbsdwest-linuxeast.sh
+++ b/testing/pluto/pfkeyv2-ondemand-transport/all.netbsdwest-linuxeast.sh
@@ -16,6 +16,6 @@ west# ipsec _kernel state
 west# ipsec _kernel policy
 
 # trigger acquire
-west# ../../guestbin/ping-once.sh --fire-and-forget -I 192.0.1.254 192.0.2.254
-west# sleep 5 # negotiate
-west# ../../guestbin/ping-once.sh --up -I 192.0.1.254 192.0.2.254
+west# ../../guestbin/ping-once.sh --fire-and-forget 192.1.2.23
+west# ../../guestbin/wait-for-pluto.sh '^".*#2: initiator established Child SA'
+west# ../../guestbin/ping-once.sh --up 192.1.2.23

--- a/testing/pluto/pfkeyv2-ondemand-transport/east.console.txt
+++ b/testing/pluto/pfkeyv2-ondemand-transport/east.console.txt
@@ -7,6 +7,9 @@ east #
 east #
  ipsec whack --impair suppress_retransmits
 east #
+ ipsec add eastnet-westnet-ikev2
+"eastnet-westnet-ikev2": added oriented IKEv2 connection
+east #
  echo "initdone"
 initdone
 east #

--- a/testing/pluto/pfkeyv2-ondemand-transport/ipsec.conf
+++ b/testing/pluto/pfkeyv2-ondemand-transport/ipsec.conf
@@ -14,10 +14,10 @@ config setup
 conn eastnet-westnet-ikev2
 	left=192.1.2.45
 	leftid="@west"
-	leftsubnet=192.0.1.0/24
+	leftsubnet=192.1.2.45
 	right=192.1.2.23
 	rightid="@east"
-	rightsubnet=192.0.2.0/24
+	rightsubnet=192.1.2.23
 	authby=secret
 	ike=aes-sha1
 	esp=aes-sha1

--- a/testing/pluto/pfkeyv2-ondemand-transport/west.console.txt
+++ b/testing/pluto/pfkeyv2-ondemand-transport/west.console.txt
@@ -1,5 +1,4 @@
-west #
- ../../guestbin/prep.sh
+../../guestbin/prep.sh
 ipsec.conf -> PATH/etc/ipsec.conf
 ipsec.secrets -> PATH/etc/ipsec.secrets
 west #
@@ -7,6 +6,8 @@ west #
 Redirecting to: [initsystem]
 Initializing NSS database
 Starting pluto.
+west #
+ ../../guestbin/wait-until-pluto-started
 west #
  ipsec add eastnet-westnet-ikev2
 "eastnet-westnet-ikev2": added oriented IKEv2 connection
@@ -20,19 +21,18 @@ west #
 No SAD entries.
 west #
  ipsec _kernel policy
-192.0.1.0/24[any] 192.0.2.0/24[any] 255(reserved)
+192.1.2.45[any] 192.1.2.23[any] 255(reserved)
 	out ipsec
 	esp/transport//require
 	spid=1 seq=0 pid=PID
 	refcnt=0
 west #
- ../../guestbin/ping-once.sh --up -I 192.0.1.254 192.0.2.254
-unexpected status 2
-# ping -n -c 1  -i 6 -w 5   -I 192.0.1.254 192.0.2.254
-PING 192.0.2.254 (192.0.2.254): 56 data bytes ----192.0.2.254 PING Statistics---- 1 packets transmitted, 0 packets received, 100.0% packet loss
+ ../../guestbin/ping-once.sh --fire-and-forget 192.1.2.23
+fired and forgotten
 west #
- ../../guestbin/ping-once.sh --up -I 192.0.1.254 192.0.2.254
-unexpected status 2
-# ping -n -c 1  -i 6 -w 5   -I 192.0.1.254 192.0.2.254
-PING 192.0.2.254 (192.0.2.254): 56 data bytes ----192.0.2.254 PING Statistics---- 1 packets transmitted, 0 packets received, 100.0% packet loss
+ ../../guestbin/wait-for-pluto.sh '^".*#2: initiator established Child SA'
+"eastnet-westnet-ikev2" #2: initiator established Child SA using #1; IPsec transport [192.1.2.45/32===192.1.2.23/32] {ESP=>0xESPESP <0xESPESP xfrm=AES_CBC_128-HMAC_SHA1_96 DPD=passive}
+west #
+ ../../guestbin/ping-once.sh --up 192.1.2.23
+up
 west #


### PR DESCRIPTION
see the pfkeyv2-ondemand tests (wip #netbsd-wip)

On NetBSD the outbound policy install fails with EEXIST because the ondemand policy is still there, and the connection gets torn down, use REPLACE instead of ADD when an outbound policy is already installed

Also updates the transport test to use host to host selectors so transport mode can actually work. Both tests now pass
