### PR TITLE
Fix IKE_FOLLOWUP_KE processing with multiple ADDKE configuration

### DIFF
--- a/programs/pluto/ikev2_ike_followup_ke.c
+++ b/programs/pluto/ikev2_ike_followup_ke.c
@@ -86,6 +86,18 @@ struct ikev2_task {
 	const struct prf_desc *prf;
 };
 
+static struct prf_keys *clone_prf_keys(const struct prf_keys *keys,
+				       struct logger *logger)
+{
+	struct prf_keys *keys_ = table_alloc(struct prf_keys, keys->len);
+	unsigned pos = 0;
+
+	TABLE_FOR_EACH(key, keys) {
+		keys_->table[pos++] = symkey_addref(logger, "SK(n)", *key);
+	}
+	return keys_;
+}
+
 void cleanup_IKE_FOLLOWUP_KE_task(struct ikev2_task **task, struct logger *logger)
 {
 	pfree_kem_initiator(&(*task)->initiator, logger);
@@ -347,11 +359,8 @@ stf_status process_v2_IKE_FOLLOWUP_KE_rekey_ike_request(struct ike_sa *ike,
 		task.nr = clone_hunk_as_chunk(&larval_ike->sa.st_nr, "Nr");
 		task.d = symkey_addref(larval_ike->sa.logger, "d", ike->sa.st_skey_d_nss);
 		task.dh_shared_secret = symkey_addref(larval_ike->sa.logger, "SK(0)", larval_ike->sa.st_dh_shared_secret);
-		task.keys = clone_thing(*larval_ike->sa.st_v2_ike_followup_ke.keys,
-					"additional_ke_secrets");
-		TABLE_FOR_EACH(key, task.keys) {
-			symkey_addref(larval_ike->sa.logger, "SK(n)", *key);
-		}
+		task.keys = clone_prf_keys(larval_ike->sa.st_v2_ike_followup_ke.keys,
+					   larval_ike->sa.logger);
 		task.prf = larval_ike->sa.st_oakley.ta_prf;
 		/* for KEYMAT */
 		task.nr_keymat_bytes = nr_ikev2_ike_keymat_bytes(&larval_ike->sa);
@@ -537,11 +546,8 @@ stf_status process_v2_IKE_FOLLOWUP_KE_rekey_ike_response(struct ike_sa *ike,
 		task.nr = clone_hunk_as_chunk(&larval_ike->sa.st_nr, "Nr");
 		task.d = symkey_addref(larval_ike->sa.logger, "d", ike->sa.st_skey_d_nss);
 		task.dh_shared_secret = symkey_addref(larval_ike->sa.logger, "SK(0)", larval_ike->sa.st_dh_shared_secret);
-		task.keys = clone_thing(*larval_ike->sa.st_v2_ike_followup_ke.keys,
-					"additional_ke_secrets");
-		TABLE_FOR_EACH(key, task.keys) {
-			symkey_addref(larval_ike->sa.logger, "SK(n)", *key);
-		}
+		task.keys = clone_prf_keys(larval_ike->sa.st_v2_ike_followup_ke.keys,
+					   larval_ike->sa.logger);
 		task.prf = larval_ike->sa.st_oakley.ta_prf;
 		/* for KEYMAT */
 		task.nr_keymat_bytes = nr_ikev2_ike_keymat_bytes(&larval_ike->sa);

--- a/programs/pluto/ikev2_ike_followup_ke.c
+++ b/programs/pluto/ikev2_ike_followup_ke.c
@@ -497,12 +497,11 @@ stf_status process_v2_IKE_FOLLOWUP_KE_rekey_ike_request_continue(struct ike_sa *
 
 		emancipate_larval_ike_sa(ike, larval_ike);
 	} else if (task->responder != NULL) {
-		struct prf_keys *keys =
-			ike->sa.st_v2_ike_followup_ke.keys;
 		PK11SymKey *new_ke_secret =
 			kem_responder_shared_key(task->responder);
 		new_ke_secret = symkey_addref(larval_ike->sa.logger, "new_ke_secret", new_ke_secret);
-		table_grow(keys, new_ke_secret);
+		table_grow(larval_ike->sa.st_v2_ike_followup_ke.keys,
+			   new_ke_secret);
 	}
 
 	return STF_OK;
@@ -650,12 +649,11 @@ stf_status process_v2_IKE_FOLLOWUP_KE_rekey_ike_response_continue(struct ike_sa 
 
 		return STF_OK; /* IKE */
 	} else if (task->initiator != NULL) {
-		struct prf_keys *keys =
-			larval_ike->sa.st_v2_ike_followup_ke.keys;
 		PK11SymKey *new_ke_secret =
 			kem_initiator_shared_key(task->initiator);
 		new_ke_secret = symkey_addref(larval_ike->sa.logger, "new_ke_secret", new_ke_secret);
-		table_grow(keys, new_ke_secret);
+		table_grow(larval_ike->sa.st_v2_ike_followup_ke.keys,
+			   new_ke_secret);
 	}
 
 	if (next_is_ikev2_ike_followup_ke_exchange(&larval_ike->sa)) {

--- a/testing/pluto/ikev2-intermediate-10-rekey-ike/03-west-up.sh
+++ b/testing/pluto/ikev2-intermediate-10-rekey-ike/03-west-up.sh
@@ -1,7 +1,7 @@
 ipsec up west-cuckold
 ipsec up west-cuckoo
 
-ipsec whack --rekey-ike --name west-cuckold --asynchronous
+ipsec whack --rekey-ike --name west-cuckold
 
 ../../guestbin/wait-for-pluto.sh '#4: initiator rekeyed IKE SA #1'
 

--- a/testing/pluto/ikev2-intermediate-10-rekey-ike/ipsec.conf
+++ b/testing/pluto/ikev2-intermediate-10-rekey-ike/ipsec.conf
@@ -19,7 +19,7 @@ conn base
 	authby=secret
 	leftsubnet=192.0.3.0/24
 	intermediate=yes
-	ike=aes128-sha2-dh31;addke1=ml_kem_768
+	ike=aes128-sha2-dh31;addke2=ml_kem_768;addke4=modp2048;addke6=ml_kem_1024
 
 conn east
 	also=base

--- a/testing/pluto/ikev2-intermediate-10-rekey-ike/west.console.txt
+++ b/testing/pluto/ikev2-intermediate-10-rekey-ike/west.console.txt
@@ -24,8 +24,14 @@ west #
  ipsec up west-cuckold
 "west-cuckold" #1: initiating IKEv2 connection to 192.1.2.23 using UDP
 "west-cuckold" #1: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
-"west-cuckold" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_128 integ=HMAC_SHA2_256_128 prf=HMAC_SHA2_256 ke=DH31 addke1=ML_KEM_768}, initiating IKE_INTERMEDIATE
-"west-cuckold" #1: sent IKE_INTERMEDIATE request to 192.1.2.23:UDP/500 {addke1=ML_KEM_768}
+"west-cuckold" #1: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_128 integ=HMAC_SHA2_256_128 prf=HMAC_SHA2_256 ke=DH31 addke2=ML_KEM_768 addke4=MODP2048 addke6=ML_KEM_1024}, initiating IKE_INTERMEDIATE
+"west-cuckold" #1: sent IKE_INTERMEDIATE request to 192.1.2.23:UDP/500 {addke2=ML_KEM_768}
+"west-cuckold" #1: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE} reassembled from N fragments
+"west-cuckold" #1: initiator processed IKE_INTERMEDIATE, initiating IKE_INTERMEDIATE
+"west-cuckold" #1: sent IKE_INTERMEDIATE request to 192.1.2.23:UDP/500 {addke4=MODP2048}
+"west-cuckold" #1: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE}
+"west-cuckold" #1: initiator processed IKE_INTERMEDIATE, initiating IKE_INTERMEDIATE
+"west-cuckold" #1: sent IKE_INTERMEDIATE request to 192.1.2.23:UDP/500 {addke6=ML_KEM_1024}
 "west-cuckold" #1: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE} reassembled from N fragments
 "west-cuckold" #1: initiator processed IKE_INTERMEDIATE, initiating IKE_AUTH
 "west-cuckold" #1: sent IKE_AUTH request to 192.1.2.23:UDP/500 with shared-key-mac and FQDN '@west'; Child SA #2 {ESP <0xESPESP} [192.0.3.0/24===192.0.2.0/24]
@@ -38,10 +44,14 @@ west #
 "west-cuckoo" #3: sent CREATE_CHILD_SA request to create Child SA using IKE SA #1 {ESP <0xESPESP} [192.0.3.0/24===192.0.20.0/24]
 "west-cuckoo" #3: initiator established Child SA using #1; IPsec tunnel [192.0.3.0/24===192.0.20.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256-DH31 DPD=passive}
 west #
- ipsec whack --rekey-ike --name west-cuckold --asynchronous
+ ipsec whack --rekey-ike --name west-cuckold
+"west-cuckold" #4: initiating rekey to replace IKE SA #1 using IKE SA #1
+"west-cuckold" #4: sent CREATE_CHILD_SA request to rekey IKE SA #1 (using IKE SA #1)
+"west-cuckold" #4: initiator rekeyed IKE SA #1 {cipher=AES_CBC_128 integ=HMAC_SHA2_256_128 prf=HMAC_SHA2_256 ke=DH31 addke2=ML_KEM_768 addke4=MODP2048 addke6=ML_KEM_1024}
+"west-cuckold" #1: deleting IKE SA (ESTABLISHED_IKE_SA) and sending notification
 west #
  ../../guestbin/wait-for-pluto.sh '#4: initiator rekeyed IKE SA #1'
-"west-cuckold" #4: initiator rekeyed IKE SA #1 {cipher=AES_CBC_128 integ=HMAC_SHA2_256_128 prf=HMAC_SHA2_256 ke=DH31 addke1=ML_KEM_768}
+"west-cuckold" #4: initiator rekeyed IKE SA #1 {cipher=AES_CBC_128 integ=HMAC_SHA2_256_128 prf=HMAC_SHA2_256 ke=DH31 addke2=ML_KEM_768 addke4=MODP2048 addke6=ML_KEM_1024}
 west #
  ../../guestbin/ping-once.sh --up 192.0.2.254
 up


### PR DESCRIPTION
While trying to address review comments in #2936, I noticed that rekeying with multiple ADDKE is not working because of the misuses of table API. This should fix it and expand the test to cover the configuration.