### PR TITLE
ikev2: use correct SPIs for rekeying IKE SA with IKE_FOLLOWUP_KE

### DIFF
--- a/programs/pluto/ikev2_ike_followup_ke.c
+++ b/programs/pluto/ikev2_ike_followup_ke.c
@@ -80,7 +80,7 @@ struct ikev2_task {
 	chunk_t ni;
 	chunk_t nr;
 	/* for KEYMAT */
-	ike_spis_t ike_spis;
+	ike_spis_t ike_rekey_spis;
 	size_t nr_keymat_bytes;
 	PK11SymKey *keymat;
 	const struct prf_desc *prf;
@@ -383,7 +383,7 @@ stf_status process_v2_IKE_FOLLOWUP_KE_rekey_ike_request(struct ike_sa *ike,
 		task.prf = larval_ike->sa.st_oakley.ta_prf;
 		/* for KEYMAT */
 		task.nr_keymat_bytes = nr_ikev2_ike_keymat_bytes(&larval_ike->sa);
-		task.ike_spis = larval_ike->sa.st_ike_spis;
+		task.ike_rekey_spis = larval_ike->sa.st_ike_rekey_spis;
 	}
 
 	submit_ikev2_task(ike, md,
@@ -451,7 +451,7 @@ stf_status process_v2_IKE_FOLLOWUP_KE_rekey_ike_request_helper(struct ikev2_task
 
 			task->keymat = ikev2_ike_sa_keymat(task->prf, skeyseed,
 							   task->ni, task->nr,
-							   &task->ike_spis,
+							   &task->ike_rekey_spis,
 							   task->nr_keymat_bytes,
 							   logger);
 			symkey_delref(logger, "skeyseed", &skeyseed);
@@ -577,7 +577,7 @@ stf_status process_v2_IKE_FOLLOWUP_KE_rekey_ike_response(struct ike_sa *ike,
 		task.prf = larval_ike->sa.st_oakley.ta_prf;
 		/* for KEYMAT */
 		task.nr_keymat_bytes = nr_ikev2_ike_keymat_bytes(&larval_ike->sa);
-		task.ike_spis = larval_ike->sa.st_ike_spis;
+		task.ike_rekey_spis = larval_ike->sa.st_ike_rekey_spis;
 	}
 
 	submit_ikev2_task(ike, md,
@@ -635,7 +635,7 @@ stf_status process_v2_IKE_FOLLOWUP_KE_rekey_ike_response_helper(struct ikev2_tas
 			     task->prf->common.fqn);
 			task->keymat = ikev2_ike_sa_keymat(task->prf, skeyseed,
 							   task->ni, task->nr,
-							   &task->ike_spis,
+							   &task->ike_rekey_spis,
 							   task->nr_keymat_bytes,
 							   logger);
 			symkey_delref(logger, "skeyseed", &skeyseed);

--- a/testing/pluto/interop-ikev2-strongswan-49-intermediate-initiator/east.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-49-intermediate-initiator/east.console.txt
@@ -13,36 +13,8 @@ east #
 initdone
 east #
  if [ -f /var/run/pluto/pluto.pid ]; then ipsec _kernel state ; fi
-src 192.1.2.23 dst 192.1.2.45
-	proto esp spi 0xSPISPI reqid REQID mode tunnel
-	replay-window 0 flag af-unspec
-	aead rfc4106(gcm(aes)) 0xENCAUTHKEY 128
-	lastused YYYY-MM-DD HH:MM:SS
-	dir out
-src 192.1.2.45 dst 192.1.2.23
-	proto esp spi 0xSPISPI reqid REQID mode tunnel
-	replay-window 0 flag af-unspec
-	aead rfc4106(gcm(aes)) 0xENCAUTHKEY 128
-	lastused YYYY-MM-DD HH:MM:SS
-	anti-replay esn context:
-	 seq-hi 0x0, seq 0xXX, oseq-hi 0x0, oseq 0xXX
-	 replay_window 128, bitmap-length 4
-	 00000000 00000000 00000000 XXXXXXXX 
-	dir in
 east #
  if [ -f /var/run/pluto/pluto.pid ]; then ipsec _kernel policy ; fi
-src 192.0.1.0/24 dst 192.0.2.0/24
-	dir fwd priority PRIORITY ptype main
-	tmpl src 192.1.2.45 dst 192.1.2.23
-		proto esp reqid REQID mode tunnel
-src 192.0.1.0/24 dst 192.0.2.0/24
-	dir in priority PRIORITY ptype main
-	tmpl src 192.1.2.45 dst 192.1.2.23
-		proto esp reqid REQID mode tunnel
-src 192.0.2.0/24 dst 192.0.1.0/24
-	dir out priority PRIORITY ptype main
-	tmpl src 192.1.2.23 dst 192.1.2.45
-		proto esp reqid REQID mode tunnel
 east #
  if [ -f /var/run/charon.pid -o -f /var/run/strongswan/charon.pid ]; then strongswan status ; fi
 east #

--- a/testing/pluto/interop-ikev2-strongswan-49-intermediate-initiator/west.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-49-intermediate-initiator/west.console.txt
@@ -64,26 +64,42 @@ up
 west #
  strongswan down westnet-eastnet-ikev2
 received packet: from 192.1.2.23[4500] to 192.1.2.45[4500] (XXX bytes)
-parsed IKE_FOLLOWUP_KE response 4 [ EF(1/3) ]
+parsed CREATE_CHILD_SA response 0 [ EF(1/3) ]
 received fragment #1 of 3, waiting for complete IKE message
 received packet: from 192.1.2.23[4500] to 192.1.2.45[4500] (XXX bytes)
-parsed IKE_FOLLOWUP_KE response 4 [ EF(2/3) ]
+parsed CREATE_CHILD_SA response 0 [ EF(2/3) ]
 received fragment #2 of 3, waiting for complete IKE message
 received packet: from 192.1.2.23[4500] to 192.1.2.45[4500] (XXX bytes)
-parsed IKE_FOLLOWUP_KE response 4 [ EF(3/3) ]
+parsed CREATE_CHILD_SA response 0 [ EF(3/3) ]
 received fragment #3 of 3, reassembled fragmented IKE message (XXX bytes)
-parsed IKE_FOLLOWUP_KE response 4 [ KE ]
-scheduling rekeying in XXXs
-maximum IKE_SA lifetime XXXs
-IKE_SA westnet-eastnet-ikev2[2] rekeyed between 192.1.2.45[west]...192.1.2.23[east]
-deleting IKE_SA westnet-eastnet-ikev2[1] between 192.1.2.45[west]...192.1.2.23[east]
-sending DELETE for IKE_SA westnet-eastnet-ikev2[1]
-generating INFORMATIONAL request 5 [ D ]
+parsed CREATE_CHILD_SA response 0 [ SA N(ADD_KE) No KE ]
+generating IKE_FOLLOWUP_KE request 1 [ KE N(ADD_KE) ]
+splitting IKE message (XXX bytes) into 2 fragments
+generating IKE_FOLLOWUP_KE request 1 [ EF(1/2) ]
+generating IKE_FOLLOWUP_KE request 1 [ EF(2/2) ]
+sending packet: from 192.1.2.45[4500] to 192.1.2.23[4500] (XXX bytes)
 sending packet: from 192.1.2.45[4500] to 192.1.2.23[4500] (XXX bytes)
 received packet: from 192.1.2.23[4500] to 192.1.2.45[4500] (XXX bytes)
-parsed INFORMATIONAL response 5 [ ]
+parsed IKE_FOLLOWUP_KE response 1 [ EF(1/3) ]
+received fragment #1 of 3, waiting for complete IKE message
+received packet: from 192.1.2.23[4500] to 192.1.2.45[4500] (XXX bytes)
+parsed IKE_FOLLOWUP_KE response 1 [ EF(2/3) ]
+received fragment #2 of 3, waiting for complete IKE message
+received packet: from 192.1.2.23[4500] to 192.1.2.45[4500] (XXX bytes)
+parsed IKE_FOLLOWUP_KE response 1 [ EF(3/3) ]
+received fragment #3 of 3, reassembled fragmented IKE message (XXX bytes)
+parsed IKE_FOLLOWUP_KE response 1 [ KE ]
+scheduling rekeying in XXXs
+maximum IKE_SA lifetime XXXs
+IKE_SA westnet-eastnet-ikev2[3] rekeyed between 192.1.2.45[west]...192.1.2.23[east]
+deleting IKE_SA westnet-eastnet-ikev2[2] between 192.1.2.45[west]...192.1.2.23[east]
+sending DELETE for IKE_SA westnet-eastnet-ikev2[2]
+generating INFORMATIONAL request 2 [ D ]
+sending packet: from 192.1.2.45[4500] to 192.1.2.23[4500] (XXX bytes)
+received packet: from 192.1.2.23[4500] to 192.1.2.45[4500] (XXX bytes)
+parsed INFORMATIONAL response 2 [ ]
 IKE_SA deleted
-IKE_SA [1] closed successfully
+IKE_SA [2] closed successfully
 west #
  echo done
 done
@@ -96,8 +112,6 @@ west #
 Shunted Connections:
 Bypass LAN 192.0.1.0/24:  192.0.1.0/24 === 192.0.1.0/24 PASS
 Bypass LAN 192.1.2.0/24:  192.1.2.0/24 === 192.1.2.0/24 PASS
-Security Associations (1 up, 0 connecting):
-westnet-eastnet-ikev2[2]: DELETING, 192.1.2.45[west]...192.1.2.23[east]
-westnet-eastnet-ikev2{1}:  INSTALLED, TUNNEL, reqid 1, ESP SPIs: SPISPI_i SPISPI_o
-westnet-eastnet-ikev2{1}:   192.0.1.0/24 === 192.0.2.0/24
+Security Associations (0 up, 0 connecting):
+  none
 west #

--- a/testing/pluto/interop-ikev2-strongswan-49-intermediate-responder/east.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-49-intermediate-responder/east.console.txt
@@ -29,19 +29,6 @@ westnet-eastnet-ikev2:   child:  192.0.2.0/24 === 192.0.1.0/24 TUNNEL
 Shunted Connections:
 Bypass LAN 192.0.2.0/24:  192.0.2.0/24 === 192.0.2.0/24 PASS
 Bypass LAN 192.1.2.0/24:  192.1.2.0/24 === 192.1.2.0/24 PASS
-Security Associations (2 up, 0 connecting):
-westnet-eastnet-ikev2[5]: DELETING, 192.1.2.23[east]...192.1.2.45[west]
-westnet-eastnet-ikev2[5]: IKEv2 SPIs: SPISPI_i SPISPI_r*
-westnet-eastnet-ikev2[5]: IKE proposal: AES_CBC_128/HMAC_SHA1_96/PRF_HMAC_SHA1/MODP_8192/KE1_ML_KEM_768
-westnet-eastnet-ikev2[5]: Tasks active: IKE_DELETE 
-westnet-eastnet-ikev2{3}:  INSTALLED, TUNNEL, reqid 1, ESP SPIs: SPISPI_i SPISPI_o
-westnet-eastnet-ikev2{3}:  AES_GCM_16_256, XXX bytes_i (XX pkts, XXs ago), XXX bytes_o (XX pkts, XXs ago), rekeying in XX minutes
-westnet-eastnet-ikev2{3}:   192.0.2.0/24 === 192.0.1.0/24
-westnet-eastnet-ikev2[2]: DELETING, 192.1.2.23[east]...192.1.2.45[west]
-westnet-eastnet-ikev2[2]: IKEv2 SPIs: SPISPI_i SPISPI_r*
-westnet-eastnet-ikev2[2]: IKE proposal: AES_CBC_128/HMAC_SHA1_96/PRF_HMAC_SHA1/MODP_8192/KE1_ML_KEM_768
-westnet-eastnet-ikev2[2]: Tasks active: IKE_DELETE 
-westnet-eastnet-ikev2{1}:  INSTALLED, TUNNEL, reqid 1, ESP SPIs: SPISPI_i SPISPI_o
-westnet-eastnet-ikev2{1}:  AES_GCM_16_256, XXX bytes_i (XX pkts, XXs ago), XXX bytes_o (XX pkts, XXs ago), rekeying in XX minutes
-westnet-eastnet-ikev2{1}:   192.0.2.0/24 === 192.0.1.0/24
+Security Associations (0 up, 0 connecting):
+  none
 east #

--- a/testing/pluto/interop-ikev2-strongswan-49-intermediate-responder/west.console.txt
+++ b/testing/pluto/interop-ikev2-strongswan-49-intermediate-responder/west.console.txt
@@ -48,94 +48,68 @@ west #
  ipsec whack --rekey-ike --name intermediate-fragmentation-no
 "intermediate-fragmentation-no" #4: initiating rekey to replace IKE SA #3 using IKE SA #3
 "intermediate-fragmentation-no" #4: sent CREATE_CHILD_SA request to rekey IKE SA #3 (using IKE SA #3)
-"intermediate-fragmentation-no" #3: retransmitting CREATE_CHILD_SA rekey ike; will wait 0.5 seconds for response
-"intermediate-fragmentation-no" #3: retransmitting CREATE_CHILD_SA rekey ike; will wait 1 second for response
-"intermediate-fragmentation-no" #3: retransmitting CREATE_CHILD_SA rekey ike; will wait 2 seconds for response
-"intermediate-fragmentation-no" #3: retransmitting CREATE_CHILD_SA rekey ike; will wait 4 seconds for response
-"intermediate-fragmentation-no" #3: retransmitting CREATE_CHILD_SA rekey ike; will wait 8 seconds for response
-"intermediate-fragmentation-no" #3: retransmitting CREATE_CHILD_SA rekey ike; will wait 16 seconds for response
-"intermediate-fragmentation-no" #3: ESTABLISHED_IKE_SA: 30 second timeout exceeded after 6 retransmits.  No response (or no acceptable response) to our IKEv2 message
-"intermediate-fragmentation-no" #2: connection is supposed to remain up; revival attempt 1 scheduled in 0 seconds
-"intermediate-fragmentation-no" #2: ESP traffic information: in=168B out=168B
-"intermediate-fragmentation-no" #4: deleting larval Child SA
-"intermediate-fragmentation-no" #3: deleting IKE SA (established IKE SA)
-west #
- /testing/guestbin/ping-once.sh --up -I 192.0.1.254 192.0.2.254
-down UNEXPECTED
-# ping -n -c 1  -i 6 -w 5   -I 192.0.1.254 192.0.2.254
-PING 192.0.2.254 (192.0.2.254) from 192.0.1.254 : 56(84) bytes of data.
---- 192.0.2.254 ping statistics ---
-1 packets transmitted, 0 received, 100% packet loss, time 0ms
-west #
- ipsec trafficstatus
-#6: "intermediate-fragmentation-no", type=ESP, add_time=1234567890, inBytes=0, outBytes=0, maxBytes=2^63B, id='@east'
-west #
- ipsec down intermediate-fragmentation-no
-"intermediate-fragmentation-no": initiating delete of connection's IKE SA #5 (and Child SA #6)
-"intermediate-fragmentation-no" #5: sent INFORMATIONAL request to delete IKE SA
-"intermediate-fragmentation-no" #6: ESP traffic information: in=0B out=0B
-"intermediate-fragmentation-no" #5: deleting IKE SA (established IKE SA)
-west #
- ipsec up intermediate-fragmentation-yes
-"intermediate-fragmentation-yes" #7: initiating IKEv2 connection to 192.1.2.23 using UDP
-"intermediate-fragmentation-yes" #7: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
-"intermediate-fragmentation-yes" #7: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_128 integ=HMAC_SHA1_96 prf=HMAC_SHA1 ke=MODP8192 addke1=ML_KEM_768}, initiating IKE_INTERMEDIATE
-"intermediate-fragmentation-yes" #7: sent IKE_INTERMEDIATE request to 192.1.2.23:UDP/500 {addke1=ML_KEM_768}
-"intermediate-fragmentation-yes" #7: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE}
-"intermediate-fragmentation-yes" #7: initiator processed IKE_INTERMEDIATE, initiating IKE_AUTH
-"intermediate-fragmentation-yes" #7: sent IKE_AUTH request to 192.1.2.23:UDP/500 with shared-key-mac and FQDN '@west'; Child SA #8 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
-"intermediate-fragmentation-yes" #7: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
-"intermediate-fragmentation-yes" #7: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
-"intermediate-fragmentation-yes" #8: initiator established Child SA using #7; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
+"intermediate-fragmentation-no" #4: initiator rekeyed IKE SA #3 {cipher=AES_CBC_128 integ=HMAC_SHA1_96 prf=HMAC_SHA1 ke=MODP8192 addke1=ML_KEM_768}
+"intermediate-fragmentation-no" #3: deleting IKE SA (ESTABLISHED_IKE_SA) and sending notification
 west #
  /testing/guestbin/ping-once.sh --up -I 192.0.1.254 192.0.2.254
 up
 west #
  ipsec trafficstatus
-#8: "intermediate-fragmentation-yes", type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='@east'
+#2: "intermediate-fragmentation-no", type=ESP, add_time=1234567890, inBytes=252, outBytes=252, maxBytes=2^63B, id='@east'
+west #
+ ipsec down intermediate-fragmentation-no
+"intermediate-fragmentation-no": initiating delete of connection's IKE SA #4 (and Child SA #2)
+"intermediate-fragmentation-no" #4: sent INFORMATIONAL request to delete IKE SA
+"intermediate-fragmentation-no" #2: ESP traffic information: in=252B out=252B
+"intermediate-fragmentation-no" #4: deleting IKE SA (established IKE SA)
+west #
+ ipsec up intermediate-fragmentation-yes
+"intermediate-fragmentation-yes" #5: initiating IKEv2 connection to 192.1.2.23 using UDP
+"intermediate-fragmentation-yes" #5: sent IKE_SA_INIT request to 192.1.2.23:UDP/500
+"intermediate-fragmentation-yes" #5: processed IKE_SA_INIT response from 192.1.2.23:UDP/500 {cipher=AES_CBC_128 integ=HMAC_SHA1_96 prf=HMAC_SHA1 ke=MODP8192 addke1=ML_KEM_768}, initiating IKE_INTERMEDIATE
+"intermediate-fragmentation-yes" #5: sent IKE_INTERMEDIATE request to 192.1.2.23:UDP/500 {addke1=ML_KEM_768}
+"intermediate-fragmentation-yes" #5: processing IKE_INTERMEDIATE response from 192.1.2.23:UDP/500 containing SK{KE}
+"intermediate-fragmentation-yes" #5: initiator processed IKE_INTERMEDIATE, initiating IKE_AUTH
+"intermediate-fragmentation-yes" #5: sent IKE_AUTH request to 192.1.2.23:UDP/500 with shared-key-mac and FQDN '@west'; Child SA #6 {ESP <0xESPESP} [192.0.1.0/24===192.0.2.0/24]
+"intermediate-fragmentation-yes" #5: processing IKE_AUTH response from 192.1.2.23:UDP/500 containing SK{IDr,AUTH,SA,TSi,TSr}
+"intermediate-fragmentation-yes" #5: initiator established IKE SA; authenticated peer using authby=secret and FQDN '@east'
+"intermediate-fragmentation-yes" #6: initiator established Child SA using #5; IPsec tunnel [192.0.1.0/24===192.0.2.0/24] {ESP=>0xESPESP <0xESPESP xfrm=AES_GCM_16_256 DPD=passive}
+west #
+ /testing/guestbin/ping-once.sh --up -I 192.0.1.254 192.0.2.254
+up
+west #
+ ipsec trafficstatus
+#6: "intermediate-fragmentation-yes", type=ESP, add_time=1234567890, inBytes=84, outBytes=84, maxBytes=2^63B, id='@east'
 west #
  ipsec whack --rekey-ike --name intermediate-fragmentation-yes
-"intermediate-fragmentation-yes" #9: initiating rekey to replace IKE SA #7 using IKE SA #7
-"intermediate-fragmentation-yes" #9: sent CREATE_CHILD_SA request to rekey IKE SA #7 (using IKE SA #7)
-"intermediate-fragmentation-yes" #9: initiator rekeyed IKE SA #7 {cipher=AES_CBC_128 integ=HMAC_SHA1_96 prf=HMAC_SHA1 ke=MODP8192 addke1=ML_KEM_768}
+"intermediate-fragmentation-yes" #7: initiating rekey to replace IKE SA #5 using IKE SA #5
+"intermediate-fragmentation-yes" #7: sent CREATE_CHILD_SA request to rekey IKE SA #5 (using IKE SA #5)
+"intermediate-fragmentation-yes" #7: initiator rekeyed IKE SA #5 {cipher=AES_CBC_128 integ=HMAC_SHA1_96 prf=HMAC_SHA1 ke=MODP8192 addke1=ML_KEM_768}
+"intermediate-fragmentation-yes" #5: deleting IKE SA (ESTABLISHED_IKE_SA) and sending notification
+west #
+ /testing/guestbin/ping-once.sh --up -I 192.0.1.254 192.0.2.254
+up
+west #
+ ipsec trafficstatus
+#6: "intermediate-fragmentation-yes", type=ESP, add_time=1234567890, inBytes=168, outBytes=168, maxBytes=2^63B, id='@east'
+west #
+ ipsec whack --rekey-ike --name intermediate-fragmentation-yes
+"intermediate-fragmentation-yes" #8: initiating rekey to replace IKE SA #7 using IKE SA #7
+"intermediate-fragmentation-yes" #8: sent CREATE_CHILD_SA request to rekey IKE SA #7 (using IKE SA #7)
+"intermediate-fragmentation-yes" #8: initiator rekeyed IKE SA #7 {cipher=AES_CBC_128 integ=HMAC_SHA1_96 prf=HMAC_SHA1 ke=MODP8192 addke1=ML_KEM_768}
 "intermediate-fragmentation-yes" #7: deleting IKE SA (ESTABLISHED_IKE_SA) and sending notification
 west #
  /testing/guestbin/ping-once.sh --up -I 192.0.1.254 192.0.2.254
 up
 west #
  ipsec trafficstatus
-#8: "intermediate-fragmentation-yes", type=ESP, add_time=1234567890, inBytes=168, outBytes=168, maxBytes=2^63B, id='@east'
-west #
- ipsec whack --rekey-ike --name intermediate-fragmentation-yes
-"intermediate-fragmentation-yes" #10: initiating rekey to replace IKE SA #9 using IKE SA #9
-"intermediate-fragmentation-yes" #10: sent CREATE_CHILD_SA request to rekey IKE SA #9 (using IKE SA #9)
-"intermediate-fragmentation-yes" #9: retransmitting CREATE_CHILD_SA rekey ike; will wait 0.5 seconds for response
-"intermediate-fragmentation-yes" #9: retransmitting CREATE_CHILD_SA rekey ike; will wait 1 second for response
-"intermediate-fragmentation-yes" #9: retransmitting CREATE_CHILD_SA rekey ike; will wait 2 seconds for response
-"intermediate-fragmentation-yes" #9: retransmitting CREATE_CHILD_SA rekey ike; will wait 4 seconds for response
-"intermediate-fragmentation-yes" #9: retransmitting CREATE_CHILD_SA rekey ike; will wait 8 seconds for response
-"intermediate-fragmentation-yes" #9: retransmitting CREATE_CHILD_SA rekey ike; will wait 16 seconds for response
-"intermediate-fragmentation-yes" #9: ESTABLISHED_IKE_SA: 30 second timeout exceeded after 6 retransmits.  No response (or no acceptable response) to our IKEv2 message
-"intermediate-fragmentation-yes" #8: connection is supposed to remain up; revival attempt 1 scheduled in 0 seconds
-"intermediate-fragmentation-yes" #8: ESP traffic information: in=168B out=168B
-"intermediate-fragmentation-yes" #10: deleting larval Child SA
-"intermediate-fragmentation-yes" #9: deleting IKE SA (established IKE SA)
-west #
- /testing/guestbin/ping-once.sh --up -I 192.0.1.254 192.0.2.254
-down UNEXPECTED
-# ping -n -c 1  -i 6 -w 5   -I 192.0.1.254 192.0.2.254
-PING 192.0.2.254 (192.0.2.254) from 192.0.1.254 : 56(84) bytes of data.
---- 192.0.2.254 ping statistics ---
-1 packets transmitted, 0 received, 100% packet loss, time 0ms
-west #
- ipsec trafficstatus
-#12: "intermediate-fragmentation-yes", type=ESP, add_time=1234567890, inBytes=0, outBytes=0, maxBytes=2^63B, id='@east'
+#6: "intermediate-fragmentation-yes", type=ESP, add_time=1234567890, inBytes=252, outBytes=252, maxBytes=2^63B, id='@east'
 west #
  ipsec down intermediate-fragmentation-yes
-"intermediate-fragmentation-yes": initiating delete of connection's IKE SA #11 (and Child SA #12)
-"intermediate-fragmentation-yes" #11: sent INFORMATIONAL request to delete IKE SA
-"intermediate-fragmentation-yes" #12: ESP traffic information: in=0B out=0B
-"intermediate-fragmentation-yes" #11: deleting IKE SA (established IKE SA)
+"intermediate-fragmentation-yes": initiating delete of connection's IKE SA #8 (and Child SA #6)
+"intermediate-fragmentation-yes" #8: sent INFORMATIONAL request to delete IKE SA
+"intermediate-fragmentation-yes" #6: ESP traffic information: in=252B out=252B
+"intermediate-fragmentation-yes" #8: deleting IKE SA (established IKE SA)
 west #
  if [ -f /var/run/pluto/pluto.pid ]; then ipsec _kernel state ; fi
 west #


### PR DESCRIPTION
We were using yet to be updated SPIs when expanding key materials from SKEYSEED, causing interop problems with other implementations.

Fixes: #2958 