### PR TITLE
Fix: CVE-2026-12413, CVE-2026-50721 & CVE-2026-50722 for v4.15

### DIFF
--- a/lib/libswan/pubkey_rsa.c
+++ b/lib/libswan/pubkey_rsa.c
@@ -402,58 +402,20 @@ static bool RSA_authenticate_signature_raw_rsa(const struct crypt_mac *expected_
 			      *expected_hash);
 	}
 
-	/*
-	 * Use the same space used by the out going hash.
-	 */
-
-	SECItem decrypted_signature = {
-		.type = siBuffer,
-	};
-
-	if (SECITEM_AllocItem(NULL, &decrypted_signature, signature.len) == NULL) {
-		llog_nss_error(RC_LOG, logger, "allocating space for decrypted RSA signature");
-		return false;
-	}
-
 	/* NSS doesn't do const */
-	const SECItem encrypted_signature = {
-		.type = siBuffer,
-		.data = DISCARD_CONST(unsigned char *, signature.ptr),
-		.len  = signature.len,
-	};
 
-	if (PK11_VerifyRecover(seckey_public, &encrypted_signature, &decrypted_signature,
-			       lsw_nss_get_password_context(logger)) != SECSuccess) {
-		SECITEM_FreeItem(&decrypted_signature, PR_FALSE/*not-pointer*/);
+	const SECItem signature_secitem =
+		same_shunk_as_secitem(signature, siBuffer);
+	const SECItem expected_hash_secitem =
+		same_shunk_as_secitem(HUNK_AS_SHUNK(*expected_hash), siBuffer);
+
+	if (PK11_Verify(seckey_public, &signature_secitem, &expected_hash_secitem,
+			lsw_nss_get_password_context(logger)) != SECSuccess) {
 		dbg("NSS RSA verify: decrypting signature is failed");
 		*fatal_diag = NULL;
 		return false;
 	}
 
-	if (DBGP(DBG_CRYPT)) {
-		LLOG_JAMBUF(DEBUG_STREAM, logger, buf) {
-			jam_string(buf, "NSS RSA verify: decrypted sig: ");
-			jam_nss_secitem(buf, &decrypted_signature);
-		}
-	}
-
-	/*
-	 * Expect the matching hash to appear at the end.  See above
-	 * for length check.  It may, or may not, be prefixed by a
-	 * PKCS#1 1.5 RSA ASN.1 blob.
-	 */
-	passert(decrypted_signature.len >= expected_hash->len);
-	uint8_t *start = (decrypted_signature.data
-			  + decrypted_signature.len
-			  - expected_hash->len);
-	if (!memeq(start, expected_hash->ptr, expected_hash->len)) {
-		dbg("RSA Signature NOT verified");
-		SECITEM_FreeItem(&decrypted_signature, PR_FALSE/*not-pointer*/);
-		*fatal_diag = NULL;
-		return false;
-	}
-
-	SECITEM_FreeItem(&decrypted_signature, PR_FALSE/*not-pointer*/);
 	*fatal_diag = NULL;
 	return true;
 }

--- a/lib/libswan/pubkey_rsa.c
+++ b/lib/libswan/pubkey_rsa.c
@@ -491,7 +491,7 @@ static struct hash_signature RSA_sign_hash_pkcs1_1_5_rsa(const struct secret_stu
 static bool RSA_authenticate_signature_pkcs1_1_5_rsa(const struct crypt_mac *expected_hash,
 						     shunk_t signature,
 						     struct pubkey *pubkey,
-						     const struct hash_desc *unused_hash_algo UNUSED,
+						     const struct hash_desc *hash_alg,
 						     diag_t *fatal_diag,
 						     struct logger *logger)
 {
@@ -509,58 +509,24 @@ static bool RSA_authenticate_signature_pkcs1_1_5_rsa(const struct crypt_mac *exp
 			      *expected_hash);
 	}
 
-	/*
-	 * Use the same space used by the out going hash.
-	 */
-
-	SECItem decrypted_signature = {
-		.type = siBuffer,
-	};
-
-	if (SECITEM_AllocItem(NULL, &decrypted_signature, signature.len) == NULL) {
-		llog_nss_error(RC_LOG, logger, "allocating space for decrypted RSA signature");
-		return false;
-	}
+	SECItem hash_item =
+		same_shunk_as_secitem(HUNK_AS_SHUNK(*expected_hash), siBuffer);
 
 	/* NSS doesn't do const */
-	const SECItem encrypted_signature = {
-		.type = siBuffer,
-		.data = DISCARD_CONST(unsigned char *, signature.ptr),
-		.len  = signature.len,
-	};
+	SECItem signature_item =
+		same_shunk_as_secitem(signature, siBuffer);
 
-	if (PK11_VerifyRecover(seckey_public, &encrypted_signature, &decrypted_signature,
-			       lsw_nss_get_password_context(logger)) != SECSuccess) {
-		SECITEM_FreeItem(&decrypted_signature, PR_FALSE/*not-pointer*/);
-		dbg("NSS RSA verify: decrypting signature is failed");
+	if (VFY_VerifyDigestDirect(&hash_item,
+				   seckey_public,
+				   &signature_item,
+				   /*pubkey algorithm*/SEC_OID_PKCS1_RSA_ENCRYPTION,
+				   /*hash algorithm*/hash_alg->nss.oid_tag,
+				   lsw_nss_get_password_context(logger)) != SECSuccess) {
+		ldbg_nss_error(logger, "NSS VFY_VerifyDigest() failed");
 		*fatal_diag = NULL;
 		return false;
 	}
 
-	if (DBGP(DBG_CRYPT)) {
-		LLOG_JAMBUF(DEBUG_STREAM, logger, buf) {
-			jam_string(buf, "NSS RSA verify: decrypted sig: ");
-			jam_nss_secitem(buf, &decrypted_signature);
-		}
-	}
-
-	/*
-	 * Expect the matching hash to appear at the end.  See above
-	 * for length check.  It may, or may not, be prefixed by a
-	 * PKCS#1 1.5 RSA ASN.1 blob.
-	 */
-	passert(decrypted_signature.len >= expected_hash->len);
-	uint8_t *start = (decrypted_signature.data
-			  + decrypted_signature.len
-			  - expected_hash->len);
-	if (!memeq(start, expected_hash->ptr, expected_hash->len)) {
-		dbg("RSA Signature NOT verified");
-		SECITEM_FreeItem(&decrypted_signature, PR_FALSE/*not-pointer*/);
-		*fatal_diag = NULL;
-		return false;
-	}
-
-	SECITEM_FreeItem(&decrypted_signature, PR_FALSE/*not-pointer*/);
 	*fatal_diag = NULL;
 	return true;
 }

--- a/programs/pluto/ikev2_message.c
+++ b/programs/pluto/ikev2_message.c
@@ -1000,7 +1000,7 @@ struct msg_digest *reassemble_v2_incoming_fragments(struct v2_incoming_fragments
 	passert(md->chain[ISAKMP_NEXT_v2SK] == NULL);
 	passert(md->chain[ISAKMP_NEXT_v2SKF] != NULL);
 	pexpect(md->chain[ISAKMP_NEXT_v2SKF]->payload.v2skf.isaskf_number == 1);
-	passert(md->digest_roof < elemsof(md->digest));
+	passert(md->digest_roof <= elemsof(md->digest));
 
 	/*
 	 * Pass 1: Compute the total payload size.


### PR DESCRIPTION
Fix: CVE-2026-12413, CVE-2026-50721 & CVE-2026-50722

XCP-ng project plan to integrate provided security fixes already provided (as patches).

Since the CVE patches files did not provide authorship, we replayed the backport from upstream git changes (resolved with content from shared patches files)

Feel free to merge of not, anyway may it also help 4.12+ users.