### PR TITLE
kernel_pfkeyv2: on openbsd fetch an acquire's flow with SADB_X_ASKPOLICY

### DIFF
--- a/include/lsw-pfkeyv2.h
+++ b/include/lsw-pfkeyv2.h
@@ -96,6 +96,10 @@
  * Work-around OpenBSD which completely re-defined struct
  * sadb_x_policy: the fields are not the same; the way it is used is
  * not the same.
+ *
+ * SADB_X_ASKPOLICY, which fetches the flow that triggered an
+ * ACQUIRE, does use the rewritten structure, so its extension type
+ * is kept under a new name.
  */
 
 #ifdef __OpenBSD__
@@ -104,6 +108,7 @@
 #   error confused
 #  endif
 #  undef SADB_X_EXT_POLICY
+#  define SADB_X_EXT_OPENBSD_POLICY 25
 # endif
 #endif
 

--- a/programs/pluto/kernel_pfkeyv2.c
+++ b/programs/pluto/kernel_pfkeyv2.c
@@ -1485,8 +1485,21 @@ static bool pfkeyv2_policy_add(enum kernel_policy_op op,
 		policy_name = "%pass(bypass)";
 		break;
 	case SHUNT_DROP:
-		policy_type = SADB_X_FLOW_TYPE_DENY;
-		policy_name = "%drop(deny)";
+		if (policy->kind == SHUNT_KIND_NEGOTIATION) {
+			/*
+			 * DENY is absolute, it would also block this
+			 * negotiation's IKE exchange (the IKE
+			 * socket's BYPASS levels only exempt it from
+			 * IPsec-class flows).  DONTACQ holds the
+			 * traffic without generating further
+			 * ACQUIREs.
+			 */
+			policy_type = SADB_X_FLOW_TYPE_DONTACQ;
+			policy_name = "%hold(dontacq)";
+		} else {
+			policy_type = SADB_X_FLOW_TYPE_DENY;
+			policy_name = "%drop(deny)";
+		}
 		break;
 	case SHUNT_NONE:
 		/* FAILURE=NONE should have been turned into
@@ -1736,6 +1749,80 @@ static bool parse_sadb_address(struct verbose verbose, const struct sadb_msg *b,
 	return true;
 }
 
+/*
+ * OpenBSD's ACQUIRE only carries the SA's peer (ADDRESS_DST), and
+ * not the flow that triggered it.  The flow needs to be fetched
+ * separately using SADB_X_ASKPOLICY: given the ACQUIRE's sequence
+ * number, the kernel responds with the flow's source/destination
+ * (and their ports) in SADB_X_EXT_{SRC,DST}_FLOW.
+ */
+
+#ifdef SADB_X_ASKPOLICY /* OpenBSD */
+static bool ask_sadb_policy(uint32_t acquire_seq,
+			    ip_address *src_address, ip_port *src_port,
+			    ip_address *dst_address, ip_port *dst_port,
+			    struct verbose verbose)
+{
+	vdbg("%s() seq=%u ...", __func__, acquire_seq);
+	verbose.level++;
+
+	uint8_t reqbuf[SIZEOF_SADB_BASE + sizeof(struct sadb_x_policy)];
+	struct outbuf req;
+	msg_base(verbose, &req, __func__,
+		 chunk2(reqbuf, sizeof(reqbuf)),
+		 SADB_X_ASKPOLICY, SADB_SATYPE_UNSPEC);
+
+	/* OpenBSD's rewritten sadb_x_policy, see lsw-pfkeyv2.h */
+
+	put_sadb_ext(&req, sadb_x_policy, SADB_X_EXT_OPENBSD_POLICY,
+		     .sadb_x_policy_seq = acquire_seq);
+
+	struct inbuf resp;
+	if (!msg_sendrecv(&req, &resp, verbose)) {
+		/* ESRCH when the acquire has expired */
+		return false;
+	}
+
+	while (resp.base_cursor.len > 0) {
+
+		shunk_t ext_cursor;
+		const struct sadb_ext *ext =
+			get_sadb_ext(&resp.base_cursor, &ext_cursor, verbose);
+		if (ext == NULL) {
+			llog_pexpect(verbose.logger, HERE, "bad ext");
+			return false;
+		}
+
+		enum sadb_exttype exttype = ext->sadb_ext_type;
+		switch (exttype) {
+
+		case SADB_X_EXT_SRC_FLOW:
+			if (!parse_sadb_address(verbose, resp.base, &ext_cursor,
+						src_address, src_port)) {
+				return false;
+			}
+			break;
+		case SADB_X_EXT_DST_FLOW:
+			if (!parse_sadb_address(verbose, resp.base, &ext_cursor,
+						dst_address, dst_port)) {
+				return false;
+			}
+			break;
+
+		default:
+			if (verbose.debug) {
+				verbose.level++;
+				llog_sadb_ext(verbose, resp.base, ext, ext_cursor);
+				verbose.level--;
+			}
+			break;
+		}
+	}
+
+	return true;
+}
+#endif
+
 static void parse_sadb_acquire(const struct sadb_msg *msg,
 			       shunk_t msg_cursor,
 			       struct verbose verbose)
@@ -1798,6 +1885,24 @@ static void parse_sadb_acquire(const struct sadb_msg *msg,
 			break;
 		}
 	}
+
+#ifdef SADB_X_ASKPOLICY /* OpenBSD */
+	/*
+	 * No source, ask the kernel for the flow that triggered the
+	 * ACQUIRE.  Both addresses are replaced: for a tunnel it is
+	 * the flow's endpoints, not the SA's, that select the
+	 * connection.
+	 */
+	if (address_is_unset(&src_address)) {
+		if (!ask_sadb_policy(msg->sadb_msg_seq,
+				     &src_address, &src_port,
+				     &dst_address, &dst_port,
+				     verbose)) {
+			vdbg("ask policy failed");
+			return;
+		}
+	}
+#endif
 
 	if (address_is_unset(&src_address) || address_is_unset(&dst_address)) {
 		vdbg("something isn't set");

--- a/programs/pluto/kernel_sadb.c
+++ b/programs/pluto/kernel_sadb.c
@@ -127,7 +127,7 @@ GET_SADB(sadb_x_ipsecrequest, sizeof(uint8_t)); /* XXX: see rfc, screwup */
 #ifdef SADB_X_EXT_NAT_T_TYPE
 GET_SADB(sadb_x_nat_t_type, sizeof(uint64_t));
 #endif
-#ifdef SADB_X_EXT_POLICY
+#if defined(SADB_X_EXT_POLICY) || defined(SADB_X_EXT_OPENBSD_POLICY)
 GET_SADB(sadb_x_policy, sizeof(uint64_t));
 #endif
 #ifdef SADB_X_EXT_SA2

--- a/programs/pluto/kernel_sadb.h
+++ b/programs/pluto/kernel_sadb.h
@@ -270,6 +270,12 @@ enum sadb_exttype {
 #define SADB_X_EXT_DST_FLOW sadb_x_ext_dst_flow
 #endif
 
+#ifdef SADB_X_EXT_OPENBSD_POLICY /* OpenBSD */
+	sadb_x_ext_openbsd_policy = SADB_X_EXT_OPENBSD_POLICY,
+#undef SADB_X_EXT_OPENBSD_POLICY
+#define SADB_X_EXT_OPENBSD_POLICY sadb_x_ext_openbsd_policy
+#endif
+
 #ifdef SADB_X_EXT_PROTOCOL
 	sadb_x_ext_protocol = SADB_X_EXT_PROTOCOL,
 #undef SADB_X_EXT_PROTOCOL
@@ -580,7 +586,7 @@ void llog_sadb_x_nat_t_port(struct verbose verbose, const struct sadb_msg *b, co
 #ifdef SADB_X_EXT_NAT_T_TYPE
 void llog_sadb_x_nat_t_type(struct verbose verbose, const struct sadb_msg *b, const struct sadb_x_nat_t_type *m);
 #endif
-#ifdef SADB_X_EXT_POLICY
+#if defined(SADB_X_EXT_POLICY) || defined(SADB_X_EXT_OPENBSD_POLICY)
 void llog_sadb_x_policy(struct verbose verbose, const struct sadb_msg *b, const struct sadb_x_policy *m);
 #endif
 #ifdef SADB_X_EXT_SA2
@@ -629,7 +635,7 @@ GET_SADB(sadb_supported);
 #ifdef SADB_X_EXT_POLICY
 GET_SADB(sadb_x_ipsecrequest);
 #endif
-#ifdef SADB_X_EXT_POLICY
+#if defined(SADB_X_EXT_POLICY) || defined(SADB_X_EXT_OPENBSD_POLICY)
 GET_SADB(sadb_x_policy);
 #endif
 GET_SADB(sadb_x_nat_t_type);

--- a/programs/pluto/kernel_sadb_logger.c
+++ b/programs/pluto/kernel_sadb_logger.c
@@ -473,6 +473,18 @@ void llog_sadb_x_replay(struct verbose verbose, const struct sadb_msg *b,
 }
 #endif
 
+#ifdef SADB_X_EXT_OPENBSD_POLICY /* OpenBSD */
+void llog_sadb_x_policy(struct verbose verbose, const struct sadb_msg *b,
+			const struct sadb_x_policy *m)
+{
+	JAM_HEADER_SADB(sadb_x_policy);
+
+	JAM(u32, sadb_x_policy, seq);
+
+	JAM_FOOTER();
+}
+#endif
+
 #ifdef SADB_X_EXT_UDPENCAP /* OpenBSD */
 void llog_sadb_x_udpencap(struct verbose verbose, const struct sadb_msg *b,
 			const struct sadb_x_udpencap *m)
@@ -667,6 +679,21 @@ void llog_sadb_ext(struct verbose verbose,
 				     sizeof(struct sadb_supported)) / sizeof(struct sadb_alg)));
 		return;
 	}
+
+#ifdef SADB_X_EXT_OPENBSD_POLICY
+	case SADB_X_EXT_OPENBSD_POLICY:
+	{
+		shunk_t x_policy_cursor;
+		const struct sadb_x_policy *x_policy =
+			get_sadb_x_policy(&ext_cursor, &x_policy_cursor, verbose);
+		if (x_policy == NULL) {
+			return;
+		}
+		llog_sadb_x_policy(verbose, base, x_policy);
+		vexpect(x_policy_cursor.len == 0); /* nothing following */
+		return;
+	}
+#endif
 
 #ifdef SADB_X_EXT_POLICY
 	case SADB_X_EXT_POLICY:

--- a/programs/pluto/kernel_sadb_names.c
+++ b/programs/pluto/kernel_sadb_names.c
@@ -192,6 +192,9 @@ const struct sparse_names sadb_exttype_names = {
 #ifdef SADB_X_EXT_POLICY
 		S(SADB_X_EXT_POLICY),
 #endif
+#ifdef SADB_X_EXT_OPENBSD_POLICY
+		S(SADB_X_EXT_OPENBSD_POLICY),
+#endif
 #ifdef SADB_X_EXT_PRAND
 		S(SADB_X_EXT_PRAND),
 #endif

--- a/testing/pluto/TESTLIST
+++ b/testing/pluto/TESTLIST
@@ -1789,7 +1789,7 @@ kvmplutotest	host-to-host-transport-netbsd		good	github/2602
 kvmplutotest	host-to-host-transport-ondemand-freebsd	good
 kvmplutotest	host-to-host-transport-ondemand-linux	good
 kvmplutotest	host-to-host-transport-ondemand-netbsd	good
-kvmplutotest	host-to-host-transport-ondemand-openbsd	wip	github/2952
+kvmplutotest	host-to-host-transport-ondemand-openbsd	good
 kvmplutotest	host-to-host-transport-openbsd		good	github/2602
 kvmplutotest	host-to-host-tunnel-forward-freebsd	good
 kvmplutotest	host-to-host-tunnel-forward-linux	good
@@ -1801,7 +1801,7 @@ kvmplutotest	host-to-host-tunnel-netbsd		good
 kvmplutotest	host-to-host-tunnel-ondemand-freebsd	good
 kvmplutotest	host-to-host-tunnel-ondemand-linux	good
 kvmplutotest	host-to-host-tunnel-ondemand-netbsd	good
-kvmplutotest	host-to-host-tunnel-ondemand-openbsd	wip	github/2952
+kvmplutotest	host-to-host-tunnel-ondemand-openbsd	good
 kvmplutotest	host-to-host-tunnel-openbsd		good
 
 # Racoon interop

--- a/testing/pluto/host-to-host-transport-ondemand-openbsd/west.console.txt
+++ b/testing/pluto/host-to-host-transport-ondemand-openbsd/west.console.txt
@@ -39,19 +39,20 @@ west #
 	enckey 0xENCKEY
 	sa: spi 0xSPISPI auth gmac-aes-256 enc aes-gcm
 		state mature replay 16 flags 0x400<esn>
-	lifetime_cur: alloc 0 bytes 0 add N first 0
+	lifetime_cur: alloc 0 bytes 68 add N first N
 	lifetime_hard: alloc 0 bytes 0 add N first 0
 	lifetime_soft: alloc 0 bytes 0 add N first 0
 	address_src: 192.1.2.23
 	address_dst: 192.1.2.45
 	key_auth: bits 288: HASHKEY
 	key_encrypt: bits 288: ENCKEY
+	lifetime_lastuse: alloc 0 bytes 0 add 0 first N
 	counter:
-		0 input packets
+		1 input packet
 		0 output packets
-		0 input bytes
+		188 input bytes
 		0 output bytes
-		0 input bytes, decompressed
+		84 input bytes, decompressed
 		0 output bytes, uncompressed
 		0 packets dropped on input
 		0 packets dropped on output
@@ -61,23 +62,24 @@ west #
 	enckey 0xENCKEY
 	sa: spi 0xSPISPI auth gmac-aes-256 enc aes-gcm
 		state mature replay 16 flags 0x400<esn>
-	lifetime_cur: alloc 0 bytes 0 add N first 0
+	lifetime_cur: alloc 0 bytes 64 add N first N
 	lifetime_hard: alloc 0 bytes 0 add N first 0
 	lifetime_soft: alloc 0 bytes 0 add N first 0
 	address_src: 192.1.2.45
 	address_dst: 192.1.2.23
 	key_auth: bits 288: HASHKEY
 	key_encrypt: bits 288: ENCKEY
+	lifetime_lastuse: alloc 0 bytes 0 add 0 first N
 	counter:
 		0 input packets
-		0 output packets
+		1 output packet
 		0 input bytes
-		0 output bytes
+		120 output bytes
 		0 input bytes, decompressed
-		0 output bytes, uncompressed
+		84 output bytes, uncompressed
 		0 packets dropped on input
 		0 packets dropped on output
-	replay: rpl 1
+	replay: rpl 2
 west #
  ipsec _kernel policy
 @0 flow esp in from 192.1.2.23 to 192.1.2.45 local 192.1.2.45 peer 192.1.2.23 type require

--- a/testing/pluto/host-to-host-tunnel-ondemand-openbsd/east.console.txt
+++ b/testing/pluto/host-to-host-tunnel-ondemand-openbsd/east.console.txt
@@ -27,55 +27,57 @@ east #
 "westnet-eastnet" #2: initiator established Child SA using #1; IPsec tunnel [192.0.2.0/24===192.0.1.0/24] {ESP/ESN=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
 east #
  ipsec whack --trafficstatus
-#2: "westnet-eastnet", type=ESP, add_time=1234567890, inBytes=168, outBytes=176, maxBytes=2^63B, id='@west'
+#2: "westnet-eastnet", type=ESP, add_time=1234567890, inBytes=176, outBytes=168, maxBytes=2^63B, id='@west'
 east #
  ../../guestbin/wait-for.sh --no-match 'spi 0x00000000' ipsec _kernel state
 east #
  ipsec _kernel state
-@0 esp tunnel from 192.1.2.45 to 192.1.2.23 spi 0xSPISPI enc aes-256-gcm \
-	authkey 0xHASHKEY \
-	enckey 0xENCKEY
-	sa: spi 0xSPISPI auth gmac-aes-256 enc aes-gcm
-		state mature replay 16 flags 0x404<tunnel,esn>
-	lifetime_cur: alloc 0 bytes 0 add N first 0
-	lifetime_hard: alloc 0 bytes 0 add N first 0
-	lifetime_soft: alloc 0 bytes 0 add N first 0
-	address_src: 192.1.2.45
-	address_dst: 192.1.2.23
-	key_auth: bits 288: HASHKEY
-	key_encrypt: bits 288: ENCKEY
-	counter:
-		0 input packets
-		0 output packets
-		0 input bytes
-		0 output bytes
-		0 input bytes, decompressed
-		0 output bytes, uncompressed
-		0 packets dropped on input
-		0 packets dropped on output
-	replay: rpl 1
 @0 esp tunnel from 192.1.2.23 to 192.1.2.45 spi 0xSPISPI enc aes-256-gcm \
 	authkey 0xHASHKEY \
 	enckey 0xENCKEY
 	sa: spi 0xSPISPI auth gmac-aes-256 enc aes-gcm
 		state mature replay 16 flags 0x404<tunnel,esn>
-	lifetime_cur: alloc 0 bytes 0 add N first 0
+	lifetime_cur: alloc 0 bytes 168 add N first N
 	lifetime_hard: alloc 0 bytes 0 add N first 0
 	lifetime_soft: alloc 0 bytes 0 add N first 0
 	address_src: 192.1.2.23
 	address_dst: 192.1.2.45
 	key_auth: bits 288: HASHKEY
 	key_encrypt: bits 288: ENCKEY
+	lifetime_lastuse: alloc 0 bytes 0 add 0 first N
 	counter:
 		0 input packets
-		0 output packets
+		2 output packets
 		0 input bytes
-		0 output bytes
+		280 output bytes
 		0 input bytes, decompressed
+		208 output bytes, uncompressed
+		0 packets dropped on input
+		0 packets dropped on output
+	replay: rpl 3
+@0 esp tunnel from 192.1.2.45 to 192.1.2.23 spi 0xSPISPI enc aes-256-gcm \
+	authkey 0xHASHKEY \
+	enckey 0xENCKEY
+	sa: spi 0xSPISPI auth gmac-aes-256 enc aes-gcm
+		state mature replay 16 flags 0x404<tunnel,esn>
+	lifetime_cur: alloc 0 bytes 176 add N first N
+	lifetime_hard: alloc 0 bytes 0 add N first 0
+	lifetime_soft: alloc 0 bytes 0 add N first 0
+	address_src: 192.1.2.45
+	address_dst: 192.1.2.23
+	key_auth: bits 288: HASHKEY
+	key_encrypt: bits 288: ENCKEY
+	lifetime_lastuse: alloc 0 bytes 0 add 0 first N
+	counter:
+		2 input packets
+		0 output packets
+		456 input bytes
+		0 output bytes
+		208 input bytes, decompressed
 		0 output bytes, uncompressed
 		0 packets dropped on input
 		0 packets dropped on output
-	replay: rpl 1
+	replay: rpl 2
 east #
  ipsec _kernel policy
 @0 flow esp in from 192.0.1.0/24 to 192.0.2.0/24 local 192.1.2.23 peer 192.1.2.45 type require
@@ -84,7 +86,7 @@ east #
  ipsec down westnet-eastnet
 "westnet-eastnet": initiating delete of connection's IKE SA #1 (and Child SA #2)
 "westnet-eastnet" #1: sent INFORMATIONAL request to delete IKE SA
-"westnet-eastnet" #2: ESP traffic information: in=168B out=176B
+"westnet-eastnet" #2: ESP traffic information: in=176B out=168B
 "westnet-eastnet" #1: deleting IKE SA (established IKE SA)
 east #
  ipsec _kernel state


### PR DESCRIPTION
Fixes #2952

-- openbsd  acquire only carries ADDRESS_DST, pluto now asks the kernel for the triggering flow with SADB_X_ASKPOLICY

-- that exposed a second bug: the negotiation hold was going in as a DENY flow, and on openbsd DENY also blocks the IKE exchange itself (the ike socket's bypass levels donot apply to it) so the kernel just re acquired every 20 seconds ,negotiation holds now go in as DONTACQ