### PR TITLE
IKEv2: crossed streams IKE SA should be deleted without family

### DIFF
--- a/programs/pluto/ikev2_retransmit.c
+++ b/programs/pluto/ikev2_retransmit.c
@@ -74,16 +74,15 @@ void event_v2_retransmit(struct state *ike_sa, monotime_t now UNUSED)
 		 * Note: since it isn't established it can't be the
 		 * connection's established IKE SA.
 		 *
-		 * Note: this may also leave the Child SA for the
-		 * connection in limbo.  Hopefully revival code will
-		 * pick that up.
+		 * Note: this should leave the other IKE SA with its
+		 * Child SA intact. .  Hopefully revival code will
+		 * not screw this up.
 		 */
 		PEXPECT(ike->sa.logger, c->established_ike_sa != ike->sa.st_serialno);
 		llog(RC_LOG, ike->sa.logger,
 		     "dropping negotiation as superseded by established IKE SA "PRI_SO"",
 		     pri_so(c->established_ike_sa));
-		terminate_ike_family(&ike, REASON_SUPERSEDED_BY_NEW_SA,
-				     VERBOSE(DEBUG_STREAM, ike->sa.logger, NULL));
+		connection_teardown_ike(&ike, REASON_SUPERSEDED_BY_NEW_SA, HERE);
 		return;
 	}
 


### PR DESCRIPTION
While this does not affect the testcase, it seems the more right thing to do?