### PR TITLE
patches for {pub,rsasig,ecdsa,eddsa}key documentation

### DIFF
--- a/configs/d.ipsec.conf/conn/cert.xml
+++ b/configs/d.ipsec.conf/conn/cert.xml
@@ -7,9 +7,10 @@
   </term>
   <listitem>
     <para>
-      If you are using <option>leftrsasigkey=%cert</option>
-      this defines the certificate nickname of your certificate in the NSS
-      database. This can be on software or hardware security device.
+      If you are using <option>left{pub,rsasig,ecdsa,eddsa}key=%cert</option>/
+      <option>right{pub,rsasig,ecdsa,eddsa}key=%cert</option>, this defines
+      the certificate nickname of your certificate in the NSS database.
+      This can be on software or hardware security device.
     </para>
   </listitem>
 </varlistentry>

--- a/configs/d.ipsec.conf/conn/ecdsakey.xml
+++ b/configs/d.ipsec.conf/conn/ecdsakey.xml
@@ -1,21 +1,21 @@
-<varlistentry id='conn.rsasigkey'>
+<varlistentry id='conn.ecdsakey'>
   <term>
-    <option>leftrsasigkey=</option>
+    <option>leftecdsakey=</option>
   </term>
   <term>
-    <option>rightrsasigkey=</option>
+    <option>rightecdsakey=</option>
   </term>
   <listitem>
     <para>
-      The left/right participant's public key for RSA signature authentication.
+      The left/right participant's public key for ECDSA signature authentication.
       The argument can be one of the generic arguments listed in
       <option>leftpubkey</option>/<option>rightpubkey</option> option.
       The generic DNS-related arguments can use the mechanism described
-      in either RFC 3110 (previously RFC 2537) or RFC 4025.
+      in RFC 8005. 
     </para>
     <para>
       Additionally, one can provide a raw public key generated using
-      <command>ipsec rsasigkey</command> command.
+      <command>ipsec ecdsakey</command> command.
     </para>
     <caution>
       <para>

--- a/configs/d.ipsec.conf/conn/eddsakey.xml
+++ b/configs/d.ipsec.conf/conn/eddsakey.xml
@@ -1,21 +1,21 @@
-<varlistentry id='conn.rsasigkey'>
+<varlistentry id='conn.eddsakey'>
   <term>
-    <option>leftrsasigkey=</option>
+    <option>lefteddsakey=</option>
   </term>
   <term>
-    <option>rightrsasigkey=</option>
+    <option>righteddsakey=</option>
   </term>
   <listitem>
     <para>
-      The left/right participant's public key for RSA signature authentication.
+      The left/right participant's public key for EdDSA signature authentication.
       The argument can be one of the generic arguments listed in
       <option>leftpubkey</option>/<option>rightpubkey</option> option.
       The generic DNS-related arguments can use the mechanism described
-      in either RFC 3110 (previously RFC 2537) or RFC 4025.
+      in RFC 9373. 
     </para>
     <para>
       Additionally, one can provide a raw public key generated using
-      <command>ipsec rsasigkey</command> command.
+      <command>ipsec eddsakey</command> command.
     </para>
     <caution>
       <para>

--- a/configs/d.ipsec.conf/conn/pubkey.xml
+++ b/configs/d.ipsec.conf/conn/pubkey.xml
@@ -1,0 +1,76 @@
+<varlistentry id='conn.pubkey'>
+  <term>
+    <option>leftpubkey=</option>
+  </term>
+  <term>
+    <option>rightpubkey=</option>
+  </term>
+  <listitem>
+    <para>
+      The left participant's public key for signature (either RSA, ECDSA or EdDSA)
+      authentication. The <option>leftpubkey</option> is the generic option.
+      The key should be in base-64 encoded RFC 2537 format (with 0s prepended),
+      or one of the following:
+      <variablelist>
+	<varlistentry>
+	  <term>
+	    <option>%none</option>
+	  </term>
+	  <listitem>
+	    <para>
+	      the same as not specifying a value (useful to override a
+	      default)
+	    </para>
+	  </listitem>
+	</varlistentry>
+	<varlistentry>
+	  <term>
+	    <option>%dnsondemand</option>
+	  </term>
+	  <listitem>
+	    <para>
+	      (the default) the key is to be fetched from DNS at the
+	      time it is needed.
+	    </para>
+	  </listitem>
+	</varlistentry>
+	<varlistentry>
+	  <term>
+	    <option>%dns</option>
+	  </term>
+	  <listitem>
+	    <para>
+	      Treated as <option>%dnsondemand</option>.  The identity
+	      used for the left participant must be a specific host,
+	      not <option>%any</option> or another magic value.
+	    </para>
+	  </listitem>
+	</varlistentry>
+	<varlistentry>
+	  <term>
+	    <option>%cert</option>
+	  </term>
+	  <listitem>
+	    <para>
+	      the information required from a certificate defined in
+	      <option>%leftcert</option> and automatically define
+	      leftid for you
+	    </para>
+	  </listitem>
+	</varlistentry>
+      </variablelist>
+    </para>
+    <para>
+      Additionally, one can provide: a DER-encoded public key, or a raw
+      public key generated using <command>ipsec {rsasig,ecdsa,eddsa}key</command>
+      command.
+    </para>
+    <caution>
+      <para>
+	If two connection descriptions specify different public keys
+	for the same <option>leftid</option>, confusion and
+	madness will ensue.
+      </para>
+    </caution>
+  </listitem>
+</varlistentry>

--- a/configs/d.ipsec.conf/sect/conn.xml
+++ b/configs/d.ipsec.conf/sect/conn.xml
@@ -148,7 +148,10 @@
       &conn.narrowing;
       &conn.nic-offload;
       &conn.id;
+      &conn.pubkey;
       &conn.rsasigkey;
+      &conn.ecdsakey;
+      &conn.eddsakey;
       &conn.cert;
       &conn.ckaid;
       &conn.auth;

--- a/programs/ecdsasigkey/ipsec-ecdsasigkey.8.xml
+++ b/programs/ecdsasigkey/ipsec-ecdsasigkey.8.xml
@@ -82,7 +82,7 @@
     </para>
 
     <para>
-      The <option>--password</option> option specifies the nss cryptographic module authentication
+      The <option>--nsspw</option> option specifies the nss cryptographic module authentication
       password if the NSS module has been configured to require it.  A password is required by hardware
       tokens and also by the internal software token module when configured to run in FIPS mode.
       If the argument is <emphasis>@@IPSEC_CONFDDIR@@</emphasis><filename>/nsspassword</filename>,
@@ -94,10 +94,10 @@
   <variablelist>
     <varlistentry>
       <term>
-	<command>ipsec ecdsasigkey --verbose 4096</command>
+	<command>ipsec ecdsasigkey --verbose secp521r1</command>
       </term>
       <listitem>
-	<para>generates a 4096-bit signature key  and stores this key in the NSS database.
+	<para>generates a secp521r1-based key and stores this key in the NSS database.
 	The public key can then be extracted and edited into the <filename>ipsec.conf</filename> (see
 	&ipsec-showhostkey.8;).
 	</para>

--- a/programs/eddsasigkey/ipsec-eddsasigkey.8.xml
+++ b/programs/eddsasigkey/ipsec-eddsasigkey.8.xml
@@ -33,8 +33,7 @@
     <para>
       <command>eddsasigkey</command>
       generates an EDDSA public/private key pair, suitable for digital signatures, on a named curve specified with
-      <emphasis>curvename</emphasis>. Currently it only accepts <emphasis>secp256r1</emphasis>,
-      <emphasis>secp384r1</emphasis>, and <emphasis>secp521r1</emphasis>.
+      <emphasis>curvename</emphasis>. Currently it only accepts <emphasis>ed25519</emphasis>.
     </para>
 
     <para>
@@ -82,7 +81,7 @@
     </para>
 
     <para>
-      The <option>--password</option> option specifies the nss cryptographic module authentication
+      The <option>--nsspw</option> option specifies the nss cryptographic module authentication
       password if the NSS module has been configured to require it.  A password is required by hardware
       tokens and also by the internal software token module when configured to run in FIPS mode.
       If the argument is <emphasis>@@IPSEC_CONFDDIR@@</emphasis><filename>/nsspassword</filename>,
@@ -94,10 +93,10 @@
   <variablelist>
     <varlistentry>
       <term>
-	<command>ipsec eddsasigkey --verbose 4096</command>
+	<command>ipsec eddsasigkey --verbose ed25519</command>
       </term>
       <listitem>
-	<para>generates a 4096-bit signature key  and stores this key in the NSS database.
+	<para>generates a ed25519-based key and stores this key in the NSS database.
 	The public key can then be extracted and edited into the <filename>ipsec.conf</filename> (see
 	&ipsec-showhostkey.8;).
 	</para>

--- a/programs/ipsec/ipsec.8.xml
+++ b/programs/ipsec/ipsec.8.xml
@@ -291,17 +291,20 @@
 	<term><command>ipsec showhostkey</command></term>
 	<term><command>ipsec newhostkey</command></term>
 	<term><command>ipsec ecdsasigkey</command></term>
+	<term><command>ipsec eddsasigkey</command></term>
 	<term><command>ipsec rsasigkey</command></term>
 	<listitem>
 	  <para>
 	    Generate and display raw host keys stored in the
-	    &NSS; database.
+	    &NSS; database. <command>ipsec eddsasigkey</command> is not built
+	    by default.
 	  </para>
 	  <para>
 	    See:
 	    &ipsec-showhostkey.8;,
 	    &ipsec-newhostkey.8;,
 	    &ipsec-ecdsasigkey.8;,
+	    &ipsec-eddsasigkey.8;,
 	    &ipsec-rsasigkey.8;.
 	  </para>
 	</listitem>


### PR DESCRIPTION
Two commits:

- one fixing ipsec.conf (Issue #2896). I took artistic liberty here, and put everything under one option which is listed as `left{pub,rsasig,ecdsa,eddsa}key` (saves a lot of space)
- one updating some details in man pages of `ipsec {ecdsa,eddsa}sigkey` programs.
