### PR TITLE
CVE 2026 14957 fips bad rsa exponent

### DIFF
--- a/include/impair.h
+++ b/include/impair.h
@@ -210,6 +210,9 @@ struct impair {
 	bool ignore_viable_parent;
 
 	struct impair_unsigned truncate_signed_hash;
+
+	bool mangle_cert_pubkey;
+
 	/*
 	 * add more here
 	 */

--- a/lib/libswan/impair.c
+++ b/lib/libswan/impair.c
@@ -396,6 +396,8 @@ struct impairment impairments[] = {
 
 	U(truncate_signed_hash, "truncate HASH being signed to N bytes"),
 
+	B(mangle_cert_pubkey, "mangle the pubkey part of the certificate payload (currently assumes RSA)"),
+
 #undef U
 #undef B
 #undef V

--- a/programs/pluto/ikev2_cert.c
+++ b/programs/pluto/ikev2_cert.c
@@ -89,10 +89,30 @@ stf_status emit_v2CERT(const struct connection *c, struct pbs_out *outpbs)
 
 		ldbg(outpbs->logger, "sending [CERT] of certificate: %s", cert_nickname(mycert));
 
-		if (!pbs_out_struct(outpbs, certhdr, &ikev2_certificate_desc, &cert_pbs) ||
-		    !pbs_out_hunk(&cert_pbs, cert_der(mycert), "CERT")) {
+		if (!pbs_out_struct(outpbs, certhdr, &ikev2_certificate_desc, &cert_pbs)) {
 			free_auth_chain(auth_chain, chain_len);
 			return STF_INTERNAL_ERROR;
+		}
+
+		uint8_t *der_start = cert_pbs.cur;
+		if (!pbs_out_hunk(&cert_pbs, cert_der(mycert), "CERT")) {
+			free_auth_chain(auth_chain, chain_len);
+			return STF_INTERNAL_ERROR;
+		}
+
+		if (impair.mangle_cert_pubkey) {
+			const char exponent_65537[] = { 0x02, 0x03, 0x01, 0x00, 0x01 };
+			uint8_t *exponent = memmem(der_start, cert_pbs.cur - der_start,
+						   exponent_65537, sizeof(exponent_65537));
+			if (exponent == NULL) {
+				llog(IMPAIR_STREAM, outpbs->logger,
+				     "could not find RSA pubkey's exponent to mangle");
+				return STF_INTERNAL_ERROR;
+			}
+			llog(IMPAIR_STREAM, outpbs->logger,
+			     "mangling RSA pubkey's exponent");
+			const char exponent_0[] = { 0x02, 0x03, 0x00, 0x00, 0x00 };
+			memcpy(exponent, exponent_0, sizeof(exponent_0));
 		}
 
 		close_pbs_out(&cert_pbs);

--- a/programs/pluto/nss_cert_verify.c
+++ b/programs/pluto/nss_cert_verify.c
@@ -410,16 +410,23 @@ static void add_decoded_cert(CERTCertDBHandle *handle,
 	 */
 	if (is_fips_mode()) {
 		SECKEYPublicKey *pk = CERT_ExtractPublicKey(cert);
-		PASSERT(logger, pk != NULL);
-		unsigned key_bit_size = pk->u.rsa.modulus.len * BITS_IN_BYTE;
-		if (pk->keyType == rsaKey && key_bit_size < FIPS_MIN_RSA_KEY_SIZE) {
-			llog(RC_LOG, logger,
-			     "FIPS: rejecting peer cert with key size %u under %u: %s",
-			     key_bit_size, FIPS_MIN_RSA_KEY_SIZE,
-			     cert->subjectName);
-			SECKEY_DestroyPublicKey(pk);
-			CERT_DestroyCertificate(cert);
+		if (pk == NULL) {
+			llog_nss_error(RC_LOG, logger,
+				       "extracting certificate public key using CERT_ExtractPublicKey() failed");
 			return;
+		}
+
+		if (pk->keyType == rsaKey) {
+			unsigned key_bit_size = pk->u.rsa.modulus.len * BITS_IN_BYTE;
+			if (key_bit_size < FIPS_MIN_RSA_KEY_SIZE) {
+				llog(RC_LOG, logger,
+				     "FIPS: rejecting peer cert with key size %u under %u: %s",
+				     key_bit_size, FIPS_MIN_RSA_KEY_SIZE,
+				     cert->subjectName);
+				SECKEY_DestroyPublicKey(pk);
+				CERT_DestroyCertificate(cert);
+				return;
+			}
 		}
 		SECKEY_DestroyPublicKey(pk);
 	}

--- a/programs/pluto/nss_cert_verify.c
+++ b/programs/pluto/nss_cert_verify.c
@@ -390,7 +390,7 @@ static void add_decoded_cert(CERTCertDBHandle *handle,
 		 * auth for some for some seamingly unrelated reason.
 		 */
 		llog_nss_error(RC_LOG, logger,
-			       "NSS: decoding certificate payload using CERT_NewTempCertificate() failed");
+			       "decoding certificate payload using CERT_NewTempCertificate() failed");
 		if (PR_GetError() == SEC_ERROR_REUSED_ISSUER_AND_SERIAL) {
 			enum stream stream = log_limiter_stream(logger, CERTIFICATE_LOG_LIMITER);
 			if (stream != NO_STREAM) {

--- a/testing/pluto/TESTLIST
+++ b/testing/pluto/TESTLIST
@@ -460,6 +460,7 @@ kvmplutotest	impair-41-log-rate-limit		good
 
 kvmplutotest	cve-2026-50721-truncate-signed-hash-ikev1	good
 kvmplutotest	cve-2026-50722-truncate-signed-hash-ikev2	good
+kvmplutotest	cve-2026-14957-fips-bad-rsa-pubkey		good
 
 kvmplutotest	ikev1-psk-dual-behind-nat-01		good
 kvmplutotest	ikev1-psk-two-rw-id-ip-01		good

--- a/testing/pluto/cve-2026-14957-fips-bad-rsa-pubkey/description.txt
+++ b/testing/pluto/cve-2026-14957-fips-bad-rsa-pubkey/description.txt
@@ -1,0 +1,11 @@
+Basic pluto with IKEv2 on the initiator (west), and on the responder.
+It uses certificates.
+
+This also tests having public keys loaded from certificates, but not
+use the DN as the ID.  Pluto also loads the public key in the certificate
+file with the name given.
+
+This test does not use or reply on any CA cert.
+
+This is called "out of bound PKIX", as the certificates are not sent
+in-band.

--- a/testing/pluto/cve-2026-14957-fips-bad-rsa-pubkey/east.conf
+++ b/testing/pluto/cve-2026-14957-fips-bad-rsa-pubkey/east.conf
@@ -1,0 +1,25 @@
+# /etc/ipsec.conf - Libreswan IPsec configuration file
+
+version 2.0
+
+config setup
+	# put the logs in /tmp for the UMLs, so that we can operate
+	# without syslogd, which seems to break on UMLs
+	logfile=/tmp/pluto.log
+	logtime=no
+	logappend=no
+	plutodebug=all,crypt
+	dumpdir=/tmp
+
+conn westnet-eastnet-ikev2
+	authby=rsasig
+	left=192.1.2.45
+	leftid="%fromcert"
+	leftnexthop=192.1.2.23
+	leftsubnet=192.0.1.0/24
+	leftca=%same
+	right=192.1.2.23
+	rightid="%fromcert"
+	rightnexthop=192.1.2.45
+	rightsubnet=192.0.2.0/24
+	rightcert=east

--- a/testing/pluto/cve-2026-14957-fips-bad-rsa-pubkey/east.console.txt
+++ b/testing/pluto/cve-2026-14957-fips-bad-rsa-pubkey/east.console.txt
@@ -1,0 +1,24 @@
+/testing/guestbin/swan-prep --nokeys --fips
+Creating empty NSS database
+Password changed successfully.
+FIPS mode enabled.
+east #
+ /testing/x509/import.sh real/mainca/east.p12
+ ipsec pk12util -k /run/pluto/nsspw -w nss-pw -i real/mainca/east.p12
+pk12util: PKCS12 IMPORT SUCCESSFUL
+ ipsec certutil -f /run/pluto/nsspw -M -n mainca -t CT,,
+ ipsec certutil -O -n east
+"mainca" [E=testing@libreswan.org,CN=Libreswan test CA for mainca,OU=Test Department,O=Libreswan,L=Toronto,ST=Ontario,C=CA]
+  "east" [E=user-east@testing.libreswan.org,CN=east.testing.libreswan.org,OU=Test Department,O=Libreswan,L=Toronto,ST=Ontario,C=CA]
+east #
+ ipsec start
+Redirecting to: [initsystem]
+east #
+ ../../guestbin/wait-until-pluto-started
+east #
+ ipsec auto --add westnet-eastnet-ikev2
+"westnet-eastnet-ikev2": added oriented IKEv2 connection
+east #
+ echo "initdone"
+initdone
+east #

--- a/testing/pluto/cve-2026-14957-fips-bad-rsa-pubkey/eastinit.sh
+++ b/testing/pluto/cve-2026-14957-fips-bad-rsa-pubkey/eastinit.sh
@@ -1,0 +1,7 @@
+/testing/guestbin/swan-prep --nokeys --fips
+/testing/x509/import.sh real/mainca/east.p12
+
+ipsec start
+../../guestbin/wait-until-pluto-started
+ipsec auto --add westnet-eastnet-ikev2
+echo "initdone"

--- a/testing/pluto/cve-2026-14957-fips-bad-rsa-pubkey/west.conf
+++ b/testing/pluto/cve-2026-14957-fips-bad-rsa-pubkey/west.conf
@@ -1,0 +1,26 @@
+# /etc/ipsec.conf - Libreswan IPsec configuration file
+
+version 2.0
+
+config setup
+	# put the logs in /tmp for the UMLs, so that we can operate
+	# without syslogd, which seems to break on UMLs
+	logfile=/tmp/pluto.log
+	logtime=no
+	logappend=no
+	plutodebug=all
+	dumpdir=/tmp
+
+conn westnet-eastnet-ikev2
+	authby=rsasig
+	left=192.1.2.45
+	leftid="%fromcert"
+	leftnexthop=192.1.2.23
+	leftsubnet=192.0.1.0/24
+	leftcert=west
+	right=192.1.2.23
+	rightid="%fromcert"
+	rightnexthop=192.1.2.45
+	rightsubnet=192.0.2.0/24
+	rightcert=east
+	fragmentation=no

--- a/testing/pluto/cve-2026-14957-fips-bad-rsa-pubkey/west.console.txt
+++ b/testing/pluto/cve-2026-14957-fips-bad-rsa-pubkey/west.console.txt
@@ -1,0 +1,51 @@
+/testing/guestbin/swan-prep --nokeys
+Creating empty NSS database
+west #
+ /testing/x509/import.sh real/mainca/west.p12
+ ipsec pk12util -w nss-pw -i real/mainca/west.p12
+pk12util: PKCS12 IMPORT SUCCESSFUL
+ ipsec certutil -M -n mainca -t CT,,
+ ipsec certutil -O -n west
+"mainca" [E=testing@libreswan.org,CN=Libreswan test CA for mainca,OU=Test Department,O=Libreswan,L=Toronto,ST=Ontario,C=CA]
+  "west" [E=user-west@testing.libreswan.org,CN=west.testing.libreswan.org,OU=Test Department,O=Libreswan,L=Toronto,ST=Ontario,C=CA]
+west #
+ /testing/x509/import.sh real/mainca/east.p12
+ ipsec pk12util -w nss-pw -i real/mainca/east.p12
+pk12util: PKCS12 IMPORT SUCCESSFUL
+ ipsec certutil -M -n mainca -t CT,,
+ ipsec certutil -O -n east
+"mainca" [E=testing@libreswan.org,CN=Libreswan test CA for mainca,OU=Test Department,O=Libreswan,L=Toronto,ST=Ontario,C=CA]
+  "east" [E=user-east@testing.libreswan.org,CN=east.testing.libreswan.org,OU=Test Department,O=Libreswan,L=Toronto,ST=Ontario,C=CA]
+west #
+ ipsec start
+Redirecting to: [initsystem]
+west #
+ ../../guestbin/wait-until-pluto-started
+west #
+ ipsec auto --add westnet-eastnet-ikev2
+"westnet-eastnet-ikev2": added oriented IKEv2 connection
+west #
+ echo "initdone"
+initdone
+west #
+ ipsec whack --impair mangle_cert_pubkey
+west #
+ ipsec up westnet-eastnet-ikev2
+"westnet-eastnet-ikev2" #1: initiating IKEv2 connection to 192.1.2.23 using UDP
+"westnet-eastnet-ikev2" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
+"westnet-eastnet-ikev2" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_GCM_16_256 integ=n/a prf=HMAC_SHA2_512 ke=DH19}, initiating IKE_AUTH
+IMPAIR: "westnet-eastnet-ikev2" #1: mangling RSA pubkey's exponent
+"westnet-eastnet-ikev2" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with digital-signature RSASSA-PSS with SHA2_512 and DER_ASN1_DN 'C=CA, ST=Ontario, L=Toronto, O=Libreswan, OU=Test Department, CN=west.testing.libreswan.org, E=user-west@testing.libreswan.org'; Child SA #2 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
+"westnet-eastnet-ikev2" #1: IKE SA authentication request rejected by peer: AUTHENTICATION_FAILED
+"westnet-eastnet-ikev2" #1: encountered fatal error in state IKE_AUTH_I
+"westnet-eastnet-ikev2" #2: connection is supposed to remain up; revival attempt 1 scheduled in 0 seconds
+"westnet-eastnet-ikev2" #1: deleting IKE SA (sent IKE_AUTH request)
+west #
+ ../../guestbin/ping-once.sh --up -I 192.0.1.254 192.0.2.254
+up
+west #
+ ipsec whack --trafficstatus
+west #
+ echo done
+done
+west #

--- a/testing/pluto/cve-2026-14957-fips-bad-rsa-pubkey/westinit.sh
+++ b/testing/pluto/cve-2026-14957-fips-bad-rsa-pubkey/westinit.sh
@@ -1,0 +1,8 @@
+/testing/guestbin/swan-prep --nokeys
+/testing/x509/import.sh real/mainca/west.p12
+/testing/x509/import.sh real/mainca/east.p12
+
+ipsec start
+../../guestbin/wait-until-pluto-started
+ipsec auto --add westnet-eastnet-ikev2
+echo "initdone"

--- a/testing/pluto/cve-2026-14957-fips-bad-rsa-pubkey/westrun.sh
+++ b/testing/pluto/cve-2026-14957-fips-bad-rsa-pubkey/westrun.sh
@@ -1,0 +1,5 @@
+ipsec whack --impair mangle_cert_pubkey
+ipsec up westnet-eastnet-ikev2
+../../guestbin/ping-once.sh --up -I 192.0.1.254 192.0.2.254
+ipsec whack --trafficstatus
+echo done


### PR DESCRIPTION
Check the result of CERT_ExtractPublicKey() before using it.
Fixes CVE 2026 14957
